### PR TITLE
feat: added allowDefault

### DIFF
--- a/packages/use-intl/src/IntlContext.tsx
+++ b/packages/use-intl/src/IntlContext.tsx
@@ -6,6 +6,7 @@ import IntlMessages from './IntlMessages';
 export type IntlContextShape = {
   messages?: IntlMessages;
   locale: string;
+  allowDefault?: boolean;
   formats?: Partial<Formats>;
   timeZone?: string;
   onError(error: IntlError): void;

--- a/packages/use-intl/src/IntlProvider.tsx
+++ b/packages/use-intl/src/IntlProvider.tsx
@@ -14,6 +14,7 @@ type Props = {
   formats?: Partial<Formats>;
   /** A time zone as defined in [the tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) which will be applied when formatting dates and times. If this is absent, the user time zone will be used. You can override this by supplying an explicit time zone to `formatDateTime`. */
   timeZone?: string;
+  allowDefault?: boolean;
   /** This callback will be invoked when an error is encountered during
    * resolving a message or formatting it. This defaults to `console.error` to
    * keep your app running. You can customize the handling by taking


### PR DESCRIPTION
as it can be advantageous to "not define the default language in JSON files, etc." in some scenarios

```tsx
// set provider like this
<NextIntlProvider messages={{...messages, ...pageProps.messages}} allowDefault={true}>
    <Component {...pageProps} />
</NextIntlProvider>
        
// usage
$t('tables')
// and if it doesn't exist, it won't throw an error. result will be : "tables"

// usage
$t('Header.tables')
// also here it won't throw an error. result will be : "tables"
```