### PR TITLE
fix: Clearer error message when no messages are provided

### DIFF
--- a/packages/example/messages/de.json
+++ b/packages/example/messages/de.json
@@ -13,6 +13,9 @@
     "about": "Über",
     "switchLocale": "Zu {locale, select, de {Deutsch} en {Englisch}} wechseln"
   },
+  "NotFound": {
+    "title": "Entschuldigung, diese Seite konnte nicht gefunden werden."
+  },
   "PageLayout": {
     "pageTitle": "next-intl"
   }

--- a/packages/example/messages/en.json
+++ b/packages/example/messages/en.json
@@ -13,6 +13,9 @@
     "about": "About",
     "switchLocale": "Switch to {locale, select, de {German} en {English}}"
   },
+  "NotFound": {
+    "title": "Sorry, this page could not be found."
+  },
   "PageLayout": {
     "pageTitle": "next-intl"
   }

--- a/packages/example/src/components/PageLayout.tsx
+++ b/packages/example/src/components/PageLayout.tsx
@@ -4,7 +4,7 @@ import {ReactNode} from 'react';
 import Navigation from './Navigation';
 
 type Props = {
-  children: ReactNode;
+  children?: ReactNode;
   title: string;
 };
 

--- a/packages/example/src/pages/404.tsx
+++ b/packages/example/src/pages/404.tsx
@@ -1,0 +1,22 @@
+import pick from 'lodash/pick';
+import {GetStaticPropsContext} from 'next';
+import {useTranslations} from 'next-intl';
+import PageLayout from '../components/PageLayout';
+
+export default function NotFound() {
+  const t = useTranslations('NotFound');
+  return <PageLayout title={t('title')} />;
+}
+
+NotFound.messages = ['NotFound', ...PageLayout.messages];
+
+export async function getStaticProps({locale}: GetStaticPropsContext) {
+  return {
+    props: {
+      messages: pick(
+        await import(`../../messages/${locale}.json`),
+        NotFound.messages
+      )
+    }
+  };
+}

--- a/packages/use-intl/src/useTranslations.tsx
+++ b/packages/use-intl/src/useTranslations.tsx
@@ -100,6 +100,12 @@ export default function useTranslations(namespace?: string) {
 
   const messagesOrError = useMemo(() => {
     try {
+      if (!allMessages) {
+        throw new Error(
+          __DEV__ ? `No messages were configured on the provider.` : undefined
+        );
+      }
+
       const retrievedMessages = namespace
         ? resolvePath(allMessages, namespace)
         : allMessages;

--- a/packages/use-intl/test/useTranslations.test.tsx
+++ b/packages/use-intl/test/useTranslations.test.tsx
@@ -369,6 +369,28 @@ describe('t.raw', () => {
 });
 
 describe('error handling', () => {
+  it('warns when no messages are configured', () => {
+    const onError = jest.fn();
+
+    function Component() {
+      const t = useTranslations('Component');
+      return <>{t('label')}</>;
+    }
+
+    render(
+      <IntlProvider locale="en" onError={onError}>
+        <Component />
+      </IntlProvider>
+    );
+
+    const error: IntlError = onError.mock.calls[0][0];
+    expect(error.message).toBe(
+      'MISSING_MESSAGE: No messages were configured on the provider.'
+    );
+    expect(error.code).toBe(IntlErrorCode.MISSING_MESSAGE);
+    screen.getByText('Component.label');
+  });
+
   it('allows to configure a fallback', () => {
     const onError = jest.fn();
 


### PR DESCRIPTION
… and provide a 404 example.

Closes #65 