### PR TITLE
fix: add missing 'use client' directive for usePathname

### DIFF
--- a/packages/next-intl/src/client/usePathname.tsx
+++ b/packages/next-intl/src/client/usePathname.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {usePathname as useNextPathname} from 'next/navigation';
 import {useEffect, useState} from 'react';
 import getCookieLocale from './getCookieLocale';


### PR DESCRIPTION
```
error - ./node_modules/.pnpm/next-intl@2.11.0-beta.8_next@13.1.6+react@18.2.0/node_modules/next-intl/dist/src/client/usePathname.js
ReactServerComponentsError:

You're importing a component that needs useState. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.

   ,-[./node_modules/.pnpm/next-intl@2.11.0-beta.8_next@13.1.6+react@18.2.0/node_modules/next-intl/dist/src/client/usePathname.js:1:1]
 1 | import { usePathname as useNextPathname } from 'next/navigation';
 2 | import { useEffect, useState } from 'react';
   :                     ^^^^^^^^
 3 | import getCookieLocale from './getCookieLocale';
 4 | import hasPathnamePrefixed from './hasPathnamePrefixed';
 5 | export function unlocalizePathname(pathname) {
   `----

Maybe one of these should be marked as a client entry with "use client":
  node_modules/.pnpm/next-intl@2.11.0-beta.8_next@13.1.6+react@18.2.0/node_modules/next-intl/dist/src/client/usePathname.js
  node_modules/.pnpm/next-intl@2.11.0-beta.8_next@13.1.6+react@18.2.0/node_modules/next-intl/dist/src/client/index.js
  app/[locale]/layout.tsx
```

Reference: <https://beta.nextjs.org/docs/rendering/server-and-client-components#convention>

Introduced in https://github.com/amannn/next-intl/commit/68ce7db79383900de2d46bb69dd5c175a6d0c7d1#diff-b67520fde3f77290ca84cfb11466b0d730d23909f7c67ee7150ee2888e9307b1R2

https://github.com/amannn/next-intl/blob/b301d472c9d1fd7ec27eff344b677c04540333dc/packages/next-intl/src/client/usePathname.tsx#L2
