### PR TITLE
feat: Add standalone "getTranslation" for React

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 node_modules
 dist
+.vscode

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "publish": "lerna publish --yes --no-verify-access",
-    "prerelease": "lerna publish prerelease --yes --no-verify-access --dist-tag next --no-changelog --no-git-tag-version"
+    "prerelease": "lerna publish prerelease --yes --no-verify-access --dist-tag next --no-changelog --no-git-tag-version",
+    "postinstall": "yarn workspace use-intl run build && yarn workspace next-intl run build"
   },
   "workspaces": [
     "packages/use-intl",

--- a/packages/example-advanced/src/pages/index.tsx
+++ b/packages/example-advanced/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import pick from 'lodash/pick';
 import {GetStaticPropsContext} from 'next';
-import {useTranslations} from 'next-intl';
+import {useTranslations, getTranslation} from 'next-intl';
 import {useRouter} from 'next/router';
 import Code from 'components/Code';
 import PageLayout from 'components/PageLayout';
@@ -25,6 +25,14 @@ export default function Index() {
           </li>
         ))}
       </ul>
+
+      <div>
+        {getTranslation("Index", "description", "rich", {
+          locale,
+          p: (children) => <p>{children}</p>,
+          code: (children) => <Code>{children}</Code>
+        })}
+      </div>
     </PageLayout>
   );
 }

--- a/packages/example/src/pages/index.tsx
+++ b/packages/example/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import {GetStaticPropsContext} from 'next';
-import {useTranslations} from 'next-intl';
+import {useTranslations, getTranslation} from 'next-intl';
 import LocaleSwitcher from 'components/LocaleSwitcher';
 import PageLayout from 'components/PageLayout';
 
@@ -10,6 +10,8 @@ export default function Index() {
     <PageLayout title={t('title')}>
       <p>{t('description')}</p>
       <LocaleSwitcher />
+
+      <p>{getTranslation('Index', 'description')}</p>
     </PageLayout>
   );
 }

--- a/packages/use-intl/src/react/IntlContext.tsx
+++ b/packages/use-intl/src/react/IntlContext.tsx
@@ -21,4 +21,7 @@ export type IntlContextShape = {
 
 const IntlContext = createContext<IntlContextShape | undefined>(undefined);
 
+// used for getTranslation helper
+export const IntlContextValue: IntlContextShape = {} as any;
+
 export default IntlContext;

--- a/packages/use-intl/src/react/IntlProvider.tsx
+++ b/packages/use-intl/src/react/IntlProvider.tsx
@@ -4,7 +4,7 @@ import IntlConfiguration from '../core/IntlConfiguration';
 import {RichTranslationValues} from '../core/TranslationValues';
 import {defaultGetMessageFallback, defaultOnError} from '../core/defaults';
 import validateMessages from '../core/validateMessages';
-import IntlContext from './IntlContext';
+import IntlContext, { IntlContextValue } from './IntlContext';
 
 type Props = IntlConfiguration & {
   /** All components that use the provided hooks should be within this tree. */
@@ -32,6 +32,9 @@ export default function IntlProvider({
       }
     }, [messages, onError]);
   }
+
+  // makes IntlContextValue have the same value as IntlContext
+  Object.assign(IntlContextValue, {...contextValues, messages, onError, getMessageFallback});
 
   return (
     <IntlContext.Provider

--- a/packages/use-intl/src/react/getTranslation.ts
+++ b/packages/use-intl/src/react/getTranslation.ts
@@ -1,0 +1,85 @@
+import IntlMessageFormat from "intl-messageformat";
+
+import { Formats, RichTranslationValues } from "../core";
+import createBaseTranslator, {
+  getMessagesOrError,
+} from "../core/createBaseTranslator";
+import resolveNamespace from "../core/resolveNamespace";
+import MessageKeys from "../core/utils/MessageKeys";
+import NamespaceKeys from "../core/utils/NamespaceKeys";
+import NestedKeyOf from "../core/utils/NestedKeyOf";
+import NestedValueOf from "../core/utils/NestedValueOf";
+import { IntlContextValue } from "./IntlContext";
+
+const cachedFormatsByLocaleRef: Record<
+  string,
+  Record<string, IntlMessageFormat>
+> = {};
+
+type Rich = [RichTranslationValues?, Partial<Formats>?];
+
+type Raw = [];
+
+export default function getTranslation<
+  NestedKey extends NamespaceKeys<IntlMessages, NestedKeyOf<IntlMessages>>,
+  NestedKeyValue extends MessageKeys<
+    NestedValueOf<
+      { "!": IntlMessages },
+      [NestedKey] extends [never] ? "!" : `!.${NestedKey}`
+    >,
+    NestedKeyOf<
+      NestedValueOf<
+        { "!": IntlMessages },
+        [NestedKey] extends [never] ? "!" : `!.${NestedKey}`
+      >
+    >
+  >,
+  ExtraKey extends "rich" | "raw",
+  ExtraArgs extends ExtraKey extends "rich"
+    ? Rich
+    : Raw
+>(
+  baseNamespace: NestedKey,
+  message: NestedKeyValue,
+  specialIdentifier?: ExtraKey,
+  ...specialArgs: ExtraArgs
+) {
+  // TODO: should check if IntlContextValue has actual value from provider
+  const {
+    defaultTranslationValues,
+    formats: globalFormats,
+    getMessageFallback,
+    locale,
+    onError,
+    timeZone,
+  } = IntlContextValue;
+
+  const messages = IntlContextValue.messages as IntlMessages;
+
+  const namespace = resolveNamespace(`!.${baseNamespace}`, "!") as NestedKeyOf<
+    typeof messages
+  >;
+
+  const translate = createBaseTranslator({
+    cachedFormatsByLocale: cachedFormatsByLocaleRef,
+    getMessageFallback,
+    messagesOrError: getMessagesOrError({
+      messages,
+      namespace,
+      onError,
+    }),
+    defaultTranslationValues,
+    namespace,
+    onError,
+    formats: globalFormats,
+    locale,
+    timeZone,
+  });
+
+  if (specialIdentifier && specialArgs) {
+    // @ts-ignore -- if you know how to fix this TS error, that'd be much appreciated
+    return translate[specialIdentifier](message, ...specialArgs);
+  }
+
+  return translate(message);
+}

--- a/packages/use-intl/src/react/index.tsx
+++ b/packages/use-intl/src/react/index.tsx
@@ -4,3 +4,4 @@ export {default as useIntl} from './useIntl';
 export {default as useLocale} from './useLocale';
 export {default as useNow} from './useNow';
 export {default as useTimeZone} from './useTimeZone';
+export {default as getTranslation} from './getTranslation';


### PR DESCRIPTION
Fixes https://github.com/amannn/next-intl/issues/141

This adds a `getTranslation` helper that will work the same as `useTranslations(<namespace>)(<message>)`. It uses the same translations as the closest translation Provider*.

The use case for this helper is in the event you want to access translations outside of a hook/react component, but within your react application, for instance an error handler without needing to pass a "translation" function to the error handler.

Caveats:
* It won't use the closest Provider in the event of memo'ing of component(s) that stops full tree revalidation. (would say it isn't really a relevant case)

* needs to be used within the Provider, but only if you'll be using this in the initial render. Outside of initial render it won't _technically_ be a requirement to be needed to be used within the Provider, it will instead use the "closest" provider. Which provider that ends up being depends on where you'll be using the helper. (would say not really relevant due to single provider)

* it will not be replacing the react hook, it's more of a "edge case" helper

Notes / Todos:
* Not super happy with the API in the current PR, any alternative suggestions?

* PR doesn't update docs, as I'm not sure if we'll keep this API and/or that such a helper will get accepted. -- In the event both are resolved, it will update docs.

* PR doesn't add tests, same reasoning as the above; will also be added in the event both of the above gets resolved.

* PR doesn't follow project coding conventions in `getTranslation.ts`. Will be updated in the event the above gets resolved.

* PR updates example code, but this leads to the text in the example code to look confusing. This should be removed and/or changed in some way.

* Didn't create this as a draft PR, even though it technically is. Reasoning being that I want feedback and not sure if the maintainer(s) would do that for a draft PR. Feel free to change it.