### PR TITLE
fix: #112 - default NestedKey to never

### DIFF
--- a/packages/use-intl/src/useTranslations.tsx
+++ b/packages/use-intl/src/useTranslations.tsx
@@ -17,7 +17,7 @@ import NestedValueOf from './utils/NestedValueOf';
  * (e.g. `namespace.Component`).
  */
 export default function useTranslations<
-  NestedKey extends NamespaceKeys<IntlMessages, NestedKeyOf<IntlMessages>>
+  NestedKey extends NamespaceKeys<IntlMessages, NestedKeyOf<IntlMessages>> = never
 >(
   namespace?: NestedKey
 ): // Explicitly defining the return type is necessary as TypeScript would get it wrong
@@ -27,17 +27,14 @@ export default function useTranslations<
     TargetKey extends MessageKeys<
       NestedValueOf<
         {'!': IntlMessages},
-        NamespaceKeys<IntlMessages, NestedKeyOf<IntlMessages>> extends NestedKey
+        [NestedKey] extends [never]
           ? '!'
           : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
           {'!': IntlMessages},
-          NamespaceKeys<
-            IntlMessages,
-            NestedKeyOf<IntlMessages>
-          > extends NestedKey
+          [NestedKey] extends [never],
             ? '!'
             : `!.${NestedKey}`
         >
@@ -54,17 +51,14 @@ export default function useTranslations<
     TargetKey extends MessageKeys<
       NestedValueOf<
         {'!': IntlMessages},
-        NamespaceKeys<IntlMessages, NestedKeyOf<IntlMessages>> extends NestedKey
+        [NestedKey] extends [never]
           ? '!'
           : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
           {'!': IntlMessages},
-          NamespaceKeys<
-            IntlMessages,
-            NestedKeyOf<IntlMessages>
-          > extends NestedKey
+          [NestedKey] extends [never]
             ? '!'
             : `!.${NestedKey}`
         >
@@ -81,17 +75,14 @@ export default function useTranslations<
     TargetKey extends MessageKeys<
       NestedValueOf<
         {'!': IntlMessages},
-        NamespaceKeys<IntlMessages, NestedKeyOf<IntlMessages>> extends NestedKey
+        [NestedKey] extends [never]
           ? '!'
           : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
           {'!': IntlMessages},
-          NamespaceKeys<
-            IntlMessages,
-            NestedKeyOf<IntlMessages>
-          > extends NestedKey
+          [NestedKey] extends [never]
             ? '!'
             : `!.${NestedKey}`
         >
@@ -109,7 +100,7 @@ export default function useTranslations<
   // The prefix ("!"") is arbitrary, but we have to use some.
   return useTranslationsImpl<
     {'!': IntlMessages},
-    NamespaceKeys<IntlMessages, NestedKeyOf<IntlMessages>> extends NestedKey
+    [NestedKey] extends [never]
       ? '!'
       : `!.${NestedKey}`
   >(

--- a/packages/use-intl/src/useTranslations.tsx
+++ b/packages/use-intl/src/useTranslations.tsx
@@ -34,7 +34,7 @@ export default function useTranslations<
       NestedKeyOf<
         NestedValueOf<
           {'!': IntlMessages},
-          [NestedKey] extends [never],
+          [NestedKey] extends [never]
             ? '!'
             : `!.${NestedKey}`
         >

--- a/packages/use-intl/src/useTranslations.tsx
+++ b/packages/use-intl/src/useTranslations.tsx
@@ -17,7 +17,10 @@ import NestedValueOf from './utils/NestedValueOf';
  * (e.g. `namespace.Component`).
  */
 export default function useTranslations<
-  NestedKey extends NamespaceKeys<IntlMessages, NestedKeyOf<IntlMessages>> = never
+  NestedKey extends NamespaceKeys<
+    IntlMessages,
+    NestedKeyOf<IntlMessages>
+  > = never
 >(
   namespace?: NestedKey
 ): // Explicitly defining the return type is necessary as TypeScript would get it wrong
@@ -27,16 +30,12 @@ export default function useTranslations<
     TargetKey extends MessageKeys<
       NestedValueOf<
         {'!': IntlMessages},
-        [NestedKey] extends [never]
-          ? '!'
-          : `!.${NestedKey}`
+        [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
           {'!': IntlMessages},
-          [NestedKey] extends [never]
-            ? '!'
-            : `!.${NestedKey}`
+          [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
     >
@@ -51,16 +50,12 @@ export default function useTranslations<
     TargetKey extends MessageKeys<
       NestedValueOf<
         {'!': IntlMessages},
-        [NestedKey] extends [never]
-          ? '!'
-          : `!.${NestedKey}`
+        [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
           {'!': IntlMessages},
-          [NestedKey] extends [never]
-            ? '!'
-            : `!.${NestedKey}`
+          [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
     >
@@ -75,16 +70,12 @@ export default function useTranslations<
     TargetKey extends MessageKeys<
       NestedValueOf<
         {'!': IntlMessages},
-        [NestedKey] extends [never]
-          ? '!'
-          : `!.${NestedKey}`
+        [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
           {'!': IntlMessages},
-          [NestedKey] extends [never]
-            ? '!'
-            : `!.${NestedKey}`
+          [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
     >
@@ -100,9 +91,7 @@ export default function useTranslations<
   // The prefix ("!"") is arbitrary, but we have to use some.
   return useTranslationsImpl<
     {'!': IntlMessages},
-    [NestedKey] extends [never]
-      ? '!'
-      : `!.${NestedKey}`
+    [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
   >(
     {'!': messages},
     // @ts-ignore


### PR DESCRIPTION
Fixes #112 

Modified files:

- `packages/use-intl/src/useTranslations.tsx`

It's just my comment with the ideas applied:

> And in the conditional, I just check if `NestedKey` is `never`: `[NestedKey] extends [never] ? ... : ...`. It seems to work fine.
> 
> You can find the fix [here](https://www.typescriptlang.org/play?#code/PTAEFpM0FcBcCWAbAzgWAFCbgTwA4CmoAcgSnAQCYDSBOA8gGYA89AfKALyj2gEAeFAHaUUoAPYAjAFYEAxnFAB+UAG9MoTaADa1UAiGgA1nXGMeAXQBcoAAYASVXoBkocgCcDAcwC+t0AA+do4ubnCeQr4AdI6k5FS0DCz0uhZsfgDcmD7aJjhmlqA2QgQAbgTuWVgYuISgAOIEcKwANKAACnyCBCJiHt4cnBodXcKiwaoGjBWgiT4xk0LT7qAASmRwfsOaKomjPeN5Bbwqjc0piRZt6+QcxWUV20UjAmNiR+YnPNrtFs8l5UqmGw+CIZ3oMnkcESKFas32vTCES8gzUwx++kM1GsDSacPaHFeBz64W8ylAAJmNnaVRy2KqmBAECg4H0AFs8EgCGyenAAIaIcRCYEYJkAIXc4hMwuqciF5AkMi4aIwmkkfPcNnUqq0fJsAHIABIEJBIcT64Y+bKgPliOVCcgMjCMGBCBQIIWgRh8hTidw4ACMzDiFBodAR43BkIUMOYtQIBSk0jaIYSdCYcdBiZkbFRlPcbAAFEI+TyUHgfQQlDZU2GcABKFWaJm1vYIMRStpwAAWRHtlAQgsM7dAkkl0qiw3cTRg7kM+sY4nNNrEhdb4aJiO0+b+KgARGOpT09889wB3P1Gbx7+u0kVMgDql+8IvtCqTACZldrNLbKIwtT-ADQD3IC9x8FphnVTUm11A1jVNc1LWtW1QDfOAnRdN0hy9H04D9HAP2DDY0xwCMxCjWQYzoWF42zaQPxTEi6wzOjzE-XMixLMsKzkKsa2YxJGx-TRpzgWd50XZdUMLSioVjNjFQYpj4hYlhFI4wlukRdcyP3Q9pRPGxz2fSIbzvaomRZVk5D5U10FleVFHcANlW9X1-QDQt9Wg-VGyZA9x2PTB0NAdwv24dz8P9D9vN8-ywBM9wrzMzAgA)