### PR TITLE
feat: Next.js 13 RSC middleware improvements

### DIFF
--- a/packages/example-next-13-advanced/package.json
+++ b/packages/example-next-13-advanced/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "lint": "eslint src && tsc",
     "test": "playwright test",
+    "test:watch": "chokidar 'tests/main.spec.ts' -c 'npm run test'",
     "build": "next build",
     "start": "next start"
   },
@@ -24,6 +25,7 @@
     "@types/lodash": "^4.14.176",
     "@types/node": "^17.0.23",
     "@types/react": "^18.0.23",
+    "chokidar-cli": "3.0.0",
     "eslint": "^8.12.0",
     "eslint-config-molindo": "^6.0.0",
     "eslint-config-next": "^13.0.0"

--- a/packages/example-next-13-advanced/src/middleware.ts
+++ b/packages/example-next-13-advanced/src/middleware.ts
@@ -1,14 +1,8 @@
 import createIntlMiddleware from 'next-intl/middleware';
 
 export default createIntlMiddleware({
-  locales: ['en', 'de', 'es', 'fr'],
-  defaultLocale: 'en',
-  domains: [
-    {
-      domain: 'example.fr',
-      defaultLocale: 'fr'
-    }
-  ]
+  locales: ['en', 'de', 'es'],
+  defaultLocale: 'en'
 });
 
 export const config = {

--- a/packages/example-next-13-advanced/src/middleware.ts
+++ b/packages/example-next-13-advanced/src/middleware.ts
@@ -1,16 +1,12 @@
 import createIntlMiddleware from 'next-intl/middleware';
 
 export default createIntlMiddleware({
-  locales: ['en', 'de', 'es'],
+  locales: ['en', 'de', 'es', 'fr'],
   defaultLocale: 'en',
   domains: [
     {
-      domain: 'example.de',
-      defaultLocale: 'de'
-    },
-    {
-      domain: 'de.example.com',
-      defaultLocale: 'de'
+      domain: 'example.fr',
+      defaultLocale: 'fr'
     }
   ]
 });

--- a/packages/example-next-13-advanced/tests/main.spec.ts
+++ b/packages/example-next-13-advanced/tests/main.spec.ts
@@ -12,12 +12,51 @@ it('handles unknown locales', async ({page}) => {
 it('redirects to a matched locale at the root for non-default locales', async ({
   browser
 }) => {
-  const context = await browser.newContext({locale: 'de'});
+  const context = await browser.newContext({locale: 'es'});
   const page = await context.newPage();
 
   await page.goto('/');
-  await expect(page).toHaveURL('/de');
-  page.getByRole('heading', {name: 'Start'});
+  await expect(page).toHaveURL('/es');
+  page.getByRole('heading', {name: 'Inicio'});
+});
+
+it('redirects to a matched domain for non-default locales at the root', async ({
+  request
+}) => {
+  const response = await request.get('/', {
+    maxRedirects: 0,
+    headers: {
+      'accept-language': 'fr'
+    }
+  });
+  expect(response.status()).toBe(307);
+  expect(response.headers().location).toEqual('http://example.fr:3000/');
+});
+
+it('redirects to a matched domain for non-default locales at a nested pathname', async ({
+  request
+}) => {
+  const response = await request.get('/nested', {
+    maxRedirects: 0,
+    headers: {
+      'accept-language': 'fr'
+    }
+  });
+  expect(response.status()).toBe(307);
+  expect(response.headers().location).toEqual('http://example.fr:3000/nested');
+});
+
+it('redirects to a matched domain for non-default locales at a nested pathname with a prefix', async ({
+  request
+}) => {
+  const response = await request.get('/fr/nested', {
+    maxRedirects: 0,
+    headers: {
+      'accept-language': 'fr'
+    }
+  });
+  expect(response.status()).toBe(307);
+  expect(response.headers().location).toEqual('http://example.fr:3000/nested');
 });
 
 it('can redirect a more specific locale to a more generic one', async ({
@@ -346,9 +385,9 @@ it('sets alternate links', async ({request}) => {
     expect((await request.get(pathname)).headers().link).toBe(
       [
         '<http://localhost:3000/en>; rel="alternate"; hreflang="en"',
-        '<http://example.de:3000/>; rel="alternate"; hreflang="de"',
-        '<http://de.example.com:3000/>; rel="alternate"; hreflang="de"',
+        '<http://localhost:3000/de>; rel="alternate"; hreflang="de"',
         '<http://localhost:3000/es>; rel="alternate"; hreflang="es"',
+        '<http://example.fr:3000/>; rel="alternate"; hreflang="fr"',
         '<http://localhost:3000/>; rel="alternate"; hreflang="x-default"'
       ].join(', ')
     );
@@ -358,9 +397,9 @@ it('sets alternate links', async ({request}) => {
     expect((await request.get(pathname)).headers().link).toBe(
       [
         '<http://localhost:3000/en/nested>; rel="alternate"; hreflang="en"',
-        '<http://example.de:3000/nested>; rel="alternate"; hreflang="de"',
-        '<http://de.example.com:3000/nested>; rel="alternate"; hreflang="de"',
+        '<http://localhost:3000/de/nested>; rel="alternate"; hreflang="de"',
         '<http://localhost:3000/es/nested>; rel="alternate"; hreflang="es"',
+        '<http://example.fr:3000/nested>; rel="alternate"; hreflang="fr"',
         '<http://localhost:3000/nested>; rel="alternate"; hreflang="x-default"'
       ].join(', ')
     );

--- a/packages/example-next-13/next-env.d.ts
+++ b/packages/example-next-13/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/next-intl/plugin.js
+++ b/packages/next-intl/plugin.js
@@ -39,6 +39,12 @@ module.exports = withNextIntl({
     }
   }
 
+  if ('i18n' in nextConfig) {
+    console.warn(
+      "\nnext-intl has found an `i18n` config in your next.config.js. This likely causes conflicts and should therefore be removed if you use the React Server Components integration.\n\nIf you're in progress of migrating from the `pages` folder, you can refer to this example: https://github.com/amannn/next-intl/tree/feat/next-13-rsc/packages/example-next-13-with-pages\n"
+    );
+  }
+
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       config.resolve.alias['next-intl/config'] = require.resolve(i18nPath);

--- a/packages/next-intl/src/client/usePathname.tsx
+++ b/packages/next-intl/src/client/usePathname.tsx
@@ -12,14 +12,18 @@ export function unlocalizePathname(pathname: string) {
 /**
  * Returns the pathname without a potential locale prefix.
  *
- * Note that on the server side `null` is returned, only on
- * the client side the correct pathname will be returned.
- *
  * This can be helpful e.g. to implement navigation links,
  * where the active link is highlighted.
+ *
+ * Note that on the server side `null` is returned, only on
+ * the client side the correct pathname will be returned.
  */
 export default function usePathname() {
   const pathname = useNextPathname();
+
+  // TODO: Once `useParams` is a thing, we can set this on the initial render.
+  // The `pathname` can either be prefixed with a locale or not, since we don't
+  // know the matched locale during SSR, we can't safely remove the prefix.
   const [unlocalizedPathname, setUnlocalizedPathname] = useState<string | null>(
     null
   );

--- a/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
+++ b/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
@@ -3,7 +3,7 @@ export type RoutingConfigPrefix = {
 
   /** The default locale can be used without a prefix (e.g. `/about`). If you prefer to have a prefix for the default locale as well (e.g. `/en/about`), you can switch this option to `always`.
    */
-  prefix?: 'as-necessary' | 'always';
+  prefix?: 'as-needed' | 'always';
 };
 
 export type DomainConfig = {

--- a/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
+++ b/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
@@ -1,15 +1,44 @@
+export type RoutingConfigPrefix = {
+  type: 'prefix';
+
+  /** The default locale can be used without a prefix (e.g. `/about`). If you prefer to have a prefix for the default locale as well (e.g. `/en/about`), you can switch this option to `always`.
+   */
+  prefix?: 'as-necessary' | 'always';
+};
+
+export type DomainConfig = {
+  /** The domain name (e.g. "example.de" or "de.example.com"). */
+  domain: string;
+
+  locale: string;
+};
+
+export type RoutingConfigDomain = {
+  type: 'domain';
+
+  /** Provide a list of mappings between domains and locales. Note that the `x-forwarded-host` or alternatively the `host` header will be used to determine the requested domain. */
+  domains: Array<{domain: string; locale: string}>;
+};
+
 type NextIntlMiddlewareConfig = {
   /** A list of all locales that are supported. */
   locales: Array<string>;
 
-  /* If this locale is matched, pathnames work without a prefix (e.g. `/about`) */
+  /* Used by default if none of the defined locales match. */
   defaultLocale: string;
-
-  /** Configure a list of domains where the `defaultLocale` is changed (e.g. `es.example.com/about`, `example.fr/about`). Note that the `x-forwarded-host` or alternatively the `host` header will be used to determine the requested domain. */
-  domains?: Array<{domain: string; defaultLocale: string}>;
 
   /** Sets the `Link` response header to notify search engines about content in other languages (defaults to `true`). See https://developers.google.com/search/docs/specialty/international/localized-versions#http */
   alternateLinks?: boolean;
+
+  /** @deprecated Deprecated in favour of `routing`. */
+  domains?: Array<{domain: string; defaultLocale: string}>;
+
+  routing?: RoutingConfigPrefix | RoutingConfigDomain;
+};
+
+export type NextIntlMiddlewareConfigWithDefaults = NextIntlMiddlewareConfig & {
+  alternateLinks: boolean;
+  routing: RoutingConfigPrefix | RoutingConfigDomain;
 };
 
 export default NextIntlMiddlewareConfig;

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -1,16 +1,68 @@
 import {NextRequest, NextResponse} from 'next/server';
 import {COOKIE_LOCALE_NAME, HEADER_LOCALE_NAME} from '../shared/constants';
-import NextIntlMiddlewareConfig from './NextIntlMiddlewareConfig';
+import NextIntlMiddlewareConfig, {
+  NextIntlMiddlewareConfigWithDefaults
+} from './NextIntlMiddlewareConfig';
 import getAlternateLinksHeaderValue from './getAlternateLinksHeaderValue';
-import getHost from './getHost';
 import resolveLocale from './resolveLocale';
 
 const ROOT_URL = '/';
 
+function receiveConfig(
+  config: NextIntlMiddlewareConfig
+): NextIntlMiddlewareConfigWithDefaults {
+  const result = {
+    ...config,
+    alternateLinks: config.alternateLinks ?? true
+  };
+
+  if (!result.routing) {
+    result.routing = {
+      type: 'prefix'
+    };
+  }
+
+  if (result.routing.type === 'prefix') {
+    result.routing.prefix = result.routing.prefix ?? 'as-necessary';
+  }
+
+  return result as NextIntlMiddlewareConfigWithDefaults;
+}
+
 export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
+  // TODO: Remove before stable release
+  if (config.domains != null) {
+    console.error(
+      'The `domains` option is deprecated. Please use `routing` instead.'
+    );
+    config = {
+      ...config,
+      routing: {
+        type: 'domain',
+        domains: config.domains.map((cur) => ({
+          domain: cur.domain,
+          locale: cur.defaultLocale
+        }))
+      }
+    };
+    delete config.domains;
+  }
+
+  const configWithDefaults = receiveConfig(config);
+
+  if (configWithDefaults.routing.type === 'domain') {
+    const {domains} = configWithDefaults.routing;
+    const hasMatchingDomainForEveryLocale = configWithDefaults.locales.every(
+      (locale) => domains.find((cur) => cur.locale === locale) != null
+    );
+    if (!hasMatchingDomainForEveryLocale) {
+      throw new Error('Every locale must have a matching domain');
+    }
+  }
+
   return function middleware(request: NextRequest) {
     const {domain, locale} = resolveLocale(
-      config,
+      configWithDefaults,
       request.headers,
       request.cookies,
       request.nextUrl.pathname
@@ -20,11 +72,14 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
     const hasOutdatedCookie =
       request.cookies.get(COOKIE_LOCALE_NAME)?.value !== locale;
     const hasMatchedDefaultLocale = domain
-      ? domain.defaultLocale === locale
-      : locale === config.defaultLocale;
-    const domainConfig = config.domains?.find(
-      (cur) => cur.defaultLocale === locale
-    );
+      ? domain.locale === locale
+      : locale === configWithDefaults.defaultLocale;
+    const domainConfigs =
+      configWithDefaults.routing.type === 'domain'
+        ? configWithDefaults.routing.domains.filter(
+            (cur) => cur.locale === locale
+          ) ?? []
+        : [];
 
     function getResponseInit() {
       let responseInit;
@@ -51,11 +106,17 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
       return NextResponse.next(getResponseInit());
     }
 
-    function redirect(url: string) {
+    function redirect(url: string, host?: string) {
       const urlObj = new URL(url, request.url);
-      if (domainConfig) {
+
+      if (domainConfigs.length > 0) {
         urlObj.pathname = url.replace(`/${locale}`, '');
-        urlObj.host = domainConfig.domain;
+        if (domainConfigs[0].domain && !host) {
+          host = domainConfigs[0].domain;
+        }
+      }
+      if (host) {
+        urlObj.host = host;
       }
 
       return NextResponse.redirect(urlObj.toString());
@@ -68,13 +129,18 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
         pathWithSearch += request.nextUrl.search;
       }
 
-      if (hasMatchedDefaultLocale) {
+      if (
+        hasMatchedDefaultLocale &&
+        ((configWithDefaults.routing.type === 'prefix' &&
+          configWithDefaults.routing.prefix === 'as-necessary') ||
+          configWithDefaults.routing.type === 'domain')
+      ) {
         response = rewrite(pathWithSearch);
       } else {
         response = redirect(pathWithSearch);
       }
     } else {
-      const pathLocale = config.locales.find((cur) =>
+      const pathLocale = configWithDefaults.locales.find((cur) =>
         request.nextUrl.pathname.startsWith(`/${cur}`)
       );
       const hasLocalePrefix = pathLocale != null;
@@ -85,21 +151,35 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
       }
 
       if (hasLocalePrefix) {
-        if (pathLocale === locale) {
-          if (
-            domainConfig &&
-            getHost(request.headers) !== domainConfig.domain
-          ) {
-            response = redirect(pathWithSearch);
-          } else {
-            response = next();
-          }
+        const basePath = pathWithSearch.replace(`/${pathLocale}`, '') || '/';
+
+        if (configWithDefaults.routing.type === 'domain') {
+          const pathDomain = configWithDefaults.routing.domains.find(
+            (cur) => pathLocale === cur.locale
+          );
+
+          response = redirect(basePath, pathDomain?.domain);
         } else {
-          const basePath = pathWithSearch.replace(`/${pathLocale}`, '');
-          response = redirect(`/${locale}${basePath}`);
+          if (pathLocale === locale) {
+            if (
+              hasMatchedDefaultLocale &&
+              configWithDefaults.routing.prefix === 'as-necessary'
+            ) {
+              response = redirect(basePath);
+            } else {
+              response = next();
+            }
+          } else {
+            response = redirect(`/${locale}${basePath}`);
+          }
         }
       } else {
-        if (hasMatchedDefaultLocale) {
+        if (
+          hasMatchedDefaultLocale &&
+          ((configWithDefaults.routing.type === 'prefix' &&
+            configWithDefaults.routing.prefix === 'as-necessary') ||
+            configWithDefaults.routing.type === 'domain')
+        ) {
           response = rewrite(`/${locale}${pathWithSearch}`);
         } else {
           response = redirect(`/${locale}${pathWithSearch}`);
@@ -111,10 +191,13 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
       response.cookies.set(COOKIE_LOCALE_NAME, locale);
     }
 
-    if ((config.alternateLinks ?? true) && config.locales.length > 1) {
+    if (
+      configWithDefaults.alternateLinks &&
+      configWithDefaults.locales.length > 1
+    ) {
       response.headers.set(
         'Link',
-        getAlternateLinksHeaderValue(config, request)
+        getAlternateLinksHeaderValue(configWithDefaults, request)
       );
     }
 

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -23,7 +23,7 @@ function receiveConfig(
   }
 
   if (result.routing.type === 'prefix') {
-    result.routing.prefix = result.routing.prefix ?? 'as-necessary';
+    result.routing.prefix = result.routing.prefix ?? 'as-needed';
   }
 
   return result as NextIntlMiddlewareConfigWithDefaults;
@@ -132,7 +132,7 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
       if (
         hasMatchedDefaultLocale &&
         ((configWithDefaults.routing.type === 'prefix' &&
-          configWithDefaults.routing.prefix === 'as-necessary') ||
+          configWithDefaults.routing.prefix === 'as-needed') ||
           configWithDefaults.routing.type === 'domain')
       ) {
         response = rewrite(pathWithSearch);
@@ -163,7 +163,7 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
           if (pathLocale === locale) {
             if (
               hasMatchedDefaultLocale &&
-              configWithDefaults.routing.prefix === 'as-necessary'
+              configWithDefaults.routing.prefix === 'as-needed'
             ) {
               response = redirect(basePath);
             } else {
@@ -177,7 +177,7 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
         if (
           hasMatchedDefaultLocale &&
           ((configWithDefaults.routing.type === 'prefix' &&
-            configWithDefaults.routing.prefix === 'as-necessary') ||
+            configWithDefaults.routing.prefix === 'as-needed') ||
             configWithDefaults.routing.type === 'domain')
         ) {
           response = rewrite(`/${locale}${pathWithSearch}`);

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -6,14 +6,14 @@ function getRequest(url = 'https://example.com/') {
   return {url} as NextRequest;
 }
 
-it('works for type prefix (as-necessary)', () => {
+it('works for type prefix (as-needed)', () => {
   const config: NextIntlMiddlewareConfigWithDefaults = {
     defaultLocale: 'en',
     locales: ['en', 'es'],
     alternateLinks: true,
     routing: {
       type: 'prefix',
-      prefix: 'as-necessary'
+      prefix: 'as-needed'
     }
   };
 

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -1,0 +1,128 @@
+import {NextRequest} from 'next/server';
+import getAlternateLinksHeaderValue from '../../src/middleware/getAlternateLinksHeaderValue';
+
+function getRequest(url = 'https://example.com/') {
+  return {url} as NextRequest;
+}
+
+it('works for multiple locales', () => {
+  const config = {
+    defaultLocale: 'en',
+    locales: ['en', 'es']
+  };
+
+  expect(getAlternateLinksHeaderValue(config, getRequest())).toEqual(
+    [
+      '<https://example.com/en>; rel="alternate"; hreflang="en"',
+      '<https://example.com/es>; rel="alternate"; hreflang="es"',
+      '<https://example.com/>; rel="alternate"; hreflang="x-default"'
+    ].join(', ')
+  );
+
+  expect(
+    getAlternateLinksHeaderValue(
+      config,
+      getRequest('https://example.com/about')
+    )
+  ).toEqual(
+    [
+      '<https://example.com/en/about>; rel="alternate"; hreflang="en"',
+      '<https://example.com/es/about>; rel="alternate"; hreflang="es"',
+      '<https://example.com/about>; rel="alternate"; hreflang="x-default"'
+    ].join(', ')
+  );
+});
+
+it('uses domains', () => {
+  const config = {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+    domains: [
+      {
+        domain: 'example.com',
+        defaultLocale: 'en'
+      },
+      {
+        domain: 'example.es',
+        defaultLocale: 'es'
+      }
+    ]
+  };
+
+  expect(getAlternateLinksHeaderValue(config, getRequest())).toEqual(
+    [
+      '<https://example.com/>; rel="alternate"; hreflang="en"',
+      '<https://example.es/>; rel="alternate"; hreflang="es"',
+      '<https://example.com/>; rel="alternate"; hreflang="x-default"'
+    ].join(', ')
+  );
+
+  expect(
+    getAlternateLinksHeaderValue(config, getRequest('https://example.es/'))
+  ).toEqual(
+    [
+      '<https://example.com/>; rel="alternate"; hreflang="en"',
+      '<https://example.es/>; rel="alternate"; hreflang="es"',
+      '<https://example.com/>; rel="alternate"; hreflang="x-default"'
+    ].join(', ')
+  );
+
+  expect(
+    getAlternateLinksHeaderValue(
+      config,
+      getRequest('https://example.com/about')
+    )
+  ).toEqual(
+    [
+      '<https://example.com/about>; rel="alternate"; hreflang="en"',
+      '<https://example.es/about>; rel="alternate"; hreflang="es"',
+      '<https://example.com/about>; rel="alternate"; hreflang="x-default"'
+    ].join(', ')
+  );
+});
+
+it('uses mixed domains', () => {
+  const config = {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+    domains: [
+      {
+        domain: 'example.es',
+        defaultLocale: 'es'
+      }
+    ]
+  };
+
+  expect(getAlternateLinksHeaderValue(config, getRequest())).toEqual(
+    [
+      '<https://example.com/en>; rel="alternate"; hreflang="en"',
+      '<https://example.es/>; rel="alternate"; hreflang="es"',
+      '<https://example.com/>; rel="alternate"; hreflang="x-default"'
+    ].join(', ')
+  );
+
+  expect(
+    getAlternateLinksHeaderValue(
+      config,
+      getRequest('https://example.com/about')
+    )
+  ).toEqual(
+    [
+      '<https://example.com/en/about>; rel="alternate"; hreflang="en"',
+      '<https://example.es/about>; rel="alternate"; hreflang="es"',
+      '<https://example.com/about>; rel="alternate"; hreflang="x-default"'
+    ].join(', ')
+  );
+
+  expect(
+    getAlternateLinksHeaderValue(config, {
+      url: 'https://example.es/'
+    } as NextRequest)
+  ).toEqual(
+    [
+      '<https://example.es/en>; rel="alternate"; hreflang="en"',
+      '<https://example.es/>; rel="alternate"; hreflang="es"',
+      '<https://example.es/>; rel="alternate"; hreflang="x-default"'
+    ].join(', ')
+  );
+});

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -201,7 +201,7 @@ describe('type: domain', () => {
     );
   });
 
-  it.only('serves requests for matching locales at unknown hosts', () => {
+  it('serves requests for matching locales at unknown hosts', () => {
     middleware(createMockRequest('/', 'en', 'http://localhost:3000'));
     expect(MockedNextResponse.next).not.toHaveBeenCalled();
     expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
@@ -220,7 +220,7 @@ describe('type: domain', () => {
       );
     });
 
-    it('redirects for for sub paths when the locale matches', () => {
+    it('redirects for sub paths when the locale matches', () => {
       middleware(createMockRequest('/en/about', 'en', 'http://en.example.com'));
       expect(MockedNextResponse.next).not.toHaveBeenCalled();
       expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
@@ -238,7 +238,7 @@ describe('type: domain', () => {
       );
     });
 
-    it("redirects for for sub paths when the locale doesn't match", () => {
+    it("redirects for sub paths when the locale doesn't match", () => {
       middleware(createMockRequest('/de/about', 'de', 'http://en.example.com'));
       expect(MockedNextResponse.next).not.toHaveBeenCalled();
       expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -1,0 +1,293 @@
+import {RequestCookies} from 'next/dist/compiled/@edge-runtime/cookies';
+import {NextRequest, NextResponse} from 'next/server';
+import createIntlMiddleware from '../../src/middleware';
+
+(global as any).Request = class Request {};
+
+type MockResponse = NextResponse & {
+  args: Array<any>;
+};
+
+jest.mock('next/server', () => {
+  const response = {
+    headers: new Headers(),
+    cookies: new RequestCookies(new Headers())
+  };
+  return {
+    NextResponse: {
+      next: jest.fn((...args) => ({...response, args})),
+      rewrite: jest.fn((...args) => ({...response, args})),
+      redirect: jest.fn((...args) => ({...response, args}))
+    }
+  };
+});
+
+function createMockRequest(
+  pathname = '/',
+  locale: 'en' | 'de' = 'en',
+  host = 'http://localhost:3000'
+) {
+  const headers = new Headers({
+    'accept-language':
+      locale === 'en' ? 'en-US,en;q=0.9,de;q=0.8' : 'de-DE,de;q=0.9,en;q=0.8',
+    host: new URL(host).host
+  });
+
+  return {
+    headers,
+    cookies: new RequestCookies(headers),
+    url: host + pathname,
+    nextUrl: {
+      pathname,
+      search: ''
+    }
+  } as NextRequest;
+}
+
+const MockedNextResponse = NextResponse as unknown as {
+  next: jest.Mock<typeof NextResponse>;
+  rewrite: jest.Mock<typeof NextResponse>;
+  redirect: jest.Mock<typeof NextResponse>;
+};
+
+beforeEach(() => {
+  MockedNextResponse.next.mockClear();
+  MockedNextResponse.rewrite.mockClear();
+  MockedNextResponse.redirect.mockClear();
+});
+
+describe('type: prefix', () => {
+  describe('prefix: as-necessary', () => {
+    const middleware = createIntlMiddleware({
+      defaultLocale: 'en',
+      locales: ['en', 'de']
+    }) as (request: NextRequest) => MockResponse;
+
+    it('rewrites requests for the default locale', () => {
+      middleware(createMockRequest('/'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/en'
+      );
+    });
+
+    it('redirects requests for the default locale when prefixed at the root', () => {
+      middleware(createMockRequest('/en'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/'
+      );
+    });
+
+    it('redirects requests for the default locale when prefixed at sub paths', () => {
+      middleware(createMockRequest('/en/about'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/about'
+      );
+    });
+
+    it('redirects requests for other locales', () => {
+      middleware(createMockRequest('/', 'de'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/de'
+      );
+    });
+
+    it('sets a cookie', () => {
+      const response = middleware(createMockRequest('/'));
+      expect(response.cookies.get('NEXT_LOCALE')).toEqual({
+        name: 'NEXT_LOCALE',
+        value: 'en'
+      });
+    });
+  });
+
+  describe('prefix: always', () => {
+    const middleware = createIntlMiddleware({
+      defaultLocale: 'en',
+      locales: ['en', 'de'],
+      routing: {
+        type: 'prefix',
+        prefix: 'always'
+      }
+    }) as (request: NextRequest) => MockResponse;
+
+    it('redirects non-prefixed requests for the default locale', () => {
+      middleware(createMockRequest('/'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/en'
+      );
+    });
+
+    it('redirects requests for other locales', () => {
+      middleware(createMockRequest('/', 'de'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/de'
+      );
+    });
+
+    it('serves requests for the default locale', () => {
+      middleware(createMockRequest('/en'));
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+      expect(MockedNextResponse.next).toHaveBeenCalled();
+    });
+
+    it('serves requests for non-default locales', () => {
+      middleware(createMockRequest('/de'));
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+      expect(MockedNextResponse.next).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('type: domain', () => {
+  const middleware = createIntlMiddleware({
+    defaultLocale: 'en',
+    locales: ['en', 'de'],
+    routing: {
+      type: 'domain',
+      domains: [
+        {locale: 'en', domain: 'en.example.com'},
+        {locale: 'de', domain: 'de.example.com'}
+      ]
+    }
+  }) as (request: NextRequest) => MockResponse;
+
+  it('serves requests for matching locales at the root', () => {
+    middleware(createMockRequest('/', 'en', 'http://en.example.com'));
+    expect(MockedNextResponse.next).not.toHaveBeenCalled();
+    expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+    expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+      'http://en.example.com/en'
+    );
+  });
+
+  it('serves requests for matching locales at nested paths', () => {
+    middleware(createMockRequest('/about', 'en', 'http://en.example.com'));
+    expect(MockedNextResponse.next).not.toHaveBeenCalled();
+    expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+    expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+      'http://en.example.com/en/about'
+    );
+  });
+
+  it('serves requests for not matching locales at the root', () => {
+    middleware(createMockRequest('/', 'de', 'http://en.example.com'));
+    expect(MockedNextResponse.next).not.toHaveBeenCalled();
+    expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+    expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+      'http://en.example.com/en'
+    );
+  });
+
+  it('serves requests for not matching locales at nested paths', () => {
+    middleware(createMockRequest('/about', 'de', 'http://en.example.com'));
+    expect(MockedNextResponse.next).not.toHaveBeenCalled();
+    expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+    expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+      'http://en.example.com/en/about'
+    );
+  });
+
+  it.only('serves requests for matching locales at unknown hosts', () => {
+    middleware(createMockRequest('/', 'en', 'http://localhost:3000'));
+    expect(MockedNextResponse.next).not.toHaveBeenCalled();
+    expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+    expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+      'http://localhost:3000/en'
+    );
+  });
+
+  describe('redirects for locale prefixes', () => {
+    it('redirects for the locale root when the locale matches', () => {
+      middleware(createMockRequest('/en/about', 'en', 'http://en.example.com'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://en.example.com/about'
+      );
+    });
+
+    it('redirects for for sub paths when the locale matches', () => {
+      middleware(createMockRequest('/en/about', 'en', 'http://en.example.com'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://en.example.com/about'
+      );
+    });
+
+    it("redirects for the locale root when the locale doesn't match", () => {
+      middleware(createMockRequest('/de/about', 'de', 'http://en.example.com'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://de.example.com/about'
+      );
+    });
+
+    it("redirects for for sub paths when the locale doesn't match", () => {
+      middleware(createMockRequest('/de/about', 'de', 'http://en.example.com'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://de.example.com/about'
+      );
+    });
+  });
+});
+
+describe('deprecated domain config', () => {
+  const middleware = createIntlMiddleware({
+    defaultLocale: 'en',
+    locales: ['en', 'de'],
+    domains: [
+      {
+        defaultLocale: 'en',
+        domain: 'en.example.com'
+      },
+      {
+        defaultLocale: 'de',
+        domain: 'de.example.com'
+      }
+    ]
+  }) as (request: NextRequest) => MockResponse;
+
+  it('accepts deprecated config', () => {
+    middleware(createMockRequest('/', 'en', 'http://en.example.com'));
+    middleware(createMockRequest('/about', 'en', 'http://en.example.com'));
+
+    expect(MockedNextResponse.next).not.toHaveBeenCalled();
+    expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+
+    expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+      'http://en.example.com/en'
+    );
+    expect(MockedNextResponse.rewrite.mock.calls[1][0].toString()).toBe(
+      'http://en.example.com/en/about'
+    );
+
+    middleware(createMockRequest('/en/about', 'en', 'http://en.example.com'));
+    expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+      'http://en.example.com/about'
+    );
+
+    middleware(createMockRequest('/de/help', 'de', 'http://en.example.com'));
+
+    expect(MockedNextResponse.redirect.mock.calls[1][0].toString()).toBe(
+      'http://de.example.com/help'
+    );
+  });
+});

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -57,7 +57,7 @@ beforeEach(() => {
 });
 
 describe('type: prefix', () => {
-  describe('prefix: as-necessary', () => {
+  describe('prefix: as-needed', () => {
     const middleware = createIntlMiddleware({
       defaultLocale: 'en',
       locales: ['en', 'de']

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -280,9 +280,28 @@ The middleware handles redirects and rewrites based on the detected user locale.
 
 ### Routing with a locale prefix (default)
 
-By default, `next-intl` will map the incoming requests to your defined routes (e.g. `/de/about` matches `[locale]/about/page.tsx`). To keep the URL short, requests for the default locale are rewritten internally to work without a locale prefix (e.g. `/about` matches `[locale]/about/page.tsx` too).
+By default, `next-intl` will map the incoming requests to your defined routes. To keep the URL short, requests for the default locale are rewritten internally to work without a locale prefix.
 
-When the user visits a route without an explicit locale, `next-intl` matches the [`accept-language` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) of the request against the available locales and optionally redirects the user to a prefixed route. Note that a previously matched locale is saved in a cookie for subsequent requests.
+**Examples:**
+
+- `/` → `/en`
+- `/about` → `/en/about`
+- `/de/about` → `/de/about`
+
+When the user visits a route without an explicit locale, `next-intl` matches the [`accept-language` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) of the request against the available locales and optionally redirects the user to a prefixed route. Note that a matched locale is saved in a cookie for subsequent requests.
+
+#### Changing locales
+
+To change the locale, the user can visit a prefixed route. This will always take precedence over a previously matched locale that is saved in a cookie or the `accept-language` header.
+
+**Example:**
+
+1. The user requests `/` and based on the `accept-language` header, the `de` locale is matched.
+2. The `de` locale is saved in the cookie and the user is redirected to `/de`.
+3. The app renders `<Link locale="en" href="/">Switch to English</Link>` to allow the user to change the locale to `en`.
+4. When the user clicks on the link, the middleware will update the cookie to `en` and will redirect the user to `/`. The user will now be served content in `en`.
+
+#### Alwyays use a locale prefix
 
 If you want to include a prefix for the default locale as well, you can configure the middleware accordingly.
 
@@ -299,6 +318,8 @@ export default createIntlMiddleware({
   }
 });
 ```
+
+In this case requests without a prefix will be redirected accordingly (e.g. `/about` to `/en/about`).
 
 ### Routing with domains
 
@@ -327,13 +348,24 @@ export default createIntlMiddleware({
 });
 ```
 
-In this case, your content will be available without a locale prefix based on the domain since `next-intl` rewrites the request internally (e.g. `de.example.com/about` matches `[locales]/about/page.tsx`).
+In this case, your content will be available without a locale prefix based on the domain since `next-intl` rewrites the request internally (e.g. `de.example.com/about` → `/de/about`).
 
 The domain that is needed to match the locale is read from the `x-forwarded-host` header, with a fallback to the `host` header. If no domain matches (e.g. on localhost), the `defaultLocale` is used.
 
+#### Changing locales
+
+Since the middleware is aware of all your domains, `next-intl` will automatically switch the domain when the user requests to change the locale.
+
+**Example:**
+
+1. The user is on `en.example.com`.
+2. The app renders `<Link locale="de" href="/">Switch to German</Link>` to allow the user to change the locale to `de`.
+3. When the link is clicked, a request to `en.example.com/de` is initiated.
+4. The middleware recognizes that the user wants to switch to another domain and responds with a redirect to `de.example.com`.
+
 ### Alternate links
 
-`next-intl` automatically sets [the `link` header](https://developers.google.com/search/docs/specialty/international/localized-versions#http) to inform search engines that your content is available in different languages.
+`next-intl` automatically sets [the `link` header](https://developers.google.com/search/docs/specialty/international/localized-versions#http) to inform search engines that your content is available in different languages. Note that this automatically integrates with your routing strategy, wether it's `prefix` or `domain`.
 
 If you prefer to include these links yourself, you can opt-out of this behaviour.
 
@@ -404,7 +436,7 @@ import {
 
 ## CDN caching
 
-Since `next-intl` is currently SSR-only, it's a good idea to use [CDN caching](https://vercel.com/docs/concepts/edge-network/caching#stale-while-revalidate) via [`headers`](https://nextjs.org/docs/api-reference/next.config.js/headers) in `next.config.js` to get the same level of performance from SSR'd pages ([learn more](https://youtu.be/bfLFHp7Sbkg?t=490)).
+Since `next-intl` is currently SSR-only, it's a good idea to use [CDN caching](https://vercel.com/docs/concepts/edge-network/caching#stale-while-revalidate) via [`headers`](https://nextjs.org/docs/api-reference/next.config.js/headers) in `next.config.js` to get the same level of performance from SSR'd pages as you'd get from SSG ([learn more](https://youtu.be/bfLFHp7Sbkg?t=490)).
 
 ```js filename="next.config.js"
 const ms = require('ms');

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -295,7 +295,7 @@ export default createIntlMiddleware({
 
   routing: {
     type: 'prefix',
-    prefix: 'always' // Default: 'as-needed'
+    prefix: 'always' // Defaults to 'as-needed'
   }
 });
 ```

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -52,7 +52,7 @@ If you haven't done so already, [create a Next.js 13 app that uses the `app` dir
 
 Messages can be provided locally or loaded from a remote data source (e.g. a translation management system). Use whatever suits your workflow best.
 
-The simplest option is to create JSON files locally based on [locales](<https://en.wikipedia.org/wiki/Locale_(computer_software)>).
+The simplest option is to create JSON files locally based on locales, e.g. `en.json`.
 
 ```json filename="messages/en.json"
 {
@@ -276,49 +276,77 @@ export default getRequestConfig(async ({locale}) => ({
 
 ## Middleware configuration
 
-The middleware handles rewrites and redirects based on the detected user locale.
+The middleware handles redirects and rewrites based on the detected user locale.
+
+### Routing with a locale prefix (default)
+
+By default, `next-intl` will map the incoming requests to your defined routes (e.g. `/de/about` matches `[locale]/about/page.tsx`). To keep the URL short, requests for the default locale are rewritten internally to work without a locale prefix (e.g. `/about` matches `[locale]/about/page.tsx` too).
+
+When the user visits a route without an explicit locale, `next-intl` matches the [`accept-language` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) of the request against the available locales and optionally redirects the user to a prefixed route. Note that a previously matched locale is saved in a cookie for subsequent requests.
+
+If you want to include a prefix for the default locale as well, you can configure the middleware accordingly.
+
+```tsx {7-10}
+import createIntlMiddleware from 'next-intl/middleware';
+
+export default createIntlMiddleware({
+  locales: ['en', 'de'],
+  defaultLocale: 'en',
+
+  routing: {
+    type: 'prefix',
+    prefix: 'always' // Default: 'as-needed'
+  }
+});
+```
+
+### Routing with domains
+
+If you want to serve your localized content based on separate domains, you can provide a list of mappings between domains and locales to the middleware.
+
+```tsx {7-19}
+import createIntlMiddleware from 'next-intl/middleware';
+
+export default createIntlMiddleware({
+  locales: ['en', 'de'],
+  defaultLocale: 'en',
+
+  routing: {
+    type: 'domain',
+    domains: [
+      {
+        domain: 'en.example.com',
+        locale: 'en'
+      },
+      {
+        domain: 'de.example.com',
+        locale: 'de'
+      }
+    ]
+  }
+});
+```
+
+In this case, your content will be available without a locale prefix based on the domain since `next-intl` rewrites the request internally (e.g. `de.example.com/about` matches `[locales]/about/page.tsx`).
+
+The domain that is needed to match the loacle is read from the `x-forwarded-host` header, with a fallback to the `host` header.
+
+### Alternate links
+
+`next-intl` automatically sets [the `link` header](https://developers.google.com/search/docs/specialty/international/localized-versions#http) to inform search engines that your content is available in different languages.
+
+If you prefer to include these links yourself, you can opt-out of this behaviour.
 
 ```tsx filename="middleware.ts"
 import createIntlMiddleware from 'next-intl/middleware';
 
 export default createIntlMiddleware({
-  // A list of all locales that are supported
-  locales: ['en', 'de'],
+  // ... other config
 
-  // If no locale matches, this will be used by default
-  defaultLocale: 'en',
-
-  // Optionally configure a list of domains where the `defaultLocale` is changed.
-  // When a locale has a matching domain, this is preferred to a locale prefix.
-  domains: [
-    {
-      domain: 'example.de',
-      defaultLocale: 'de'
-    }
-  ],
-
-  // Sets the `Link` response header to notify search engines about
-  // links to the content in other languages (defaults to `true`).
-  alternateLinks: true
+  // Default: `true`
+  alternateLinks: false
 });
-
-export const config = {
-  // Skip all paths that aren't pages that you'd like to internationalize.
-  // If you use the `public` folder, make sure your static assets are ignored
-  // (e.g. by moving them to a shared folder that is referenced here).
-  matcher: ['/((?!api|_next|favicon.ico|assets).*)']
-};
 ```
-
-The locale is matched based on this priority order:
-
-1. **Locale prefix**: The pathname is prefixed with a configured locale (e.g. `/en`).
-2. **Domain**: The host of the requested URL matches against an item in the `domains` list. The host is read from the `x-forwarded-host` or alternatively the `host` header.
-3. **Cookie**: There's an existing cookie that contains the locale that was matched from a previous request.
-4. **`accept-language` header**: The available `locales` are matched against the [`accept-language` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language).
-5. **Default fallback**: If nothing else matches, then the `defaultLocale` is used.
-
-If the default locale matches, the request will be **rewritten** to the corresponding sub path (e.g. `/about` to `/en/about`). If a non-default locale is matched, then the user is **redirected** either to the respective sub path (e.g. `/` to `/de`) or a `domain` (e.g. `/about` to `example.de/about`).
 
 ## Localizing pathnames
 
@@ -342,7 +370,7 @@ module.exports = withNextIntl({
 
 Since `next-intl` isn't aware of the rewrites you've configured, you likely want to make some adjustments:
 
-1. Turn off the `alternateLinks` option in [the middleware](#middleware-configuration) and provide [search engine hints about localized versions of your content](https://developers.google.com/search/docs/specialty/international/localized-versions) by yourself.
+1. Turn off [the `alternateLinks` option](#alternate-links) in the middleware and provide [search engine hints about localized versions of your content](https://developers.google.com/search/docs/specialty/international/localized-versions) by yourself.
 2. Translate the pathnames you're passing to the [routing APIs from `next-intl`](#routing) ([example](https://github.com/amannn/next-intl/blob/feat/next-13-rsc/packages/example-next-13-advanced/src/components/Navigation.tsx)).
 
 ## Using internationalization outside of components

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -329,7 +329,7 @@ export default createIntlMiddleware({
 
 In this case, your content will be available without a locale prefix based on the domain since `next-intl` rewrites the request internally (e.g. `de.example.com/about` matches `[locales]/about/page.tsx`).
 
-The domain that is needed to match the loacle is read from the `x-forwarded-host` header, with a fallback to the `host` header.
+The domain that is needed to match the loacle is read from the `x-forwarded-host` header, with a fallback to the `host` header. If no domain matches (e.g. on localhost), the `defaultLocale` is used.
 
 ### Alternate links
 

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -329,7 +329,7 @@ export default createIntlMiddleware({
 
 In this case, your content will be available without a locale prefix based on the domain since `next-intl` rewrites the request internally (e.g. `de.example.com/about` matches `[locales]/about/page.tsx`).
 
-The domain that is needed to match the loacle is read from the `x-forwarded-host` header, with a fallback to the `host` header. If no domain matches (e.g. on localhost), the `defaultLocale` is used.
+The domain that is needed to match the locale is read from the `x-forwarded-host` header, with a fallback to the `host` header. If no domain matches (e.g. on localhost), the `defaultLocale` is used.
 
 ### Alternate links
 

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -282,26 +282,27 @@ The middleware handles redirects and rewrites based on the detected user locale.
 
 By default, `next-intl` will map the incoming requests to your defined routes. To keep the URL short, requests for the default locale are rewritten internally to work without a locale prefix.
 
-**Examples:**
+**Examples for rewrites:**
 
 - `/` → `/en`
 - `/about` → `/en/about`
 - `/de/about` → `/de/about`
 
-When the user visits a route without an explicit locale, `next-intl` matches the [`accept-language` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) of the request against the available locales and optionally redirects the user to a prefixed route. Note that a matched locale is saved in a cookie for subsequent requests.
+When the user visits a route without an explicit locale, `next-intl` matches the [`accept-language` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) of the request against the available locales and optionally redirects the user to a prefixed route. The matched locale is saved in a cookie.
 
 #### Changing locales
 
 To change the locale, the user can visit a prefixed route. This will always take precedence over a previously matched locale that is saved in a cookie or the `accept-language` header.
 
-**Example:**
+**Example workflow:**
 
 1. The user requests `/` and based on the `accept-language` header, the `de` locale is matched.
-2. The `de` locale is saved in the cookie and the user is redirected to `/de`.
-3. The app renders `<Link locale="en" href="/">Switch to English</Link>` to allow the user to change the locale to `en`.
-4. When the user clicks on the link, the middleware will update the cookie to `en` and will redirect the user to `/`. The user will now be served content in `en`.
+2. The `de` locale is saved in a cookie and the user is redirected to `/de`.
+3. In your app code, you render `<Link locale="en" href="/">Switch to English</Link>` to allow the user to change the locale to `en`.
+4. When the user clicks on the link, a request to `/en` is initiated.
+5. The middleware will update the cookie value to `en` and will redirect the user to `/`.
 
-#### Alwyays use a locale prefix
+#### Always use a locale prefix
 
 If you want to include a prefix for the default locale as well, you can configure the middleware accordingly.
 
@@ -319,7 +320,7 @@ export default createIntlMiddleware({
 });
 ```
 
-In this case requests without a prefix will be redirected accordingly (e.g. `/about` to `/en/about`).
+In this case, requests without a prefix will be redirected accordingly (e.g. `/about` to `/en/about`).
 
 ### Routing with domains
 
@@ -356,7 +357,7 @@ The domain that is needed to match the locale is read from the `x-forwarded-host
 
 Since the middleware is aware of all your domains, `next-intl` will automatically switch the domain when the user requests to change the locale.
 
-**Example:**
+**Example workflow:**
 
 1. The user is on `en.example.com`.
 2. The app renders `<Link locale="de" href="/">Switch to German</Link>` to allow the user to change the locale to `de`.
@@ -365,7 +366,7 @@ Since the middleware is aware of all your domains, `next-intl` will automaticall
 
 ### Alternate links
 
-`next-intl` automatically sets [the `link` header](https://developers.google.com/search/docs/specialty/international/localized-versions#http) to inform search engines that your content is available in different languages. Note that this automatically integrates with your routing strategy, wether it's `prefix` or `domain`.
+`next-intl` automatically sets [the `link` header](https://developers.google.com/search/docs/specialty/international/localized-versions#http) to inform search engines that your content is available in different languages. Note that this automatically integrates with your routing strategy and will generate the correct links based on your configuration (`prefix` or `domain`).
 
 If you prefer to include these links yourself, you can opt-out of this behaviour.
 

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -285,10 +285,11 @@ export default createIntlMiddleware({
   // A list of all locales that are supported
   locales: ['en', 'de'],
 
-  // If this locale is matched, pathnames work without a prefix (e.g. `/about`)
+  // If no locale matches, this will be used by default
   defaultLocale: 'en',
 
-  // Optionally configure a list of domains where the `defaultLocale` is changed
+  // Optionally configure a list of domains where the `defaultLocale` is changed.
+  // When a locale has a matching domain, this is preferred to a locale prefix.
   domains: [
     {
       domain: 'example.de',
@@ -317,7 +318,7 @@ The locale is matched based on this priority order:
 4. **`accept-language` header**: The available `locales` are matched against the [`accept-language` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language).
 5. **Default fallback**: If nothing else matches, then the `defaultLocale` is used.
 
-If the default locale matches, the request will be **rewritten** to the corresponding sub path (e.g. `/about` to `/en/about`). If a non-default locale is matched and the user requests the root pathname, then the user is **redirected** to to the respective sub path (e.g. `/` to `/de`).
+If the default locale matches, the request will be **rewritten** to the corresponding sub path (e.g. `/about` to `/en/about`). If a non-default locale is matched, then the user is **redirected** either to the respective sub path (e.g. `/` to `/de`) or a `domain` (e.g. `/about` to `example.de/about`).
 
 ## Localizing pathnames
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3698,6 +3698,11 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
 ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
@@ -3708,7 +3713,7 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-styles@^3.1.0, ansi-styles@^3.2.1:
+ansi-styles@^3.1.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -4293,7 +4298,7 @@ camelcase@^2.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
   integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
 
-camelcase@^5.3.1:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -4384,7 +4389,17 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@^3.5.3:
+chokidar-cli@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chokidar-cli/-/chokidar-cli-3.0.0.tgz#29283666063b9e167559d30f247ff8fc48794eb7"
+  integrity sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==
+  dependencies:
+    chokidar "^3.5.2"
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    yargs "^13.3.0"
+
+chokidar@^3.5.2, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -4477,6 +4492,15 @@ clipboardy@1.2.2:
   dependencies:
     arch "^2.1.0"
     execa "^0.8.0"
+
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -4916,7 +4940,7 @@ decamelize-keys@^1.1.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.1.2:
+decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -5230,6 +5254,11 @@ emittery@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
   integrity sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -6244,6 +6273,13 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -6403,7 +6439,7 @@ gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.5:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -8358,6 +8394,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -8426,6 +8470,11 @@ lodash.templatesettings@^4.0.0:
   integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
   dependencies:
     lodash._reinterpolate "^3.0.0"
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
 lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2:
   version "4.17.20"
@@ -10112,7 +10161,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -10132,6 +10181,13 @@ p-locate@^2.0.0:
   integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -11269,6 +11325,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -11558,7 +11619,7 @@ server-only@0.0.1:
   resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
   integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
 
-set-blocking@~2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -11918,6 +11979,15 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0, string-width@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
@@ -12008,6 +12078,13 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0:
   version "6.0.0"
@@ -13043,6 +13120,11 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+  integrity sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==
+
 which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -13081,6 +13163,15 @@ wrap-ansi@^3.0.1:
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
+
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -13168,6 +13259,11 @@ xtend@^4.0.2, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+y18n@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -13202,6 +13298,30 @@ yargs-parser@20.x, yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs@^13.3.0:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.2"
 
 yargs@^16.2.0:
   version "16.2.0"


### PR DESCRIPTION
Improvements: 
- Switch to a new API in the middleware to configure advanced routing patterns (please see [the updated docs](https://next-intl-git-feat-next-13-rsc-middleware-improvements-amann.vercel.app/docs/next-13/server-components#middleware-configuration))
- Support mode to always prefix the current route with the locale
- Improve domain-based routing to allow redirects from one domain to another and better integrate with alternate links (only show domain-alternatives)

 