### PR TITLE
feat: Default translation values

### DIFF
--- a/packages/use-intl/src/IntlContext.tsx
+++ b/packages/use-intl/src/IntlContext.tsx
@@ -1,8 +1,8 @@
 import {createContext} from 'react';
-import {RichTranslationValues} from './TranslationValues';
 import Formats from './Formats';
 import IntlError from './IntlError';
 import IntlMessages from './IntlMessages';
+import {RichTranslationValues} from './TranslationValues';
 
 export type IntlContextShape = {
   messages?: IntlMessages;
@@ -16,7 +16,7 @@ export type IntlContextShape = {
     namespace?: string;
   }): string;
   now?: Date;
-  defaultRichTextElements?: RichTranslationValues
+  defaultRichTextElements?: RichTranslationValues;
 };
 
 const IntlContext = createContext<IntlContextShape | undefined>(undefined);

--- a/packages/use-intl/src/IntlContext.tsx
+++ b/packages/use-intl/src/IntlContext.tsx
@@ -16,7 +16,7 @@ export type IntlContextShape = {
     namespace?: string;
   }): string;
   now?: Date;
-  defaultRichTextElements?: RichTranslationValues;
+  defaultTranslationValues?: RichTranslationValues;
 };
 
 const IntlContext = createContext<IntlContextShape | undefined>(undefined);

--- a/packages/use-intl/src/IntlContext.tsx
+++ b/packages/use-intl/src/IntlContext.tsx
@@ -1,4 +1,5 @@
 import {createContext} from 'react';
+import {RichTranslationValues} from './TranslationValues';
 import Formats from './Formats';
 import IntlError from './IntlError';
 import IntlMessages from './IntlMessages';
@@ -15,6 +16,7 @@ export type IntlContextShape = {
     namespace?: string;
   }): string;
   now?: Date;
+  defaultRichTextElements?: RichTranslationValues
 };
 
 const IntlContext = createContext<IntlContextShape | undefined>(undefined);

--- a/packages/use-intl/src/IntlProvider.tsx
+++ b/packages/use-intl/src/IntlProvider.tsx
@@ -40,9 +40,10 @@ type Props = {
    *    afterwards the current date will be returned continuously.
    */
   now?: Date;
-  /** Global rich text elements for consistent styling or usage of rich text tags.
-   * Will be overidden by locally provided elements. */
-  defaultRichTextElements?: RichTranslationValues;
+  /** Global default values for translation values and rich text elements.
+   * Can be used for consistent usage or styling of rich text elements.
+   * Defaults will be overidden by locally provided values. */
+  defaultTranslationValues?: RichTranslationValues;
 };
 
 function defaultGetMessageFallback({

--- a/packages/use-intl/src/IntlProvider.tsx
+++ b/packages/use-intl/src/IntlProvider.tsx
@@ -3,6 +3,7 @@ import Formats from './Formats';
 import IntlContext from './IntlContext';
 import IntlMessages from './IntlMessages';
 import {IntlError} from '.';
+import {RichTranslationValues} from './TranslationValues';
 
 type Props = {
   /** All messages that will be available in your components. */
@@ -39,6 +40,9 @@ type Props = {
    *    afterwards the current date will be returned continuously.
    */
   now?: Date;
+  /** Global rich text elements for consistent styling or usage of rich text tags.
+   * Will be overidden by locally provided elements. */
+  defaultRichTextElements?: RichTranslationValues
 };
 
 function defaultGetMessageFallback({

--- a/packages/use-intl/src/IntlProvider.tsx
+++ b/packages/use-intl/src/IntlProvider.tsx
@@ -2,8 +2,8 @@ import React, {ReactNode} from 'react';
 import Formats from './Formats';
 import IntlContext from './IntlContext';
 import IntlMessages from './IntlMessages';
-import {IntlError} from '.';
 import {RichTranslationValues} from './TranslationValues';
+import {IntlError} from '.';
 
 type Props = {
   /** All messages that will be available in your components. */
@@ -42,7 +42,7 @@ type Props = {
   now?: Date;
   /** Global rich text elements for consistent styling or usage of rich text tags.
    * Will be overidden by locally provided elements. */
-  defaultRichTextElements?: RichTranslationValues
+  defaultRichTextElements?: RichTranslationValues;
 };
 
 function defaultGetMessageFallback({

--- a/packages/use-intl/src/useTranslations.tsx
+++ b/packages/use-intl/src/useTranslations.tsx
@@ -85,7 +85,7 @@ function prepareTranslationValues(values: RichTranslationValues) {
  */
 export default function useTranslations(namespace?: string) {
   const {
-    defaultRichTextElements,
+    defaultTranslationValues,
     formats: globalFormats,
     getMessageFallback,
     locale,
@@ -216,7 +216,7 @@ export default function useTranslations(namespace?: string) {
 
       try {
         const formattedMessage = messageFormat.format(
-          prepareTranslationValues({...defaultRichTextElements, ...values})
+          prepareTranslationValues({...defaultTranslationValues, ...values})
         );
 
         if (formattedMessage == null) {
@@ -306,7 +306,7 @@ export default function useTranslations(namespace?: string) {
     namespace,
     onError,
     timeZone,
-    defaultRichTextElements
+    defaultTranslationValues
   ]);
 
   return translate;

--- a/packages/use-intl/src/useTranslations.tsx
+++ b/packages/use-intl/src/useTranslations.tsx
@@ -48,7 +48,7 @@ function resolvePath(
 }
 
 function prepareTranslationValues(values: RichTranslationValues) {
-  if (Object.keys(values).length < 1) return undefined;
+  if (Object.keys(values).length === 0) return undefined;
 
   // Workaround for https://github.com/formatjs/formatjs/issues/1467
   const transformedValues: RichTranslationValues = {};
@@ -85,13 +85,13 @@ function prepareTranslationValues(values: RichTranslationValues) {
  */
 export default function useTranslations(namespace?: string) {
   const {
+    defaultRichTextElements,
     formats: globalFormats,
     getMessageFallback,
     locale,
     messages: allMessages,
     onError,
-    timeZone,
-    defaultRichTextElements
+    timeZone
   } = useIntlContext();
 
   const cachedFormatsByLocaleRef = useRef<

--- a/packages/use-intl/src/useTranslations.tsx
+++ b/packages/use-intl/src/useTranslations.tsx
@@ -47,8 +47,8 @@ function resolvePath(
   return message;
 }
 
-function prepareTranslationValues(values?: RichTranslationValues) {
-  if (!values) return values;
+function prepareTranslationValues(values: RichTranslationValues) {
+  if (Object.keys(values).length < 1) return undefined;
 
   // Workaround for https://github.com/formatjs/formatjs/issues/1467
   const transformedValues: RichTranslationValues = {};
@@ -90,7 +90,8 @@ export default function useTranslations(namespace?: string) {
     locale,
     messages: allMessages,
     onError,
-    timeZone
+    timeZone,
+    defaultRichTextElements
   } = useIntlContext();
 
   const cachedFormatsByLocaleRef = useRef<
@@ -215,7 +216,7 @@ export default function useTranslations(namespace?: string) {
 
       try {
         const formattedMessage = messageFormat.format(
-          prepareTranslationValues(values)
+          prepareTranslationValues({...defaultRichTextElements, ...values})
         );
 
         if (formattedMessage == null) {
@@ -304,7 +305,8 @@ export default function useTranslations(namespace?: string) {
     messagesOrError,
     namespace,
     onError,
-    timeZone
+    timeZone,
+    defaultRichTextElements
   ]);
 
   return translate;

--- a/packages/use-intl/test/useIntl.test.tsx
+++ b/packages/use-intl/test/useIntl.test.tsx
@@ -272,7 +272,7 @@ describe('formatNumber', () => {
 
       const error: IntlError = onError.mock.calls[0][0];
       expect(error.message).toBe(
-        'FORMATTING_ERROR: Invalid currency codes : unknown'
+        'FORMATTING_ERROR: Invalid currency code : unknown'
       );
       expect(error.code).toBe(IntlErrorCode.FORMATTING_ERROR);
       expect(container.textContent).toBe('10000');

--- a/packages/use-intl/test/useIntl.test.tsx
+++ b/packages/use-intl/test/useIntl.test.tsx
@@ -272,7 +272,7 @@ describe('formatNumber', () => {
 
       const error: IntlError = onError.mock.calls[0][0];
       expect(error.message).toBe(
-        'FORMATTING_ERROR: Invalid currency code : unknown'
+        'FORMATTING_ERROR: Invalid currency codes : unknown'
       );
       expect(error.code).toBe(IntlErrorCode.FORMATTING_ERROR);
       expect(container.textContent).toBe('10000');

--- a/packages/use-intl/test/useTranslations.test.tsx
+++ b/packages/use-intl/test/useTranslations.test.tsx
@@ -615,3 +615,86 @@ describe('global formats', () => {
     screen.getByText('Thursday, November 19, 2020');
   });
 });
+
+describe('default translation values', () => {
+  function renderRichTextMessageWithDefault(
+    message: string,
+    values?: RichTranslationValues,
+    formats?: Partial<Formats>
+  ) {
+    function Component() {
+      const t = useTranslations();
+      return <>{t.rich('message', values, formats)}</>;
+    }
+
+    return render(
+      <IntlProvider
+        defaultTranslationValues={{
+          important: (children) => <b>{children}</b>
+        }}
+        formats={{dateTime: {time: {hour: 'numeric', minute: '2-digit'}}}}
+        locale="en"
+        messages={{message}}
+        timeZone="Europe/London"
+      >
+        <Component />
+      </IntlProvider>
+    );
+  }
+
+  function renderMessageWithDefault(
+    message: string,
+    values?: TranslationValues,
+    formats?: Partial<Formats>
+  ) {
+    function Component() {
+      const t = useTranslations();
+      return <>{t('message', values, formats)}</>;
+    }
+
+    return render(
+      <IntlProvider
+        defaultTranslationValues={{
+          value: 123
+        }}
+        formats={{dateTime: {time: {hour: 'numeric', minute: '2-digit'}}}}
+        locale="en"
+        messages={{message}}
+        timeZone="Europe/London"
+      >
+        <Component />
+      </IntlProvider>
+    );
+  }
+
+  it('uses default rich text element', () => {
+    const {container} = renderRichTextMessageWithDefault(
+      'This is <important>important</important> and <important>this as well</important>'
+    );
+    expect(container.innerHTML).toBe(
+      'This is <b>important</b> and <b>this as well</b>'
+    );
+  });
+
+  it('overrides default rich text element', () => {
+    const {container} = renderRichTextMessageWithDefault(
+      'This is <important>important</important> and <important>this as well</important>',
+      {
+        important: (children) => <i>{children}</i>
+      }
+    );
+    expect(container.innerHTML).toBe(
+      'This is <i>important</i> and <i>this as well</i>'
+    );
+  });
+
+  it('uses default translation values', () => {
+    renderMessageWithDefault('Hello {value}');
+    screen.getByText('Hello 123');
+  });
+
+  it('overrides default translation values', () => {
+    renderMessageWithDefault('Hello {value}', {value: 234});
+    screen.getByText('Hello 234');
+  });
+});

--- a/packages/website/pages/docs/usage/configuration.mdx
+++ b/packages/website/pages/docs/usage/configuration.mdx
@@ -80,7 +80,8 @@ The defaults will be overridden by locally provided values.
 <NextIntlProvider
   ...
   defaultTranslationValues={{
-    b: (children) => <strong>{children}</strong>
+    important: (children) => <b>{children}</b>,
+    value: 123
   }}
 >
   <App />

--- a/packages/website/pages/docs/usage/configuration.mdx
+++ b/packages/website/pages/docs/usage/configuration.mdx
@@ -71,6 +71,21 @@ t('ordered', {orderDate: parseISO('2020-11-20T10:36:01.516Z')});
 t('latitude', {latitude: 47.414329182});
 ```
 
+## Global Rich Text Elements
+To achieve consistent usage and styling of rich text elements, you can define a set of global elements and pass them to the provider.
+If you define an element locally it will override the global default.
+
+```js
+<NextIntlProvider
+  ...
+  defaultRichTextElements={{
+    b: (value) => <strong>{value}</strong>
+  }}
+>
+  <App />
+</NextIntlProvider>
+```
+
 ## Retrieving provider config
 
 As a convenience, two hooks exist that allow to read configuration that was passed to the provider:

--- a/packages/website/pages/docs/usage/configuration.mdx
+++ b/packages/website/pages/docs/usage/configuration.mdx
@@ -71,15 +71,16 @@ t('ordered', {orderDate: parseISO('2020-11-20T10:36:01.516Z')});
 t('latitude', {latitude: 47.414329182});
 ```
 
-## Global Rich Text Elements
-To achieve consistent usage and styling of rich text elements, you can define a set of global elements and pass them to the provider.
-If you define an element locally it will override the global default.
+## Default translation values
+To achieve consistent usage of translation values and reduce redundancy, you can define a set of global default values and pass them to the provider.
+This configuration also can be used to apply consistent styling to commonly used rich text elements.
+The defaults will be overridden by locally provided values.
 
 ```js
 <NextIntlProvider
   ...
-  defaultRichTextElements={{
-    b: (value) => <strong>{value}</strong>
+  defaultTranslationValues={{
+    b: (children) => <strong>{children}</strong>
   }}
 >
   <App />

--- a/packages/website/pages/docs/usage/messages.mdx
+++ b/packages/website/pages/docs/usage/messages.mdx
@@ -149,7 +149,6 @@ t('selectordinal', {year: 11});
 ## Rich text
 
 You can format rich text with custom tags and map them to React components.
-If you want to use the same tag multiple times, you can configure it via the [default translation values](/docs/usage/configuration#default-translation-values).
 
 ```js
 {
@@ -163,6 +162,8 @@ t.rich('richText', {
   very: (children) => <i>{children}</i>
 });
 ```
+
+If you want to use the same tag multiple times, you can configure it via the [default translation values](/docs/usage/configuration#default-translation-values).
 
 ## Raw messages
 

--- a/packages/website/pages/docs/usage/messages.mdx
+++ b/packages/website/pages/docs/usage/messages.mdx
@@ -149,6 +149,7 @@ t('selectordinal', {year: 11});
 ## Rich text
 
 You can format rich text with custom tags and map them to React components.
+If you want to use the same tag multiple times, you can configure it via the [default translation values](/docs/usage/configuration#default-translation-values).
 
 ```js
 {
@@ -158,8 +159,8 @@ You can format rich text with custom tags and map them to React components.
 
 ```js
 t.rich('richText', {
-  important: children => <b>{children}</b>,
-  very: children => <i>{children}</i>
+  important: (children) => <b>{children}</b>,
+  very: (children) => <i>{children}</i>
 });
 ```
 


### PR DESCRIPTION
To achieve consistent usage and styling of rich text elements, I have included an option to define global defaults for rich text elements. The default will be overridden by a local definition of an element.

This approach is the same as the one from [react-intl](https://formatjs.io/docs/react-intl/components/#defaultrichtextelements).