### PR TITLE
Revamped error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+- Feature: Add error handling capabilities (see [docs](https://github.com/amannn/next-intl#error-handling))
+
 ## 0.2.0
 
 - Chore: Depend on `use-intl`

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "next": "^10.0.0",
-    "next-intl": "^0.2.0",
+    "next-intl": "^0.3.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   },

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-intl",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "sideEffects": false,
   "author": "Jan Amann <jan@amann.me>",
   "description": "Minimal, but complete solution for managing internationalization in Next.js apps.",
@@ -24,7 +24,7 @@
     "src"
   ],
   "dependencies": {
-    "use-intl": "^0.1.0"
+    "use-intl": "^0.2.0"
   },
   "peerDependencies": {
     "next": "^10.0.0",

--- a/packages/use-intl/package.json
+++ b/packages/use-intl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-intl",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "sideEffects": false,
   "author": "Jan Amann <jan@amann.me>",
   "description": "Minimal, but complete solution for managing internationalization in React apps.",

--- a/packages/use-intl/src/IntlContext.tsx
+++ b/packages/use-intl/src/IntlContext.tsx
@@ -1,8 +1,14 @@
 import {createContext} from 'react';
+import IntlError from './IntlError';
 import IntlMessages from './IntlMessages';
 
 const IntlContext = createContext<
-  {messages: IntlMessages; locale: string} | undefined
+  | {
+      messages: IntlMessages;
+      locale: string;
+      onError(error: IntlError): void;
+    }
+  | undefined
 >(undefined);
 
 export default IntlContext;

--- a/packages/use-intl/src/IntlContext.tsx
+++ b/packages/use-intl/src/IntlContext.tsx
@@ -2,13 +2,17 @@ import {createContext} from 'react';
 import IntlError from './IntlError';
 import IntlMessages from './IntlMessages';
 
-const IntlContext = createContext<
-  | {
-      messages: IntlMessages;
-      locale: string;
-      onError(error: IntlError): void;
-    }
-  | undefined
->(undefined);
+export type IntlContextShape = {
+  messages: IntlMessages;
+  locale: string;
+  onError(error: IntlError): void;
+  getMessageFallback(info: {
+    error: IntlError;
+    key: string;
+    namespace?: string;
+  }): string;
+};
+
+const IntlContext = createContext<IntlContextShape | undefined>(undefined);
 
 export default IntlContext;

--- a/packages/use-intl/src/IntlError.tsx
+++ b/packages/use-intl/src/IntlError.tsx
@@ -1,0 +1,24 @@
+export const enum IntlErrorCode {
+  MISSING_MESSAGE = 'MISSING_MESSAGE',
+  INSUFFICIENT_PATH = 'INSUFFICIENT_PATH',
+  INVALID_MESSAGE = 'INVALID_MESSAGE',
+  FORMATTING_ERROR = 'FORMATTING_ERROR'
+}
+
+export default class IntlError extends Error {
+  public readonly code: IntlErrorCode;
+  public readonly originalMessage: string | undefined;
+
+  constructor(code: IntlErrorCode, originalMessage?: string) {
+    let message: string = code;
+    if (originalMessage) {
+      message += ': ' + originalMessage;
+    }
+    super(message);
+
+    this.code = code;
+    if (originalMessage) {
+      this.originalMessage = originalMessage;
+    }
+  }
+}

--- a/packages/use-intl/src/IntlProvider.tsx
+++ b/packages/use-intl/src/IntlProvider.tsx
@@ -17,9 +17,9 @@ type Props = {
    * an error. This defaults to `${namespace}.${key}` You can use this to
    * customize what will be rendered in this case. */
   getMessageFallback?(info: {
-    error: IntlError;
-    key: string;
     namespace?: string;
+    key: string;
+    error: IntlError;
   }): string;
   /** All components that use the provided hooks should be within this tree. */
   children: ReactNode;

--- a/packages/use-intl/src/IntlProvider.tsx
+++ b/packages/use-intl/src/IntlProvider.tsx
@@ -1,16 +1,23 @@
 import React, {ReactNode} from 'react';
 import IntlContext from './IntlContext';
+import IntlError from './IntlError';
 import IntlMessages from './IntlMessages';
 
 type Props = {
   children: ReactNode;
-  messages: IntlMessages;
   locale: string;
+  messages: IntlMessages;
+  onError?(error: IntlError): void;
 };
 
-export default function IntlProvider({children, locale, messages}: Props) {
+export default function IntlProvider({
+  children,
+  locale,
+  messages,
+  onError = console.error
+}: Props) {
   return (
-    <IntlContext.Provider value={{messages, locale}}>
+    <IntlContext.Provider value={{messages, locale, onError}}>
       {children}
     </IntlContext.Provider>
   );

--- a/packages/use-intl/src/IntlProvider.tsx
+++ b/packages/use-intl/src/IntlProvider.tsx
@@ -1,23 +1,50 @@
 import React, {ReactNode} from 'react';
 import IntlContext from './IntlContext';
-import IntlError from './IntlError';
 import IntlMessages from './IntlMessages';
+import {IntlError} from '.';
 
 type Props = {
-  children: ReactNode;
-  locale: string;
+  /** All messages that will be available in your components. */
   messages: IntlMessages;
+  /** A valid Unicode locale tag (e.g. "en" or "en-GB"). */
+  locale: string;
+  /** This callback will be invoked when an error is encountered during
+   * resolving a message or formatting it. This defaults to `console.error` to
+   * keep your app running. You can customize the handling by taking
+   * `error.code` into account. */
   onError?(error: IntlError): void;
+  /** Will be called when a message couldn't be resolved or formatting it led to
+   * an error. This defaults to `${namespace}.${key}` You can use this to
+   * customize what will be rendered in this case. */
+  getMessageFallback?(info: {
+    error: IntlError;
+    key: string;
+    namespace?: string;
+  }): string;
+  /** All components that use the provided hooks should be within this tree. */
+  children: ReactNode;
 };
+
+function defaultGetMessageFallback({
+  key,
+  namespace
+}: {
+  key: string;
+  namespace?: string;
+}) {
+  return [namespace, key].filter((part) => part != null).join('.');
+}
 
 export default function IntlProvider({
   children,
-  locale,
-  messages,
-  onError = console.error
+  onError = console.error,
+  getMessageFallback = defaultGetMessageFallback,
+  ...contextValues
 }: Props) {
   return (
-    <IntlContext.Provider value={{messages, locale, onError}}>
+    <IntlContext.Provider
+      value={{...contextValues, onError, getMessageFallback}}
+    >
       {children}
     </IntlContext.Provider>
   );

--- a/packages/use-intl/src/index.tsx
+++ b/packages/use-intl/src/index.tsx
@@ -3,3 +3,4 @@ export {default as IntlMessages} from './IntlMessages';
 export {default as useTranslations} from './useTranslations';
 export {default as TranslationValues} from './TranslationValues';
 export {default as useIntl} from './useIntl';
+export {default as IntlError, IntlErrorCode} from './IntlError';

--- a/packages/use-intl/src/useIntlContext.tsx
+++ b/packages/use-intl/src/useIntlContext.tsx
@@ -7,7 +7,7 @@ export default function useIntlContext() {
   if (!context) {
     throw new Error(
       __DEV__
-        ? 'No context found. Have you configured the provider?'
+        ? 'No intl context found. Have you configured the provider?'
         : undefined
     );
   }

--- a/packages/use-intl/src/useIntlContext.tsx
+++ b/packages/use-intl/src/useIntlContext.tsx
@@ -5,11 +5,11 @@ export default function useIntlContext() {
   const context = useContext(IntlContext);
 
   if (!context) {
-    if (__DEV__) {
-      throw new Error('No context found. Have you configured the provider?');
-    } else {
-      throw new Error();
-    }
+    throw new Error(
+      __DEV__
+        ? 'No context found. Have you configured the provider?'
+        : undefined
+    );
   }
 
   return context;

--- a/packages/use-intl/src/useTranslations.tsx
+++ b/packages/use-intl/src/useTranslations.tsx
@@ -111,7 +111,7 @@ export default function useTranslations(namespace?: string) {
     formats?: Partial<Formats>
   ) {
     const cachedFormatsByLocale = cachedFormatsByLocaleRef.current;
-    const fallback = [namespace, key].join('.');
+    const fallback = [namespace, key].filter((part) => part != null).join('.');
 
     // We have already warned about this during render
     if (!messages) {

--- a/packages/use-intl/src/useTranslations.tsx
+++ b/packages/use-intl/src/useTranslations.tsx
@@ -1,26 +1,29 @@
 import IntlMessageFormat, {Formats} from 'intl-messageformat';
 import {cloneElement, isValidElement, ReactNode, useMemo, useRef} from 'react';
+import IntlError, {IntlErrorCode} from './IntlError';
 import IntlMessages from './IntlMessages';
 import TranslationValues from './TranslationValues';
 import useIntlContext from './useIntlContext';
 import useLocale from './useLocale';
 
-function resolvePath(messages: IntlMessages, idPath: string) {
+function resolvePath(
+  messages: IntlMessages,
+  idPath: string,
+  namespace?: string
+) {
   let message = messages;
 
   idPath.split('.').forEach((part) => {
     const next = (message as any)[part];
 
-    if (__DEV__) {
-      if (part == null || next == null) {
-        throw new Error(
-          `Could not resolve \`${idPath}\` in \`${JSON.stringify(
-            messages,
-            null,
-            2
-          )}\`.`
-        );
-      }
+    if (part == null || next == null) {
+      throw new Error(
+        __DEV__
+          ? `Could not resolve \`${idPath}\` in ${
+              namespace ? `\`${namespace}\`` : 'messages'
+            }.`
+          : undefined
+      );
     }
 
     message = next;
@@ -59,14 +62,14 @@ function prepareTranslationValues(values?: TranslationValues) {
 }
 
 /**
- * Translates messages from the given path by using the ICU syntax.
+ * Translates messages from the given namespace by using the ICU syntax.
  * See https://formatjs.io/docs/core-concepts/icu-syntax.
  *
- * If no path is provided, all available messages are returned.
+ * If no namespace is provided, all available messages are returned.
  *
- * The path can also indicate nesting by using a dot (e.g. `namespace.Component`).
+ * The namespace can also indicate nesting by using a dot (e.g. `namespace.Component`).
  */
-export default function useTranslations(path?: string) {
+export default function useTranslations(namespace?: string) {
   const context = useIntlContext();
 
   const locale = useLocale();
@@ -77,62 +80,107 @@ export default function useTranslations(path?: string) {
 
   const allMessages = context.messages;
 
-  const messages = useMemo(
-    () => (path ? resolvePath(allMessages, path) : allMessages),
-    [allMessages, path]
-  );
+  const messages = useMemo(() => {
+    try {
+      const retrievedMessages = namespace
+        ? resolvePath(allMessages, namespace)
+        : allMessages;
 
-  if (__DEV__) {
-    if (!messages) {
-      throw new Error(`No messages for component \`${path}\` found.`);
+      if (!retrievedMessages) {
+        throw new Error(
+          __DEV__
+            ? `No messages for namespace \`${namespace}\` found.`
+            : undefined
+        );
+      }
+
+      return retrievedMessages;
+    } catch (error) {
+      context.onError(
+        new IntlError(IntlErrorCode.MISSING_MESSAGE, error.message)
+      );
     }
-  }
+  }, [allMessages, context, namespace]);
 
   function translate(
     /** Use a dot to indicate a level of nesting (e.g. `namespace.nestedLabel`). */
-    idPath: string,
+    key: string,
     /** Key value pairs for values to interpolate into the message. */
     values?: TranslationValues,
     /** Provide custom formats for numbers, dates and times. */
     formats?: Partial<Formats>
   ) {
     const cachedFormatsByLocale = cachedFormatsByLocaleRef.current;
+    const fallback = [namespace, key].join('.');
+
+    // We have already warned about this during render
+    if (!messages) {
+      return fallback;
+    }
 
     let messageFormat;
-    if (cachedFormatsByLocale[locale]?.[idPath]) {
-      messageFormat = cachedFormatsByLocale[locale][idPath];
+    if (cachedFormatsByLocale[locale]?.[key]) {
+      messageFormat = cachedFormatsByLocale[locale][key];
     } else {
-      const message = resolvePath(messages, idPath);
+      let message;
+      try {
+        message = resolvePath(messages, key, namespace);
+      } catch (error) {
+        context.onError(
+          new IntlError(IntlErrorCode.MISSING_MESSAGE, error.message)
+        );
 
-      if (typeof message === 'object') {
-        if (__DEV__) {
-          throw new Error(
-            `Insufficient path specified for \`${idPath}\` in \`${path}\`.`
-          );
-        } else {
-          throw new Error();
-        }
+        return fallback;
       }
 
-      messageFormat = new IntlMessageFormat(message, locale, formats);
+      if (typeof message === 'object') {
+        context.onError(
+          new IntlError(
+            IntlErrorCode.INSUFFICIENT_PATH,
+            __DEV__
+              ? `Insufficient path specified for \`${key}\` in \`${namespace}\`.`
+              : undefined
+          )
+        );
+
+        return fallback;
+      }
+
+      try {
+        messageFormat = new IntlMessageFormat(message, locale, formats);
+      } catch (error) {
+        context.onError(
+          new IntlError(IntlErrorCode.INVALID_MESSAGE, error.message)
+        );
+
+        return fallback;
+      }
 
       if (!cachedFormatsByLocale[locale]) {
         cachedFormatsByLocale[locale] = {};
       }
-      cachedFormatsByLocale[locale][idPath] = messageFormat;
+      cachedFormatsByLocale[locale][key] = messageFormat;
     }
 
-    const formattedMessage = messageFormat.format(
-      prepareTranslationValues(values)
-    );
+    try {
+      const formattedMessage = messageFormat.format(
+        prepareTranslationValues(values)
+      );
 
-    if (__DEV__) {
-      if (formattedMessage === undefined) {
-        throw new Error(`Unable to format ${path}.${idPath}`);
+      if (formattedMessage == null) {
+        throw new Error(
+          __DEV__ ? `Unable to format ${[namespace, key].join('.')}` : undefined
+        );
       }
-    }
 
-    return formattedMessage;
+      return formattedMessage;
+    } catch (error) {
+      context.onError(
+        new IntlError(IntlErrorCode.FORMATTING_ERROR, error.message)
+      );
+
+      return fallback;
+    }
   }
 
   return translate;

--- a/packages/use-intl/test/useTranslations.test.tsx
+++ b/packages/use-intl/test/useTranslations.test.tsx
@@ -1,7 +1,13 @@
 import {render, screen} from '@testing-library/react';
 import {Formats} from 'intl-messageformat';
 import React, {ReactNode} from 'react';
-import {IntlProvider, useTranslations, TranslationValues} from '../src';
+import {
+  IntlProvider,
+  useTranslations,
+  TranslationValues,
+  IntlError,
+  IntlErrorCode
+} from '../src';
 
 (global as any).__DEV__ = true;
 
@@ -211,4 +217,94 @@ it('switches the message when a new locale is provided', () => {
     </IntlProvider>
   );
   screen.getByText('Hallo');
+});
+
+describe('error handling', () => {
+  it('handles unavailable namespaces', () => {
+    const onError = jest.fn();
+
+    function Component() {
+      const t = useTranslations('Component');
+      return <>{t('label')}</>;
+    }
+
+    render(
+      <IntlProvider locale="en" messages={{}} onError={onError}>
+        <Component />
+      </IntlProvider>
+    );
+
+    const error: IntlError = onError.mock.calls[0][0];
+    expect(error.message).toBe(
+      'MISSING_MESSAGE: Could not resolve `Component` in messages.'
+    );
+    expect(error.code).toBe(IntlErrorCode.MISSING_MESSAGE);
+  });
+
+  it('handles unavailable messages within an existing namespace', () => {
+    const onError = jest.fn();
+
+    function Component() {
+      const t = useTranslations('Component');
+      return <>{t('label')}</>;
+    }
+
+    render(
+      <IntlProvider locale="en" messages={{Component: {}}} onError={onError}>
+        <Component />
+      </IntlProvider>
+    );
+
+    const error: IntlError = onError.mock.calls[0][0];
+    expect(error.message).toBe(
+      'MISSING_MESSAGE: Could not resolve `label` in `Component`.'
+    );
+    expect(error.code).toBe(IntlErrorCode.MISSING_MESSAGE);
+  });
+
+  it('handles unparseable messages', () => {
+    const onError = jest.fn();
+
+    function Component() {
+      const t = useTranslations();
+      return <>{t('price', {value: 10})}</>;
+    }
+
+    render(
+      <IntlProvider
+        locale="en"
+        messages={{price: '{value, currency}'}}
+        onError={onError}
+      >
+        <Component />
+      </IntlProvider>
+    );
+
+    const error: IntlError = onError.mock.calls[0][0];
+    expect(error.message).toBe(
+      'INVALID_MESSAGE: Expected "date", "number", "plural", "select", "selectordinal", or "time" but "c" found.'
+    );
+    expect(error.code).toBe(IntlErrorCode.INVALID_MESSAGE);
+  });
+
+  it('handles formatting errors', () => {
+    const onError = jest.fn();
+
+    function Component() {
+      const t = useTranslations();
+      return <>{t('price')}</>;
+    }
+
+    render(
+      <IntlProvider locale="en" messages={{price: '{value}'}} onError={onError}>
+        <Component />
+      </IntlProvider>
+    );
+
+    const error: IntlError = onError.mock.calls[0][0];
+    expect(error.message).toBe(
+      'FORMATTING_ERROR: The intl string context variable "value" was not provided to the string "{value}"'
+    );
+    expect(error.code).toBe(IntlErrorCode.FORMATTING_ERROR);
+  });
 });

--- a/packages/use-intl/test/useTranslations.test.tsx
+++ b/packages/use-intl/test/useTranslations.test.tsx
@@ -239,6 +239,7 @@ describe('error handling', () => {
       'MISSING_MESSAGE: Could not resolve `Component` in messages.'
     );
     expect(error.code).toBe(IntlErrorCode.MISSING_MESSAGE);
+    screen.getByText('Component.label');
   });
 
   it('handles unavailable messages within an existing namespace', () => {
@@ -260,6 +261,7 @@ describe('error handling', () => {
       'MISSING_MESSAGE: Could not resolve `label` in `Component`.'
     );
     expect(error.code).toBe(IntlErrorCode.MISSING_MESSAGE);
+    screen.getByText('Component.label');
   });
 
   it('handles unparseable messages', () => {
@@ -285,6 +287,7 @@ describe('error handling', () => {
       'INVALID_MESSAGE: Expected "date", "number", "plural", "select", "selectordinal", or "time" but "c" found.'
     );
     expect(error.code).toBe(IntlErrorCode.INVALID_MESSAGE);
+    screen.getByText('price');
   });
 
   it('handles formatting errors', () => {
@@ -306,5 +309,6 @@ describe('error handling', () => {
       'FORMATTING_ERROR: The intl string context variable "value" was not provided to the string "{value}"'
     );
     expect(error.code).toBe(IntlErrorCode.FORMATTING_ERROR);
+    screen.getByText('price');
   });
 });

--- a/packages/use-intl/test/useTranslations.test.tsx
+++ b/packages/use-intl/test/useTranslations.test.tsx
@@ -220,6 +220,29 @@ it('switches the message when a new locale is provided', () => {
 });
 
 describe('error handling', () => {
+  it('allows to configure a fallback', () => {
+    const onError = jest.fn();
+
+    function Component() {
+      const t = useTranslations('Component');
+      return <>{t('label')}</>;
+    }
+
+    render(
+      <IntlProvider
+        getMessageFallback={() => 'fallback'}
+        locale="en"
+        messages={{}}
+        onError={onError}
+      >
+        <Component />
+      </IntlProvider>
+    );
+
+    expect(onError).toHaveBeenCalled();
+    screen.getByText('fallback');
+  });
+
   it('handles unavailable namespaces', () => {
     const onError = jest.fn();
 

--- a/packages/use-intl/tsconfig.json
+++ b/packages/use-intl/tsconfig.json
@@ -8,7 +8,7 @@
     "sourceMap": true,
     "rootDir": "./src",
     "strict": true,
-    "noImplicitReturns": true,
+    "noImplicitReturns": false,
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Fixes #8

Minor differences to the proposal:
 - No `level` (the user can decide how critical a given `code` is).
 - All errors except for the missing provider can render a fallback message and therefore simply log an error to the console instead of breaking the app.