### PR TITLE
fix: Require i18n middleware only on root

### DIFF
--- a/packages/example-next-13/src/middleware.tsx
+++ b/packages/example-next-13/src/middleware.tsx
@@ -4,3 +4,7 @@ export default createIntlMiddleware({
   locales: ['en', 'de'],
   defaultLocale: 'en'
 });
+
+export const config = {
+  matcher: '/'
+};

--- a/packages/website/pages/docs/next-13/client-components.mdx
+++ b/packages/website/pages/docs/next-13/client-components.mdx
@@ -80,6 +80,10 @@ export default createIntlMiddleware({
   locales: ['en', 'de'],
   defaultLocale: 'en'
 });
+
+export const config = {
+  matcher: '/'
+};
 ```
 
 That's all you need to do to start using translations in the `app` directory!


### PR DESCRIPTION
Might not be a good idea just yet, probably need to wait for #149.