### PR TITLE
docs: fix path in server-components.mdx

### DIFF
--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -62,7 +62,7 @@ If you haven't done so already, [create a Next.js 13 app that uses the `app` dir
 import {getRequestConfig} from 'next-intl/server';
 
 export default getRequestConfig(async ({locale}) => ({
-  messages: (await import(`../messages/${locale}.json`)).default
+  messages: (await import(`./messages/${locale}.json`)).default
 }));
 ```
 


### PR DESCRIPTION
This fixes the wrong path in `server-components.mdx`.  the Folder `messages` and `i18n.ts` are at the same level.