### PR TITLE
fix: Add ReactNode as allowed type of TranslationValue

### DIFF
--- a/packages/use-intl/src/TranslationValues.tsx
+++ b/packages/use-intl/src/TranslationValues.tsx
@@ -1,7 +1,7 @@
 import {ReactNode} from 'react';
 
 // From IntlMessageFormat#format
-type TranslationValue = ReactNode | string | number | boolean | Date | null | undefined;
+type TranslationValue = ReactNode | Date;
 
 type TranslationValues = Record<string, TranslationValue>;
 

--- a/packages/use-intl/src/TranslationValues.tsx
+++ b/packages/use-intl/src/TranslationValues.tsx
@@ -1,7 +1,7 @@
 import {ReactNode} from 'react';
 
 // From IntlMessageFormat#format
-type TranslationValue = string | number | boolean | Date | null | undefined;
+type TranslationValue = ReactNode | string | number | boolean | Date | null | undefined;
 
 type TranslationValues = Record<string, TranslationValue>;
 

--- a/packages/use-intl/src/useTranslationsImpl.tsx
+++ b/packages/use-intl/src/useTranslationsImpl.tsx
@@ -68,6 +68,8 @@ function prepareTranslationValues(values: RichTranslationValues) {
           ? cloneElement(result, {key: key + index++})
           : result;
       };
+    } else if(isValidElement(value)) {
+      transformed = cloneElement(value, {key: key + index++});
     } else {
       transformed = value;
     }


### PR DESCRIPTION
Seems like ReactNode is acceptable as TranslationValue and it's useful if we want to use React Nodes as translation values.
Example:
```
<NextIntlProvider defaultTranslationValues={{ br: <br /> }}>
    {content}
</NextIntlProvider>
```

And then use it in JSON: `Line 1 {br} Line 2`

Adding it to types helps to omit unnecessary TypeScript transformations and `@ts-ignore` usages.

I'm not sure if it possible to implement such thing as Intl has out-of-the-box: https://formatjs.io/docs/react-intl/components#wraprichtextchunksinfragment to avoid "keys" issue in another way.