### PR TITLE
feat: Next.js 13 RSC Domain middleware improvements

### DIFF
--- a/packages/example-next-13-advanced/src/middleware.ts
+++ b/packages/example-next-13-advanced/src/middleware.ts
@@ -7,5 +7,5 @@ export default createIntlMiddleware({
 
 export const config = {
   // Skip all paths that should not be internationalized
-  matcher: ['/((?!api|_next|.*\\..*).*)']
+  matcher: ['/((?!_next|.*\\..*).*)']
 };

--- a/packages/example-next-13-advanced/src/middleware.ts
+++ b/packages/example-next-13-advanced/src/middleware.ts
@@ -7,5 +7,5 @@ export default createIntlMiddleware({
 
 export const config = {
   // Skip all paths that should not be internationalized
-  matcher: ['/((?!_next|assets|favicon.ico).*)']
+  matcher: ['/((?!api|_next|.*\\..*).*)']
 };

--- a/packages/next-intl/.eslintrc.js
+++ b/packages/next-intl/.eslintrc.js
@@ -1,5 +1,14 @@
 require('eslint-config-molindo/setupPlugins');
 
 module.exports = {
-  extends: ['molindo/typescript', 'molindo/react']
+  extends: ['molindo/typescript', 'molindo/react'],
+  plugins: ['deprecation'],
+  overrides: [
+    {
+      files: ['test/**/*.tsx'],
+      rules: {
+        'deprecation/deprecation': 'error'
+      }
+    }
+  ]
 };

--- a/packages/next-intl/.eslintrc.js
+++ b/packages/next-intl/.eslintrc.js
@@ -1,7 +1,7 @@
 require('eslint-config-molindo/setupPlugins');
 
 module.exports = {
-  extends: ['molindo/typescript', 'molindo/react'],
+  extends: ['molindo/typescript', 'molindo/react', 'molindo/jest'],
   plugins: ['deprecation'],
   overrides: [
     {

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -79,6 +79,7 @@
     "dts-cli": "1.4.0",
     "eslint": "8.12.0",
     "eslint-config-molindo": "6.0.0",
+    "eslint-plugin-deprecation": "1.4.0",
     "next": "13.2.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
+++ b/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
@@ -27,7 +27,10 @@ type RoutingBaseConfig = {
   localePrefix?: LocalePrefix;
 };
 
-export type DomainConfig = Omit<RoutingBaseConfig, 'locales'> & {
+export type DomainConfig = Omit<
+  RoutingBaseConfig,
+  'locales' | 'localePrefix'
+> & {
   /** The domain name (e.g. "example.com", "www.example.com" or "fr.example.com"). Note that the `x-forwarded-host` or alternatively the `host` header will be used to determine the requested domain. */
   domain: string;
   // Optional here

--- a/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
+++ b/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
@@ -41,11 +41,14 @@ export type DomainConfig = Omit<
 };
 
 type MiddlewareConfig = RoutingBaseConfig & {
-  /** Sets the `Link` response header to notify search engines about content in other languages (defaults to `true`). See https://developers.google.com/search/docs/specialty/international/localized-versions#http */
-  alternateLinks?: boolean;
-
   /** Can be used to change the locale handling per domain. */
   domains?: Array<DomainConfig>;
+
+  /** By setting this to `false`, the `accept-language` header will no longer be used for locale detection. */
+  localeDetection?: boolean;
+
+  /** Sets the `Link` response header to notify search engines about content in other languages (defaults to `true`). See https://developers.google.com/search/docs/specialty/international/localized-versions#http */
+  alternateLinks?: boolean;
 
   /** @deprecated Deprecated in favor of `localePrefix` and `domains`. */
   routing?: RoutingConfigPrefix | RoutingConfigDomain;
@@ -54,6 +57,7 @@ type MiddlewareConfig = RoutingBaseConfig & {
 export type MiddlewareConfigWithDefaults = MiddlewareConfig & {
   alternateLinks: boolean;
   localePrefix: LocalePrefix;
+  localeDetection: boolean;
 };
 
 export default MiddlewareConfig;

--- a/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
+++ b/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
@@ -1,4 +1,4 @@
-export type RoutingConfigPrefix = {
+type RoutingConfigPrefix = {
   type: 'prefix';
 
   /** The default locale can be used without a prefix (e.g. `/about`). If you prefer to have a prefix for the default locale as well (e.g. `/en/about`), you can switch this option to `always`.
@@ -6,39 +6,51 @@ export type RoutingConfigPrefix = {
   prefix?: 'as-needed' | 'always';
 };
 
-export type DomainConfig = {
-  /** The domain name (e.g. "example.de" or "de.example.com"). */
-  domain: string;
-
-  locale: string;
-};
-
-export type RoutingConfigDomain = {
+type RoutingConfigDomain = {
   type: 'domain';
 
   /** Provide a list of mappings between domains and locales. Note that the `x-forwarded-host` or alternatively the `host` header will be used to determine the requested domain. */
   domains: Array<{domain: string; locale: string}>;
 };
 
-type NextIntlMiddlewareConfig = {
+type LocalePrefix = 'as-needed' | 'always';
+
+type RoutingBaseConfig = {
   /** A list of all locales that are supported. */
   locales: Array<string>;
 
   /* Used by default if none of the defined locales match. */
   defaultLocale: string;
 
+  /** The default locale can be used without a prefix (e.g. `/about`). If you prefer to have a prefix for the default locale as well (e.g. `/en/about`), you can switch this option to `always`.
+   */
+  localePrefix?: LocalePrefix;
+};
+
+export type DomainConfig = Omit<RoutingBaseConfig, 'locales'> & {
+  /** The domain name (e.g. "example.com", "www.example.com" or "fr.example.com"). Note that the `x-forwarded-host` or alternatively the `host` header will be used to determine the requested domain. */
+  domain: string;
+  // Optional here
+  locales?: RoutingBaseConfig['locales'];
+
+  /** @deprecated Use `defaultLocale` instead. */
+  locale?: string;
+};
+
+type MiddlewareConfig = RoutingBaseConfig & {
   /** Sets the `Link` response header to notify search engines about content in other languages (defaults to `true`). See https://developers.google.com/search/docs/specialty/international/localized-versions#http */
   alternateLinks?: boolean;
 
-  /** @deprecated Deprecated in favour of `routing`. */
-  domains?: Array<{domain: string; defaultLocale: string}>;
+  /** Can be used to change the locale handling per domain. */
+  domains?: Array<DomainConfig>;
 
+  /** @deprecated Deprecated in favor of `localePrefix` and `domains`. */
   routing?: RoutingConfigPrefix | RoutingConfigDomain;
 };
 
-export type NextIntlMiddlewareConfigWithDefaults = NextIntlMiddlewareConfig & {
+export type MiddlewareConfigWithDefaults = MiddlewareConfig & {
   alternateLinks: boolean;
-  routing: RoutingConfigPrefix | RoutingConfigDomain;
+  localePrefix: LocalePrefix;
 };
 
-export default NextIntlMiddlewareConfig;
+export default MiddlewareConfig;

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -59,7 +59,10 @@ export default function getAlternateLinksHeaderValue(
         url.port = '';
         url.host = domainConfig.domain;
 
-        if (locale !== domainConfig.defaultLocale) {
+        if (
+          locale !== domainConfig.defaultLocale ||
+          config.localePrefix === 'always'
+        ) {
           localizePathname(url);
         }
 

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -1,12 +1,10 @@
 import {NextRequest} from 'next/server';
-import NextIntlMiddlewareConfig, {
-  NextIntlMiddlewareConfigWithDefaults
+import MiddlewareConfig, {
+  MiddlewareConfigWithDefaults
 } from './NextIntlMiddlewareConfig';
+import {isLocaleSupportedOnDomain} from './utils';
 
-function getUnprefixedUrl(
-  config: NextIntlMiddlewareConfig,
-  request: NextRequest
-) {
+function getUnprefixedUrl(config: MiddlewareConfig, request: NextRequest) {
   const url = new URL(request.url);
   if (!url.pathname.endsWith('/')) {
     url.pathname += '/';
@@ -33,7 +31,7 @@ function getAlternateEntry(url: string, locale: string) {
  * See https://developers.google.com/search/docs/specialty/international/localized-versions
  */
 export default function getAlternateLinksHeaderValue(
-  config: NextIntlMiddlewareConfigWithDefaults,
+  config: MiddlewareConfigWithDefaults,
   request: NextRequest
 ) {
   const unprefixedUrl = getUnprefixedUrl(config, request);
@@ -50,22 +48,26 @@ export default function getAlternateLinksHeaderValue(
 
     let url;
 
-    if (config.routing.type === 'domain') {
+    if (config.domains) {
       const domainConfigs =
-        config.routing.domains.filter((cur) => cur.locale === locale) || [];
+        config.domains.filter((cur) =>
+          isLocaleSupportedOnDomain(locale, cur)
+        ) || [];
 
       return domainConfigs.map((domainConfig) => {
         url = new URL(unprefixedUrl);
         url.port = '';
         url.host = domainConfig.domain;
+
+        if (locale !== domainConfig.defaultLocale) {
+          localizePathname(url);
+        }
+
         return getAlternateEntry(url.toString(), locale);
       });
     } else {
       url = new URL(unprefixedUrl);
-      if (
-        locale !== config.defaultLocale ||
-        config.routing.prefix === 'always'
-      ) {
+      if (locale !== config.defaultLocale || config.localePrefix === 'always') {
         localizePathname(url);
       }
     }
@@ -74,7 +76,7 @@ export default function getAlternateLinksHeaderValue(
   });
 
   // Add x-default entry
-  if (config.routing.type === 'prefix') {
+  if (!config.domains) {
     const url = new URL(unprefixedUrl);
     links.push(getAlternateEntry(url.toString(), 'x-default'));
   } else {

--- a/packages/next-intl/src/middleware/getHost.tsx
+++ b/packages/next-intl/src/middleware/getHost.tsx
@@ -1,7 +1,0 @@
-export default function getHost(requestHeaders: Headers) {
-  return (
-    requestHeaders.get('x-forwarded-host') ??
-    requestHeaders.get('host') ??
-    undefined
-  );
-}

--- a/packages/next-intl/src/middleware/getLocaleFromPathname.tsx
+++ b/packages/next-intl/src/middleware/getLocaleFromPathname.tsx
@@ -1,3 +1,0 @@
-export default function getLocaleFromPathname(pathname: string) {
-  return pathname.split('/')[1];
-}

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -1,65 +1,75 @@
 import {NextRequest, NextResponse} from 'next/server';
 import {COOKIE_LOCALE_NAME, HEADER_LOCALE_NAME} from '../shared/constants';
-import NextIntlMiddlewareConfig, {
-  NextIntlMiddlewareConfigWithDefaults
+import MiddlewareConfig, {
+  MiddlewareConfigWithDefaults
 } from './NextIntlMiddlewareConfig';
 import getAlternateLinksHeaderValue from './getAlternateLinksHeaderValue';
-import getLocaleFromPathname from './getLocaleFromPathname';
 import resolveLocale from './resolveLocale';
+import {
+  getBestMatchingDomain,
+  getLocaleFromPathname,
+  isLocaleSupportedOnDomain
+} from './utils';
 
 const ROOT_URL = '/';
 
-function receiveConfig(
-  config: NextIntlMiddlewareConfig
-): NextIntlMiddlewareConfigWithDefaults {
-  const result = {
-    ...config,
-    alternateLinks: config.alternateLinks ?? true
-  };
+function handleConfigDeprecations(config: MiddlewareConfig) {
+  if (config.routing) {
+    const {routing} = config;
+    config = {...config};
+    delete config.routing;
 
-  if (!result.routing) {
-    result.routing = {
-      type: 'prefix'
-    };
+    if (routing.type === 'prefix') {
+      config.localePrefix = routing.prefix;
+    } else if (routing.type === 'domain') {
+      config.domains = routing.domains.map((cur) => ({
+        domain: cur.domain,
+        defaultLocale: cur.locale
+        // `locales` didn't exist before
+      }));
+    }
+
+    console.error(
+      "\n\nThe `routing` option is deprecated, please use `localePrefix` and `domains` instead. Here's your updated configuration:\n\n" +
+        JSON.stringify(config, null, 2) +
+        '\n\nThank you so much for following along with the Server Components beta and sorry for the inconvenience!\n\n'
+    );
   }
 
-  if (result.routing.type === 'prefix') {
-    result.routing.prefix = result.routing.prefix ?? 'as-needed';
+  if (config.domains) {
+    const {domains} = config;
+    config = {...config};
+    config.domains = domains.map((cur) => {
+      if (cur.locale) {
+        console.error(
+          '\n\nThe `domain.locale` option is deprecated, please use `domain.defaultLocale` instead.'
+        );
+      }
+      return {
+        ...cur,
+        defaultLocale: cur.locale || cur.defaultLocale
+      };
+    });
   }
 
-  return result as NextIntlMiddlewareConfigWithDefaults;
+  return config;
 }
 
-export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
+function receiveConfig(config: MiddlewareConfig) {
   // TODO: Remove before stable release
-  if (config.domains != null) {
-    console.error(
-      'The `domains` option is deprecated. Please use `routing` instead.'
-    );
-    config = {
-      ...config,
-      routing: {
-        type: 'domain',
-        domains: config.domains.map((cur) => ({
-          domain: cur.domain,
-          locale: cur.defaultLocale
-        }))
-      }
-    };
-    delete config.domains;
-  }
+  config = handleConfigDeprecations(config);
 
+  const result: MiddlewareConfigWithDefaults = {
+    ...config,
+    alternateLinks: config.alternateLinks ?? true,
+    localePrefix: config.localePrefix ?? 'as-needed'
+  };
+
+  return result;
+}
+
+export default function createIntlMiddleware(config: MiddlewareConfig) {
   const configWithDefaults = receiveConfig(config);
-
-  if (configWithDefaults.routing.type === 'domain') {
-    const {domains} = configWithDefaults.routing;
-    const hasMatchingDomainForEveryLocale = configWithDefaults.locales.every(
-      (locale) => domains.find((cur) => cur.locale === locale) != null
-    );
-    if (!hasMatchingDomainForEveryLocale) {
-      throw new Error('Every locale must have a matching domain');
-    }
-  }
 
   return function middleware(request: NextRequest) {
     const {domain, locale} = resolveLocale(
@@ -73,14 +83,12 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
     const hasOutdatedCookie =
       request.cookies.get(COOKIE_LOCALE_NAME)?.value !== locale;
     const hasMatchedDefaultLocale = domain
-      ? domain.locale === locale
+      ? [domain.defaultLocale, ...(domain.locales ?? [])].includes(locale)
       : locale === configWithDefaults.defaultLocale;
     const domainConfigs =
-      configWithDefaults.routing.type === 'domain'
-        ? configWithDefaults.routing.domains.filter(
-            (cur) => cur.locale === locale
-          ) ?? []
-        : [];
+      configWithDefaults.domains?.filter((curDomain) =>
+        isLocaleSupportedOnDomain(locale, curDomain)
+      ) || [];
 
     function getResponseInit() {
       let responseInit;
@@ -112,10 +120,20 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
 
       if (domainConfigs.length > 0) {
         urlObj.pathname = url.replace(`/${locale}`, '');
-        if (domainConfigs[0].domain && !host) {
-          host = domainConfigs[0].domain;
+
+        if (!host) {
+          const bestMatchingDomain = getBestMatchingDomain(
+            domain,
+            locale,
+            domainConfigs
+          );
+
+          if (bestMatchingDomain) {
+            host = bestMatchingDomain.domain;
+          }
         }
       }
+
       if (host) {
         urlObj.host = host;
       }
@@ -132,9 +150,8 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
 
       if (
         hasMatchedDefaultLocale &&
-        ((configWithDefaults.routing.type === 'prefix' &&
-          configWithDefaults.routing.prefix === 'as-needed') ||
-          configWithDefaults.routing.type === 'domain')
+        (configWithDefaults.localePrefix === 'as-needed' ||
+          domainConfigs.length > 0)
       ) {
         response = rewrite(pathWithSearch);
       } else {
@@ -159,17 +176,18 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
       if (hasLocalePrefix) {
         const basePath = pathWithSearch.replace(`/${pathLocale}`, '') || '/';
 
-        if (configWithDefaults.routing.type === 'domain') {
-          const pathDomain = configWithDefaults.routing.domains.find(
-            (cur) => pathLocale === cur.locale
+        if (configWithDefaults.domains) {
+          const pathDomain = getBestMatchingDomain(
+            domain,
+            pathLocale,
+            domainConfigs
           );
-
           response = redirect(basePath, pathDomain?.domain);
         } else {
           if (pathLocale === locale) {
             if (
               hasMatchedDefaultLocale &&
-              configWithDefaults.routing.prefix === 'as-needed'
+              configWithDefaults.localePrefix === 'as-needed'
             ) {
               response = redirect(basePath);
             } else {
@@ -182,9 +200,8 @@ export default function createIntlMiddleware(config: NextIntlMiddlewareConfig) {
       } else {
         if (
           hasMatchedDefaultLocale &&
-          ((configWithDefaults.routing.type === 'prefix' &&
-            configWithDefaults.routing.prefix === 'as-needed') ||
-            configWithDefaults.routing.type === 'domain')
+          (configWithDefaults.localePrefix === 'as-needed' ||
+            configWithDefaults.domains)
         ) {
           response = rewrite(`/${locale}${pathWithSearch}`);
         } else {

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -63,7 +63,8 @@ function receiveConfig(config: MiddlewareConfig) {
   const result: MiddlewareConfigWithDefaults = {
     ...config,
     alternateLinks: config.alternateLinks ?? true,
-    localePrefix: config.localePrefix ?? 'as-needed'
+    localePrefix: config.localePrefix ?? 'as-needed',
+    localeDetection: config.localeDetection ?? true
   };
 
   return result;

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -84,13 +84,14 @@ export default function createIntlMiddleware(config: MiddlewareConfig) {
     const hasOutdatedCookie =
       request.cookies.get(COOKIE_LOCALE_NAME)?.value !== locale;
     const hasMatchedDefaultLocale = domain
-      ? [domain.defaultLocale, ...(domain.locales ?? [])].includes(locale)
+      ? domain.defaultLocale === locale
       : locale === configWithDefaults.defaultLocale;
 
     const domainConfigs =
       configWithDefaults.domains?.filter((curDomain) =>
         isLocaleSupportedOnDomain(locale, curDomain)
       ) || [];
+    const hasUnknownHost = configWithDefaults.domains != null && !domain;
 
     function getResponseInit() {
       let responseInit;
@@ -195,7 +196,8 @@ export default function createIntlMiddleware(config: MiddlewareConfig) {
                 pathLocale,
                 domainConfigs
               );
-              if (domain?.domain !== pathDomain?.domain) {
+
+              if (domain?.domain !== pathDomain?.domain && !hasUnknownHost) {
                 response = redirect(basePath, pathDomain?.domain);
               } else {
                 response = next();

--- a/packages/next-intl/src/middleware/resolveLocale.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.tsx
@@ -94,17 +94,17 @@ function resolveLocaleFromDomain(
 ) {
   let locale, domain;
 
+  const requestLocale = getAcceptLanguageLocale(
+    requestHeaders,
+    locales,
+    defaultLocale
+  );
+
   // Prio 1: Use a domain
   if (domains) {
     domain = findDomainFromHost(requestHeaders, domains);
 
     if (domain) {
-      const requestLocale = getAcceptLanguageLocale(
-        requestHeaders,
-        locales,
-        defaultLocale
-      );
-
       if (requestLocale && isLocaleSupportedOnDomain(requestLocale, domain)) {
         locale = requestLocale;
       }
@@ -113,7 +113,13 @@ function resolveLocaleFromDomain(
     }
   }
 
-  // Prio 2: Use default locale
+  // Prio 2: Use the request locale if it is
+  // supported, but not on the current domain
+  if (!locale && requestLocale && locales.includes(requestLocale)) {
+    locale = requestLocale;
+  }
+
+  // Prio 3: Use default locale
   if (!locale) {
     locale = defaultLocale;
   }

--- a/packages/next-intl/src/middleware/resolveLocale.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.tsx
@@ -96,7 +96,7 @@ function resolveLocaleFromDomain(
 ) {
   const {domains} = config;
 
-  const localeFromPrefix = resolveLocaleFromPrefix(
+  const localeFromPrefixStrategy = resolveLocaleFromPrefix(
     config,
     requestHeaders,
     requestCookies,
@@ -107,17 +107,17 @@ function resolveLocaleFromDomain(
   if (domains) {
     const domain = findDomainFromHost(requestHeaders, domains);
     const hasLocalePrefix =
-      pathname && pathname.startsWith(`/${localeFromPrefix}`);
+      pathname && pathname.startsWith(`/${localeFromPrefixStrategy}`);
 
     if (domain) {
-      if (localeFromPrefix) {
+      if (localeFromPrefixStrategy) {
         return {
           locale:
-            isLocaleSupportedOnDomain(localeFromPrefix, domain) ||
+            isLocaleSupportedOnDomain(localeFromPrefixStrategy, domain) ||
             hasLocalePrefix
-              ? localeFromPrefix
+              ? localeFromPrefixStrategy
               : domain.defaultLocale,
-          localeFromPrefix,
+          localeFromPrefix: localeFromPrefixStrategy,
           domain
         };
       }
@@ -125,7 +125,7 @@ function resolveLocaleFromDomain(
   }
 
   // Prio 2: Use prefix strategy
-  return {locale: localeFromPrefix};
+  return {locale: localeFromPrefixStrategy};
 }
 
 export default function resolveLocale(

--- a/packages/next-intl/src/middleware/resolveLocale.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.tsx
@@ -50,7 +50,7 @@ function getAcceptLanguageLocale(
 }
 
 function resolveLocaleFromPrefix(
-  {defaultLocale, locales}: MiddlewareConfigWithDefaults,
+  {defaultLocale, localeDetection, locales}: MiddlewareConfigWithDefaults,
   requestHeaders: Headers,
   requestCookies: RequestCookies,
   pathname: string
@@ -76,7 +76,7 @@ function resolveLocaleFromPrefix(
   }
 
   // Prio 3: Use the `accept-language` header
-  if (!locale && requestHeaders) {
+  if (!locale && localeDetection && requestHeaders) {
     locale = getAcceptLanguageLocale(requestHeaders, locales, defaultLocale);
   }
 

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -31,7 +31,7 @@ export function getBestMatchingDomain(
   let domainConfig;
 
   // Prio 1: Stay on current domain
-  if (curHostDomain?.defaultLocale === locale) {
+  if (curHostDomain && isLocaleSupportedOnDomain(locale, curHostDomain)) {
     domainConfig = curHostDomain;
   }
 

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -1,0 +1,61 @@
+import {DomainConfig} from './NextIntlMiddlewareConfig';
+
+export function getLocaleFromPathname(pathname: string) {
+  return pathname.split('/')[1];
+}
+
+export function getHost(requestHeaders: Headers) {
+  return (
+    requestHeaders.get('x-forwarded-host') ??
+    requestHeaders.get('host') ??
+    undefined
+  );
+}
+
+export function isLocaleSupportedOnDomain(
+  locale: string,
+  domain: DomainConfig
+) {
+  return (
+    domain.defaultLocale === locale ||
+    !domain.locales ||
+    domain.locales.includes(locale)
+  );
+}
+
+export function getBestMatchingDomain(
+  curHostDomain: DomainConfig | undefined,
+  locale: string,
+  domainConfigs: Array<DomainConfig>
+) {
+  let domainConfig;
+
+  // Prio 1: Stay on current domain
+  if (curHostDomain?.defaultLocale === locale) {
+    domainConfig = curHostDomain;
+  }
+
+  // Prio 2: Use alternative domain with matching default locale
+  if (!domainConfig) {
+    domainConfig = domainConfigs.find((cur) => cur.defaultLocale === locale);
+  }
+
+  // Prio 3: Use alternative domain with restricted matching locale
+  if (!domainConfig) {
+    domainConfig = domainConfigs.find(
+      (cur) => cur.locales != null && cur.locales.includes(locale)
+    );
+  }
+
+  // Prio 4: Stay on the current domain if it supports all locales
+  if (!domainConfig && curHostDomain?.locales == null) {
+    domainConfig = curHostDomain;
+  }
+
+  // Prio 5: Use alternative domain that supports all locales
+  if (!domainConfig) {
+    domainConfig = domainConfigs.find((cur) => !cur.locales);
+  }
+
+  return domainConfig;
+}

--- a/packages/next-intl/test/client/NextIntlClientProvider.test.tsx
+++ b/packages/next-intl/test/client/NextIntlClientProvider.test.tsx
@@ -1,7 +1,6 @@
 import {render, screen} from '@testing-library/react';
 import React from 'react';
-import {useTranslations} from '../../src';
-import {NextIntlClientProvider} from '../../src/client';
+import {useTranslations, NextIntlClientProvider} from '../../src';
 
 jest.mock('next/router', () => ({
   useRouter: () => ({locale: 'en'})

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -1,20 +1,17 @@
 import {NextRequest} from 'next/server';
-import {NextIntlMiddlewareConfigWithDefaults} from '../../src/middleware/NextIntlMiddlewareConfig';
+import {MiddlewareConfigWithDefaults} from '../../src/middleware/NextIntlMiddlewareConfig';
 import getAlternateLinksHeaderValue from '../../src/middleware/getAlternateLinksHeaderValue';
 
 function getRequest(url = 'https://example.com/') {
   return {url} as NextRequest;
 }
 
-it('works for type prefix (as-needed)', () => {
-  const config: NextIntlMiddlewareConfigWithDefaults = {
+it('works for prefixed routing (as-needed)', () => {
+  const config: MiddlewareConfigWithDefaults = {
     defaultLocale: 'en',
     locales: ['en', 'es'],
     alternateLinks: true,
-    routing: {
-      type: 'prefix',
-      prefix: 'as-needed'
-    }
+    localePrefix: 'as-needed'
   };
 
   expect(
@@ -37,15 +34,12 @@ it('works for type prefix (as-needed)', () => {
   ]);
 });
 
-it('works for type prefix (always)', () => {
-  const config: NextIntlMiddlewareConfigWithDefaults = {
+it('works for prefixed routing (always)', () => {
+  const config: MiddlewareConfigWithDefaults = {
     defaultLocale: 'en',
     locales: ['en', 'es'],
     alternateLinks: true,
-    routing: {
-      type: 'prefix',
-      prefix: 'always'
-    }
+    localePrefix: 'always'
   };
 
   expect(
@@ -69,30 +63,39 @@ it('works for type prefix (always)', () => {
 });
 
 it('works for type domain', () => {
-  const config: NextIntlMiddlewareConfigWithDefaults = {
+  const config: MiddlewareConfigWithDefaults = {
     defaultLocale: 'en',
-    locales: ['en', 'es'],
+    locales: ['en', 'es', 'fr'],
     alternateLinks: true,
-    routing: {
-      type: 'domain',
-      domains: [
-        {
-          domain: 'example.com',
-          locale: 'en'
-        },
-        {
-          domain: 'example.es',
-          locale: 'es'
-        }
-      ]
-    }
+    localePrefix: 'as-needed',
+    domains: [
+      {
+        domain: 'example.com',
+        defaultLocale: 'en'
+        // (supports all locales)
+      },
+      {
+        domain: 'example.es',
+        defaultLocale: 'es',
+        locales: ['es']
+      },
+      {
+        domain: 'example.ca',
+        defaultLocale: 'en',
+        locales: ['en', 'fr']
+      }
+    ]
   };
 
   expect(
     getAlternateLinksHeaderValue(config, getRequest()).split(', ')
   ).toEqual([
     '<https://example.com/>; rel="alternate"; hreflang="en"',
-    '<https://example.es/>; rel="alternate"; hreflang="es"'
+    '<https://example.ca/>; rel="alternate"; hreflang="en"',
+    '<https://example.com/es>; rel="alternate"; hreflang="es"',
+    '<https://example.es/>; rel="alternate"; hreflang="es"',
+    '<https://example.com/fr>; rel="alternate"; hreflang="fr"',
+    '<https://example.ca/fr>; rel="alternate"; hreflang="fr"'
   ]);
 
   expect(
@@ -102,7 +105,11 @@ it('works for type domain', () => {
     ).split(', ')
   ).toEqual([
     '<https://example.com/>; rel="alternate"; hreflang="en"',
-    '<https://example.es/>; rel="alternate"; hreflang="es"'
+    '<https://example.ca/>; rel="alternate"; hreflang="en"',
+    '<https://example.com/es>; rel="alternate"; hreflang="es"',
+    '<https://example.es/>; rel="alternate"; hreflang="es"',
+    '<https://example.com/fr>; rel="alternate"; hreflang="fr"',
+    '<https://example.ca/fr>; rel="alternate"; hreflang="fr"'
   ]);
 
   expect(
@@ -112,6 +119,10 @@ it('works for type domain', () => {
     ).split(', ')
   ).toEqual([
     '<https://example.com/about>; rel="alternate"; hreflang="en"',
-    '<https://example.es/about>; rel="alternate"; hreflang="es"'
+    '<https://example.ca/about>; rel="alternate"; hreflang="en"',
+    '<https://example.com/es/about>; rel="alternate"; hreflang="es"',
+    '<https://example.es/about>; rel="alternate"; hreflang="es"',
+    '<https://example.com/fr/about>; rel="alternate"; hreflang="fr"',
+    '<https://example.ca/fr/about>; rel="alternate"; hreflang="fr"'
   ]);
 });

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -11,7 +11,8 @@ it('works for prefixed routing (as-needed)', () => {
     defaultLocale: 'en',
     locales: ['en', 'es'],
     alternateLinks: true,
-    localePrefix: 'as-needed'
+    localePrefix: 'as-needed',
+    localeDetection: true
   };
 
   expect(
@@ -39,7 +40,8 @@ it('works for prefixed routing (always)', () => {
     defaultLocale: 'en',
     locales: ['en', 'es'],
     alternateLinks: true,
-    localePrefix: 'always'
+    localePrefix: 'always',
+    localeDetection: true
   };
 
   expect(
@@ -68,6 +70,7 @@ it("works for type domain with `localePrefix: 'as-needed'`", () => {
     locales: ['en', 'es', 'fr'],
     alternateLinks: true,
     localePrefix: 'as-needed',
+    localeDetection: true,
     domains: [
       {
         domain: 'example.com',
@@ -125,6 +128,7 @@ it("works for type domain with `localePrefix: 'always'`", () => {
     locales: ['en', 'es', 'fr'],
     alternateLinks: true,
     localePrefix: 'always',
+    localeDetection: true,
     domains: [
       {
         domain: 'example.com',

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -62,7 +62,7 @@ it('works for prefixed routing (always)', () => {
   ]);
 });
 
-it('works for type domain', () => {
+it("works for type domain with `localePrefix: 'as-needed'`", () => {
   const config: MiddlewareConfigWithDefaults = {
     defaultLocale: 'en',
     locales: ['en', 'es', 'fr'],
@@ -87,30 +87,22 @@ it('works for type domain', () => {
     ]
   };
 
-  expect(
-    getAlternateLinksHeaderValue(config, getRequest()).split(', ')
-  ).toEqual([
-    '<https://example.com/>; rel="alternate"; hreflang="en"',
-    '<https://example.ca/>; rel="alternate"; hreflang="en"',
-    '<https://example.com/es>; rel="alternate"; hreflang="es"',
-    '<https://example.es/>; rel="alternate"; hreflang="es"',
-    '<https://example.com/fr>; rel="alternate"; hreflang="fr"',
-    '<https://example.ca/fr>; rel="alternate"; hreflang="fr"'
-  ]);
-
-  expect(
+  [
+    getAlternateLinksHeaderValue(config, getRequest()).split(', '),
     getAlternateLinksHeaderValue(
       config,
       getRequest('https://example.es/')
     ).split(', ')
-  ).toEqual([
-    '<https://example.com/>; rel="alternate"; hreflang="en"',
-    '<https://example.ca/>; rel="alternate"; hreflang="en"',
-    '<https://example.com/es>; rel="alternate"; hreflang="es"',
-    '<https://example.es/>; rel="alternate"; hreflang="es"',
-    '<https://example.com/fr>; rel="alternate"; hreflang="fr"',
-    '<https://example.ca/fr>; rel="alternate"; hreflang="fr"'
-  ]);
+  ].forEach((links) => {
+    expect(links).toEqual([
+      '<https://example.com/>; rel="alternate"; hreflang="en"',
+      '<https://example.ca/>; rel="alternate"; hreflang="en"',
+      '<https://example.com/es>; rel="alternate"; hreflang="es"',
+      '<https://example.es/>; rel="alternate"; hreflang="es"',
+      '<https://example.com/fr>; rel="alternate"; hreflang="fr"',
+      '<https://example.ca/fr>; rel="alternate"; hreflang="fr"'
+    ]);
+  });
 
   expect(
     getAlternateLinksHeaderValue(
@@ -122,6 +114,63 @@ it('works for type domain', () => {
     '<https://example.ca/about>; rel="alternate"; hreflang="en"',
     '<https://example.com/es/about>; rel="alternate"; hreflang="es"',
     '<https://example.es/about>; rel="alternate"; hreflang="es"',
+    '<https://example.com/fr/about>; rel="alternate"; hreflang="fr"',
+    '<https://example.ca/fr/about>; rel="alternate"; hreflang="fr"'
+  ]);
+});
+
+it("works for type domain with `localePrefix: 'always'`", () => {
+  const config: MiddlewareConfigWithDefaults = {
+    defaultLocale: 'en',
+    locales: ['en', 'es', 'fr'],
+    alternateLinks: true,
+    localePrefix: 'always',
+    domains: [
+      {
+        domain: 'example.com',
+        defaultLocale: 'en'
+        // (supports all locales)
+      },
+      {
+        domain: 'example.es',
+        defaultLocale: 'es',
+        locales: ['es']
+      },
+      {
+        domain: 'example.ca',
+        defaultLocale: 'en',
+        locales: ['en', 'fr']
+      }
+    ]
+  };
+
+  [
+    getAlternateLinksHeaderValue(config, getRequest()).split(', '),
+    getAlternateLinksHeaderValue(
+      config,
+      getRequest('https://example.es/')
+    ).split(', ')
+  ].forEach((links) => {
+    expect(links).toEqual([
+      '<https://example.com/en>; rel="alternate"; hreflang="en"',
+      '<https://example.ca/en>; rel="alternate"; hreflang="en"',
+      '<https://example.com/es>; rel="alternate"; hreflang="es"',
+      '<https://example.es/es>; rel="alternate"; hreflang="es"',
+      '<https://example.com/fr>; rel="alternate"; hreflang="fr"',
+      '<https://example.ca/fr>; rel="alternate"; hreflang="fr"'
+    ]);
+  });
+
+  expect(
+    getAlternateLinksHeaderValue(
+      config,
+      getRequest('https://example.com/about')
+    ).split(', ')
+  ).toEqual([
+    '<https://example.com/en/about>; rel="alternate"; hreflang="en"',
+    '<https://example.ca/en/about>; rel="alternate"; hreflang="en"',
+    '<https://example.com/es/about>; rel="alternate"; hreflang="es"',
+    '<https://example.es/es/about>; rel="alternate"; hreflang="es"',
     '<https://example.com/fr/about>; rel="alternate"; hreflang="fr"',
     '<https://example.ca/fr/about>; rel="alternate"; hreflang="fr"'
   ]);

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -23,15 +23,11 @@ jest.mock('next/server', () => {
 
 function createMockRequest(
   pathnameWithSearch = '/',
-  locale: 'en' | 'de' | 'fr' = 'en',
+  locale = 'en',
   host = 'http://localhost:3000'
 ) {
   const headers = new Headers({
-    'accept-language': {
-      en: 'en-US,en;q=0.9,de;q=0.8',
-      de: 'de-DE,de;q=0.9,en;q=0.8',
-      fr: 'fr-FR,fr;q=0.9,en;q=0.8'
-    }[locale],
+    'accept-language': `${locale};q=0.9,en;q=0.8`,
     host: new URL(host).host
   });
   const url = host + pathnameWithSearch;
@@ -334,6 +330,15 @@ describe('domain-based routing', () => {
     describe('locales-restricted domain', () => {
       it('serves requests for the default locale at the root when the accept-language header matches', () => {
         middleware(createMockRequest('/', 'en', 'http://ca.example.com'));
+        expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+          'http://ca.example.com/en'
+        );
+      });
+
+      it('serves requests for the default locale at the root when the accept-language header matches the top-level locale', () => {
+        middleware(createMockRequest('/', 'en-CA', 'http://ca.example.com'));
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
         expect(MockedNextResponse.next).not.toHaveBeenCalled();
         expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -173,6 +173,24 @@ describe('prefix-based routing', () => {
     });
   });
 
+  describe('localePrefix: as-needed, localeDetection: false', () => {
+    const middleware = createMockMiddleware({
+      defaultLocale: 'en',
+      locales: ['en', 'de'],
+      localePrefix: 'as-needed',
+      localeDetection: false
+    });
+
+    it('serves non-prefixed requests with the default locale and ignores the accept-language header', () => {
+      middleware(createMockRequest('/', 'de'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/en'
+      );
+    });
+  });
+
   describe('localePrefix: always', () => {
     const middleware = createMockMiddleware({
       defaultLocale: 'en',

--- a/packages/website/.gitignore
+++ b/packages/website/.gitignore
@@ -5,3 +5,4 @@
 .vercel
 public/.nextra
 tsconfig.tsbuildinfo
+.env

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -106,8 +106,8 @@ export default createIntlMiddleware({
 });
 
 export const config = {
-  // Skip all paths that aren't pages that you'd like to internationalize
-  matcher: ['/((?!api|_next|favicon.ico|assets).*)']
+  // Skip all paths that should not be internationalized
+  matcher: ['/((?!api|_next|.*\\..*).*)']
 };
 ```
 

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -339,22 +339,6 @@ To change the locale, users can visit a prefixed route. This will take precedenc
 4. When the user clicks on the link, a request to `/en` is initiated.
 5. The middleware will update the cookie value to `en` and subsequently redirects the user to `/`.
 
-#### Always use a locale prefix
-
-If you want to include a prefix for the default locale as well, you can configure the middleware accordingly.
-
-```tsx {6}
-import createIntlMiddleware from 'next-intl/middleware';
-
-export default createIntlMiddleware({
-  locales: ['en', 'de'],
-  defaultLocale: 'en',
-  localePrefix: 'always' // Defaults to 'as-needed'
-});
-```
-
-In this case, requests without a prefix will be redirected accordingly (e.g. `/about` to `/en/about`).
-
 ### Domain-based routing
 
 If you want to serve your localized content based on different domains, you can provide a list of mappings between domains and locales to the middleware.
@@ -421,7 +405,43 @@ Since the middleware is aware of all your domains, the domain will automatically
 3. When the link is clicked, a request to `us.example.com/fr` is initiated.
 4. The middleware recognizes that the user wants to switch to another domain and responds with a redirect to `ca.example.com/fr`.
 
-### Alternate links
+### Further configuration
+
+#### Always use a locale prefix
+
+If you want to include a prefix for the default locale as well, you can configure the middleware accordingly.
+
+```tsx {6}
+import createIntlMiddleware from 'next-intl/middleware';
+
+export default createIntlMiddleware({
+  locales: ['en', 'de'],
+  defaultLocale: 'en',
+  localePrefix: 'always' // Defaults to 'as-needed'
+});
+```
+
+In this case, requests without a prefix will be redirected accordingly (e.g. `/about` to `/en/about`).
+
+Note that this will affect both prefix-based as well as domain-based routing.
+
+#### Disable automatic locale detection
+
+If you want to disable locale detection based on the `accept-language` header, you can opt-out of this mechanism.
+
+```tsx {6}
+import createIntlMiddleware from 'next-intl/middleware';
+
+export default createIntlMiddleware({
+  locales: ['en', 'de'],
+  defaultLocale: 'en',
+  localeDetection: false // Defaults to `true`
+});
+```
+
+Note that in this case other detection mechanisms will remain in place regardless (e.g. based on a locale prefix in the pathname or a matched domain).
+
+#### Disable alternate links
 
 The middleware automatically sets [the `link` header](https://developers.google.com/search/docs/specialty/international/localized-versions#http) to inform search engines that your content is available in different languages. Note that this automatically integrates with your routing strategy and will generate the correct links based on your configuration.
 

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -320,17 +320,13 @@ To change the locale, users can visit a prefixed route. This will always take pr
 
 If you want to include a prefix for the default locale as well, you can configure the middleware accordingly.
 
-```tsx {7-10}
+```tsx {6}
 import createIntlMiddleware from 'next-intl/middleware';
 
 export default createIntlMiddleware({
   locales: ['en', 'de'],
   defaultLocale: 'en',
-
-  routing: {
-    type: 'prefix',
-    prefix: 'always' // Defaults to 'as-needed'
-  }
+  localePrefix: 'always' // Defaults to 'as-needed'
 });
 ```
 
@@ -338,34 +334,42 @@ In this case, requests without a prefix will be redirected accordingly (e.g. `/a
 
 ### Routing with domains
 
-If you want to serve your localized content based on separate domains, you can provide a list of mappings between domains and locales to the middleware.
+If you want to serve your localized content based on different domains, you can provide a list of mappings between domains and locales to the middleware.
 
-```tsx {7-19}
+**Example:**
+
+- `us.example.com` (default: `en`)
+- `ca.example.com` (default: `en`)
+- `ca.example.com/fr` (`fr`)
+
+```tsx
 import createIntlMiddleware from 'next-intl/middleware';
 
 export default createIntlMiddleware({
-  locales: ['en', 'de'],
+  // All locales across all domains
+  locales: ['en', 'fr'],
+
+  // Used when no domain matches (e.g. on localhost)
   defaultLocale: 'en',
 
-  routing: {
-    type: 'domain',
-    domains: [
-      {
-        domain: 'en.example.com',
-        locale: 'en'
-      },
-      {
-        domain: 'de.example.com',
-        locale: 'de'
-      }
-    ]
-  }
+  domains: [
+    {
+      domain: 'us.example.com',
+      defaultLocale: 'en',
+      // Optionally restrict the locales managed by this domain
+      locales: ['en']
+    },
+    {
+      domain: 'ca.example.com',
+      defaultLocale: 'en'
+    }
+  ]
 });
 ```
 
-In this case, your content will be available without a locale prefix based on the domain since `next-intl` rewrites the request internally (e.g. `de.example.com/about` → `/de/about`).
+The middleware rewrites the requests internally, so that requests for the `defaultLocale` on a given domain work without a locale prefix (e.g. `ca.example.com/about` → `/en/about`).
 
-The domain that is needed to match the locale is read from the `x-forwarded-host` header, with a fallback to `host`. If no domain matches (e.g. on localhost), the `defaultLocale` is used.
+The domain that is needed to match the locale is read from the `x-forwarded-host` header, with a fallback to `host`.
 
 <Callout>
   

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -367,7 +367,9 @@ export default createIntlMiddleware({
     {
       domain: 'us.example.com',
       defaultLocale: 'en',
-      // Optionally restrict the locales managed by this domain
+      // Optionally restrict the locales managed by this domain. If this
+      // domain receives requests for other locales (e.g. us.example.com/fr),
+      // then the middleware will redirect to a domain that supports them.
       locales: ['en']
     },
     {
@@ -381,13 +383,13 @@ export default createIntlMiddleware({
 });
 ```
 
-The middleware rewrites the requests internally, so that requests for the `defaultLocale` on a given domain work without a locale prefix (e.g. `us.example.com/about` → `/en/about`). If you want to include a prefix for the default locale as well, you can add `localePrefix: 'always'` either at the root or to an individual domain.
+The middleware rewrites the requests internally, so that requests for the `defaultLocale` on a given domain work without a locale prefix (e.g. `us.example.com/about` → `/en/about`). If you want to include a prefix for the default locale as well, you can add `localePrefix: 'always'`.
 
 The domain that is used to match the locale is read from the `x-forwarded-host` header, with a fallback to `host`.
 
 <Callout>
 
-Note that domain-based routing allows the `defaultLocale` to be used for `localhost` if it matches the `accept-language` header. However, other locales will be redirected to the configured domains. To avoid redirects pointing away from your development server, you may want to enable domain-based routing in production only.
+Note that if no domain matches an incoming request, prefix-based routing will be used. This can be useful, e.g. for local development where the host is `localhost`.
 
 </Callout>
 

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -368,26 +368,26 @@ export default createIntlMiddleware({
       domain: 'us.example.com',
       defaultLocale: 'en',
       // Optionally restrict the locales managed by this domain
-      locales: ['en'],
-      // Optionally change the `localePrefix` for this domain
-      localePrefix: 'awlays'
+      locales: ['en']
     },
     {
       domain: 'ca.example.com',
-      defaultLocale: 'en',
-      locales: ['en', 'fr']
+      defaultLocale: 'en'
+
+      // If there are no `locales` specified on a domain,
+      // all global locales will be supported here.
     }
   ]
 });
 ```
 
-The middleware rewrites the requests internally, so that requests for the `defaultLocale` on a given domain work without a locale prefix (e.g. `ca.example.com/about` → `/en/about`).
+The middleware rewrites the requests internally, so that requests for the `defaultLocale` on a given domain work without a locale prefix (e.g. `us.example.com/about` → `/en/about`). If you want to include a prefix for the default locale as well, you can add `localePrefix: 'always'` either at the root or to an individual domain.
 
-The domain that is needed to match the locale is read from the `x-forwarded-host` header, with a fallback to `host`.
+The domain that is used to match the locale is read from the `x-forwarded-host` header, with a fallback to `host`.
 
 <Callout>
 
-Note that domain-based routing allows the `defaultLocale` to be used for `localhost` if it matches, but other locales will be redirected to the configured domains. Therefore, you may want to enable domain-based routing in production only.
+Note that domain-based routing allows the `defaultLocale` to be used for `localhost` if it matches the `accept-language` header. However, other locales will be redirected to the configured domains. To avoid redirects pointing away from your development server, you may want to enable domain-based routing in production only.
 
 </Callout>
 

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -274,7 +274,16 @@ If you absolutely need to use functionality from `next-intl` on the client side,
 
 ## Global request configuration
 
-If you'd like to apply [global configuration](/docs/usage/configuration) like `formats`, `defaultTranslationValues`, `timeZone`, `now`, or [error handling functions](/docs/usage/error-handling) like `onError` and `getMessageFallback`, you can provide these in `i18n.ts`.
+`next-intl` supports the following [global configuration](/docs/usage/configuration):
+
+- `formats`
+- `defaultTranslationValues`
+- `timeZone`
+- `now`
+- `onError`
+- `getMessageFallback`
+
+For the usage in Server Components, these can be configured in `i18n.ts`.
 
 ```tsx filename="i18n.ts"
 import {headers} from 'next/headers';
@@ -287,6 +296,8 @@ export default getRequestConfig(async ({locale}) => ({
   timeZone: headers().get('x-time-zone') ?? 'Europe/Berlin'
 }));
 ```
+
+Note that the configuration object will be created once for each request and will then be made available to all of Server Components in your app.
 
 ## Middleware configuration
 
@@ -357,11 +368,14 @@ export default createIntlMiddleware({
       domain: 'us.example.com',
       defaultLocale: 'en',
       // Optionally restrict the locales managed by this domain
-      locales: ['en']
+      locales: ['en'],
+      // Optionally change the `localePrefix` for this domain
+      localePrefix: 'awlays'
     },
     {
       domain: 'ca.example.com',
-      defaultLocale: 'en'
+      defaultLocale: 'en',
+      locales: ['en', 'fr']
     }
   ]
 });
@@ -372,8 +386,8 @@ The middleware rewrites the requests internally, so that requests for the `defau
 The domain that is needed to match the locale is read from the `x-forwarded-host` header, with a fallback to `host`.
 
 <Callout>
-  
-Note that you might want to turn on domain-based routing only in production, since the middleware will try to redirect to one of the configured domains based on the matched locale.
+
+Note that domain-based routing allows the `defaultLocale` to be used for `localhost` if it matches, but other locales will be redirected to the configured domains. Therefore, you may want to enable domain-based routing in production only.
 
 </Callout>
 
@@ -384,9 +398,9 @@ Since the middleware is aware of all your domains, `next-intl` will automaticall
 **Example workflow:**
 
 1. The user is on `en.example.com`.
-2. The app renders `<Link locale="de" href="/">Switch to German</Link>` to allow the user to change the locale to `de`.
-3. When the link is clicked, a request to `en.example.com/de` is initiated.
-4. The middleware recognizes that the user wants to switch to another domain and responds with a redirect to `de.example.com`.
+2. The app renders `<Link locale="fr" href="/">Switch to French</Link>` to allow the user to change the locale to `fr`.
+3. When the link is clicked, a request to `en.example.com/fr` is initiated.
+4. The middleware recognizes that the user wants to switch to another domain and responds with a redirect to `ca.example.com/fr`.
 
 ### Alternate links
 

--- a/packages/website/pages/docs/next-13/server-components.mdx
+++ b/packages/website/pages/docs/next-13/server-components.mdx
@@ -303,7 +303,14 @@ Note that the configuration object will be created once for each request and wil
 
 The middleware handles redirects and rewrites based on the detected user locale.
 
-### Routing with a locale prefix (default)
+There are two strategies for detecting the locale:
+
+1.  [Prefix-based routing (default)](#prefix-based-routing-default)
+2.  [Domain-based routing](#domain-based-routing)
+
+Once a locale is detected, it will be saved in a cookie.
+
+### Prefix-based routing (default)
 
 Since your pages are nested within a `[locale]` folder, all routes are prefixed with one of your supported locales (e.g. `/de/about`). To keep the URL short, requests for the default locale are rewritten internally to work without a locale prefix.
 
@@ -313,17 +320,22 @@ Since your pages are nested within a `[locale]` folder, all routes are prefixed 
 - `/about` → `/en/about`
 - `/de/about` → `/de/about`
 
-When the user visits a route without an explicit locale, `next-intl` matches the [`accept-language` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) of the request against the available locales and optionally redirects the user to a prefixed route. The matched locale is saved in a cookie.
+#### Locale detection
 
-#### Changing locales
+The locale is detected based on these priorities:
 
-To change the locale, users can visit a prefixed route. This will always take precedence over a previously matched locale that is saved in a cookie or the `accept-language` header.
+1. A locale prefix is present in the pathname (e.g. `/de/about`)
+2. A cookie is present that contains a previously detected locale
+3. The [`accept-language` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) is matched against the available `locales`
+4. The `defaultLocale` is used
+
+To change the locale, users can visit a prefixed route. This will take precedence over a previously matched locale that is saved in a cookie or the `accept-language` header.
 
 **Example workflow:**
 
 1. A user requests `/` and based on the `accept-language` header, the `de` locale is matched.
 2. The `de` locale is saved in a cookie and the user is redirected to `/de`.
-3. In your app code, you render `<Link locale="en" href="/">Switch to English</Link>` to allow the user to change the locale to `en`.
+3. The app renders `<Link locale="en" href="/">Switch to English</Link>` to allow the user to change the locale to `en`.
 4. When the user clicks on the link, a request to `/en` is initiated.
 5. The middleware will update the cookie value to `en` and subsequently redirects the user to `/`.
 
@@ -343,7 +355,7 @@ export default createIntlMiddleware({
 
 In this case, requests without a prefix will be redirected accordingly (e.g. `/about` to `/en/about`).
 
-### Routing with domains
+### Domain-based routing
 
 If you want to serve your localized content based on different domains, you can provide a list of mappings between domains and locales to the middleware.
 
@@ -368,14 +380,13 @@ export default createIntlMiddleware({
       domain: 'us.example.com',
       defaultLocale: 'en',
       // Optionally restrict the locales managed by this domain. If this
-      // domain receives requests for other locales (e.g. us.example.com/fr),
-      // then the middleware will redirect to a domain that supports them.
+      // domain receives requests for another locale (e.g. us.example.com/fr),
+      // then the middleware will redirect to a domain that supports it.
       locales: ['en']
     },
     {
       domain: 'ca.example.com',
       defaultLocale: 'en'
-
       // If there are no `locales` specified on a domain,
       // all global locales will be supported here.
     }
@@ -383,30 +394,36 @@ export default createIntlMiddleware({
 });
 ```
 
-The middleware rewrites the requests internally, so that requests for the `defaultLocale` on a given domain work without a locale prefix (e.g. `us.example.com/about` → `/en/about`). If you want to include a prefix for the default locale as well, you can add `localePrefix: 'always'`.
+The middleware rewrites the requests internally, so that requests for the `defaultLocale` on a given domain work without a locale prefix (e.g. `us.example.com/about` → `/en/about`). If you want to include a prefix for the default locale as well, you can add [`localePrefix: 'always'`](#always-use-a-locale-prefix).
 
-The domain that is used to match the locale is read from the `x-forwarded-host` header, with a fallback to `host`.
+#### Locale detection
+
+To match the request against the available domains, the host is read from the `x-forwarded-host` header, with a fallback to `host`.
+
+The locale is detected based on these priorities:
+
+1. A locale prefix is present in the pathname and the domain supports it (e.g. `ca.example.com/fr`)
+2. If the host of the request is configured in `domains`, the `defaultLocale` of the domain is used
+3. As a fallback, the [locale detection of prefix-based routing](#locale-detection) applies
 
 <Callout>
 
-Note that if no domain matches an incoming request, prefix-based routing will be used. This can be useful, e.g. for local development where the host is `localhost`.
+Since unknown domains will be handled with [prefix-based routing](#prefix-based-routing-default), this strategy can be used for local development where the host is `localhost`.
 
 </Callout>
 
-#### Changing locales
-
-Since the middleware is aware of all your domains, `next-intl` will automatically switch the domain when the user requests to change the locale.
+Since the middleware is aware of all your domains, the domain will automatically be switched when the user requests to change the locale.
 
 **Example workflow:**
 
-1. The user is on `en.example.com`.
+1. The user requests `us.example.com` and based on the `defaultLocale` of this domain, the `en` locale is matched.
 2. The app renders `<Link locale="fr" href="/">Switch to French</Link>` to allow the user to change the locale to `fr`.
-3. When the link is clicked, a request to `en.example.com/fr` is initiated.
+3. When the link is clicked, a request to `us.example.com/fr` is initiated.
 4. The middleware recognizes that the user wants to switch to another domain and responds with a redirect to `ca.example.com/fr`.
 
 ### Alternate links
 
-`next-intl` automatically sets [the `link` header](https://developers.google.com/search/docs/specialty/international/localized-versions#http) to inform search engines that your content is available in different languages. Note that this automatically integrates with your routing strategy and will generate the correct links based on your configuration (`prefix` or `domain`).
+The middleware automatically sets [the `link` header](https://developers.google.com/search/docs/specialty/international/localized-versions#http) to inform search engines that your content is available in different languages. Note that this automatically integrates with your routing strategy and will generate the correct links based on your configuration.
 
 If you prefer to include these links yourself, you can opt-out of this behaviour.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,6 +1277,13 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
+  integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
 "@eslint/eslintrc@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.1.tgz#8b5e1c49f4077235516bc9ec7d41378c0f69b8c6"
@@ -3271,6 +3278,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/semver@^7.3.12":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
@@ -3322,6 +3334,13 @@
     regexpp "^3.2.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
+
+"@typescript-eslint/experimental-utils@^5.57.0":
+  version "5.57.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.57.1.tgz#da521391f16379b396896b120919c63f24fa78c2"
+  integrity sha512-5F5s8mpM1Y0RQ5iWzKQPQm5cmhARgcMfUwyHX1ZZFL8Tm0PyzyQ+9jgYSMaW74XXvpDg9/KdmMICLlwNwKtO7w==
+  dependencies:
+    "@typescript-eslint/utils" "5.57.1"
 
 "@typescript-eslint/parser@^4.20.0":
   version "4.27.0"
@@ -3395,6 +3414,14 @@
     "@typescript-eslint/types" "5.41.0"
     "@typescript-eslint/visitor-keys" "5.41.0"
 
+"@typescript-eslint/scope-manager@5.57.1":
+  version "5.57.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz#5d28799c0fc8b501a29ba1749d827800ef22d710"
+  integrity sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==
+  dependencies:
+    "@typescript-eslint/types" "5.57.1"
+    "@typescript-eslint/visitor-keys" "5.57.1"
+
 "@typescript-eslint/type-utils@5.15.0":
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.15.0.tgz#d2c02eb2bdf54d0a645ba3a173ceda78346cf248"
@@ -3432,6 +3459,11 @@
   version "5.41.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.41.0.tgz#6800abebc4e6abaf24cdf220fb4ce28f4ab09a85"
   integrity sha512-5BejraMXMC+2UjefDvrH0Fo/eLwZRV6859SXRg+FgbhA0R0l6lDqDGAQYhKbXhPN2ofk2kY5sgGyLNL907UXpA==
+
+"@typescript-eslint/types@5.57.1":
+  version "5.57.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.57.1.tgz#d9989c7a9025897ea6f0550b7036027f69e8a603"
+  integrity sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==
 
 "@typescript-eslint/typescript-estree@4.27.0":
   version "4.27.0"
@@ -3485,6 +3517,19 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.57.1":
+  version "5.57.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz#10d9643e503afc1ca4f5553d9bbe672ea4050b71"
+  integrity sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==
+  dependencies:
+    "@typescript-eslint/types" "5.57.1"
+    "@typescript-eslint/visitor-keys" "5.57.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/utils@5.15.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.13.0":
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.15.0.tgz#468510a0974d3ced8342f37e6c662778c277f136"
@@ -3508,6 +3553,20 @@
     "@typescript-eslint/typescript-estree" "5.17.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
+
+"@typescript-eslint/utils@5.57.1":
+  version "5.57.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.57.1.tgz#0f97b0bbd88c2d5e2036869f26466be5f4c69475"
+  integrity sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.57.1"
+    "@typescript-eslint/types" "5.57.1"
+    "@typescript-eslint/typescript-estree" "5.57.1"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
 
 "@typescript-eslint/visitor-keys@4.27.0":
   version "4.27.0"
@@ -3539,6 +3598,14 @@
   integrity sha512-vilqeHj267v8uzzakbm13HkPMl7cbYpKVjgFWZPIOHIJHZtinvypUhJ5xBXfWYg4eFKqztbMMpOgFpT9Gfx4fw==
   dependencies:
     "@typescript-eslint/types" "5.41.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.57.1":
+  version "5.57.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz#585e5fa42a9bbcd9065f334fd7c8a4ddfa7d905e"
+  integrity sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==
+  dependencies:
+    "@typescript-eslint/types" "5.57.1"
     eslint-visitor-keys "^3.3.0"
 
 "@vercel/analytics@0.1.11":
@@ -5519,6 +5586,15 @@ eslint-plugin-css-modules@^2.11.0:
   dependencies:
     gonzales-pe "^4.0.3"
     lodash "^4.17.2"
+
+eslint-plugin-deprecation@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.4.0.tgz#7c3194603cb7199ed7f3c4f12dae8db758835a71"
+  integrity sha512-ghFrjqdtwL4sUWjcmPu0J1HTXPDonFJLFdlPwzlvUMkoJNzR9R8Ua/J10mA4vFX9p1ggf/HWvmWBwew2XMTzmQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^5.57.0"
+    tslib "^2.3.1"
+    tsutils "^3.21.0"
 
 eslint-plugin-flowtype@^8.0.3:
   version "8.0.3"


### PR DESCRIPTION
**Changes:**
 - Allow domain-based routing to handle multiple locales (e.g. `ca.example.com/fr`)
 - Support `localePrefix` for domain-based routing
 - Handle unknown hosts like `localhost` gracefully with domain-based routing
 - Add `localeDetection: false` option
 - Improve matcher suggestion in docs

Please see the updated docs to learn more.