### PR TITLE
feat: Next.js 13 RSC caching

### DIFF
--- a/packages/example-next-13-advanced/next.config.js
+++ b/packages/example-next-13-advanced/next.config.js
@@ -1,3 +1,4 @@
+const ms = require('ms');
 const withNextIntl = require('next-intl/plugin')();
 
 module.exports = withNextIntl({
@@ -11,6 +12,28 @@ module.exports = withNextIntl({
       {
         source: '/es/anidada',
         destination: '/es/nested'
+      }
+    ];
+  },
+  headers() {
+    return [
+      {
+        source: '/((?!_next|assets|favicon.ico).*)',
+        missing: [
+          {
+            type: 'header',
+            key: 'Next-Router-Prefetch'
+          }
+        ],
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: [
+              `s-maxage=` + ms('1d') / 1000,
+              `stale-while-revalidate=` + ms('1y') / 1000
+            ].join(', ')
+          }
+        ]
       }
     ];
   }

--- a/packages/example-next-13-advanced/package.json
+++ b/packages/example-next-13-advanced/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
+    "ms": "2.1.3",
     "next": "13.2.0",
     "next-intl": "*",
     "react": "^18.2.0",

--- a/packages/example-next-13-advanced/src/middleware.ts
+++ b/packages/example-next-13-advanced/src/middleware.ts
@@ -1,6 +1,8 @@
+import ms from 'ms';
 import createIntlMiddleware from 'next-intl/middleware';
+import {NextRequest} from 'next/server';
 
-export default createIntlMiddleware({
+const middleware = createIntlMiddleware({
   locales: ['en', 'de', 'es'],
   defaultLocale: 'en',
   domains: [
@@ -14,6 +16,20 @@ export default createIntlMiddleware({
     }
   ]
 });
+
+export default function handler(req: NextRequest) {
+  const response = middleware(req);
+
+  response.headers.set(
+    'Cache-Control',
+    [
+      `s-maxage=` + ms('1d') / 1000,
+      `stale-while-revalidate=` + ms('1y') / 1000
+    ].join(', ')
+  );
+
+  return response;
+}
 
 export const config = {
   // Skip all paths that should not be internationalized

--- a/packages/example-next-13-advanced/src/middleware.ts
+++ b/packages/example-next-13-advanced/src/middleware.ts
@@ -1,8 +1,6 @@
-import ms from 'ms';
 import createIntlMiddleware from 'next-intl/middleware';
-import {NextRequest} from 'next/server';
 
-const middleware = createIntlMiddleware({
+export default createIntlMiddleware({
   locales: ['en', 'de', 'es'],
   defaultLocale: 'en',
   domains: [
@@ -16,20 +14,6 @@ const middleware = createIntlMiddleware({
     }
   ]
 });
-
-export default function handler(req: NextRequest) {
-  const response = middleware(req);
-
-  response.headers.set(
-    'Cache-Control',
-    [
-      `s-maxage=` + ms('1d') / 1000,
-      `stale-while-revalidate=` + ms('1y') / 1000
-    ].join(', ')
-  );
-
-  return response;
-}
 
 export const config = {
   // Skip all paths that should not be internationalized

--- a/packages/example-next-13-advanced/tests/main.spec.ts
+++ b/packages/example-next-13-advanced/tests/main.spec.ts
@@ -421,3 +421,17 @@ it('can localize route handlers', async ({request}) => {
     expect(data).toEqual({message: 'Hallo Welt!'});
   }
 });
+
+it('can use caching headers', async ({request}) => {
+  for (const pathname of [
+    '/',
+    '/en',
+    '/en/nested',
+    '/de',
+    '/de/verschachtelt'
+  ]) {
+    expect((await request.get(pathname)).headers()['cache-control']).toBe(
+      's-maxage=86400, stale-while-revalidate=31557600'
+    );
+  }
+});

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -21,7 +21,7 @@ This beta version was tested with `next@13.2.0`.
 ## Roadmap
 
 - ✅ All APIs from `next-intl` can be used in Server Components.
-- 💡 Currently SSR-only (i.e. no `generateStaticParams`). You can use [CDN caching](https://vercel.com/docs/concepts/edge-network/caching#stale-while-revalidate) via [`headers` in `next.config.js`](https://nextjs.org/docs/api-reference/next.config.js/headers) to to get the same level of performance from SSR'd pages ([learn more](https://youtu.be/bfLFHp7Sbkg?t=490)).
+- 💡 Currently SSR-only (i.e. no `generateStaticParams`), therefore use [CDN caching](#cdn-caching).
 
 For details, see the [pending pull request for Server Components support](https://github.com/amannn/next-intl/pull/149).
 
@@ -371,6 +371,46 @@ import {
   getNow, // like `useNow`
   getTimeZone // like `useTimeZone`
 } from 'next-intl/server';
+```
+
+## CDN caching
+
+Since `next-intl` is currently SSR-only, it's a good idea to use [CDN caching](https://vercel.com/docs/concepts/edge-network/caching#stale-while-revalidate) via [`headers`](https://nextjs.org/docs/api-reference/next.config.js/headers) in `next.config.js` to get the same level of performance from SSR'd pages ([learn more](https://youtu.be/bfLFHp7Sbkg?t=490)).
+
+```js filename="next.config.js"
+const ms = require('ms');
+const withNextIntl = require('next-intl/plugin')();
+
+module.exports = withNextIntl({
+  // ... Other config
+
+  headers() {
+    return [
+      {
+        // Cache all content pages
+        source: '/((?!_next|assets|favicon.ico).*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: [
+              `s-maxage=` + ms('1d') / 1000,
+              `stale-while-revalidate=` + ms('1y') / 1000
+            ].join(', ')
+          }
+        ],
+
+        // If you're deploying on a host that doesn't support the `vary` header (e.g. Vercel),
+        // make sure to disable caching for prefetch requests for Server Components.
+        missing: [
+          {
+            type: 'header',
+            key: 'Next-Router-Prefetch'
+          }
+        ]
+      }
+    ];
+  }
+});
 ```
 
 ## Providing feedback

--- a/yarn.lock
+++ b/yarn.lock
@@ -9431,7 +9431,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.0.0, ms@^2.1.1:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==


### PR DESCRIPTION
Unfortunately [Vercel doesn't support the `vary` header](https://github.com/vercel/vercel/discussions/7612#discussioncomment-2434736) currently which is used by RSC to differentiate prefetch requests, this [breaks page navigation](https://github.com/amannn/street-photography-viewer/pull/2).

Potential solutions:
 - Vercel supports `vary`
 - We can detect prefetch requests in the middleware to not cache those
 - Add caching via `next.config.js` or `vercel.json` and opt-out of prefetch header?