### PR TITLE
docs: update deprecated import of `NextIntlClientProvider`

### DIFF
--- a/packages/website/pages/docs/next-13/client-components.mdx
+++ b/packages/website/pages/docs/next-13/client-components.mdx
@@ -36,7 +36,7 @@ If you haven't done so already, [create a Next.js 13 app that uses the `app` dir
 2. Provide the document layout and set up `NextIntlClientProvider` in `app/[locale]/layout.tsx`:
 
 ```tsx
-import {NextIntlClientProvider} from 'next-intl/client';
+import {NextIntlClientProvider} from 'next-intl';
 import {notFound} from 'next/navigation';
 
 export function generateStaticParams() {


### PR DESCRIPTION
Update deprecated import of `NextIntlClientProvider` in Next 13 client component docs

```diff
-import {NextIntlClientProvider} from 'next-intl/client';
+import {NextIntlClientProvider} from 'next-intl';
```

Importing `NextIntlClientProvider` from `next-intl/client` cannot work properly at all (#189)