### PR TITLE
fix: Incorrect locale information provided Error if accept-language is invalid

### DIFF
--- a/packages/next-intl/src/server/resolveLocale.tsx
+++ b/packages/next-intl/src/server/resolveLocale.tsx
@@ -74,7 +74,10 @@ export default function resolveLocale(
         'accept-language': requestHeaders.get('accept-language') || undefined
       }
     }).languages();
-    locale = match(languages, i18n.locales, i18n.defaultLocale);
+    try {
+      locale = match(languages, i18n.locales, i18n.defaultLocale);
+    }
+    catch {}
   }
 
   // Prio 5: Use default locale

--- a/packages/next-intl/src/server/resolveLocale.tsx
+++ b/packages/next-intl/src/server/resolveLocale.tsx
@@ -76,8 +76,7 @@ export default function resolveLocale(
     }).languages();
     try {
       locale = match(languages, i18n.locales, i18n.defaultLocale);
-    }
-    catch {}
+    } catch (e) {}
   }
 
   // Prio 5: Use default locale

--- a/packages/next-intl/src/server/resolveLocale.tsx
+++ b/packages/next-intl/src/server/resolveLocale.tsx
@@ -77,7 +77,7 @@ export default function resolveLocale(
     try {
       locale = match(languages, i18n.locales, i18n.defaultLocale);
     } catch (e) {
-      locale = i18n.defaultLocale
+      // Invalid language
     }
   }
 

--- a/packages/next-intl/src/server/resolveLocale.tsx
+++ b/packages/next-intl/src/server/resolveLocale.tsx
@@ -76,7 +76,9 @@ export default function resolveLocale(
     }).languages();
     try {
       locale = match(languages, i18n.locales, i18n.defaultLocale);
-    } catch (e) {}
+    } catch (e) {
+      locale = i18n.defaultLocale
+    }
   }
 
   // Prio 5: Use default locale


### PR DESCRIPTION
Any errors thrown by `Intl.getCanonicalLocales` should be catched and the default language should be returned. 
I noticed this because cypress was setting the `accept-language` header to `*`.