### PR TITLE
feat: BigInt support for useFormatter.format() (#222)

### DIFF
--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -130,7 +130,7 @@ export default function createFormatter({
   }
 
   function number(
-    value: number,
+    value: number | bigint,
     formatOrOptions?: string | NumberFormatOptions
   ) {
     return getFormattedValue(

--- a/packages/use-intl/test/core/createFormatter.test.tsx
+++ b/packages/use-intl/test/core/createFormatter.test.tsx
@@ -12,9 +12,23 @@ it('formats a date and time', () => {
 });
 
 it('formats a number', () => {
+  expect(intl.number(123456)).toBe('123,456');
+});
+
+it('formats a bigint', () => {
+  expect(intl.number(123456789123456789n)).toBe('123,456,789,123,456,789');
+});
+
+it('formats a number as currency', () => {
   expect(intl.number(123456.789, {style: 'currency', currency: 'USD'})).toBe(
     '$123,456.79'
   );
+});
+
+it('formats a bigint as currency', () => {
+  expect(
+    intl.number(123456789123456789n, {style: 'currency', currency: 'USD'})
+  ).toBe('$123,456,789,123,456,789.00');
 });
 
 it('formats a relative time', () => {

--- a/packages/use-intl/test/react/useFormatter.test.tsx
+++ b/packages/use-intl/test/react/useFormatter.test.tsx
@@ -191,7 +191,7 @@ describe('dateTime', () => {
 });
 
 describe('number', () => {
-  function renderNumber(value: number, options?: NumberFormatOptions) {
+  function renderNumber(value: number | bigint, options?: NumberFormatOptions) {
     function Component() {
       const format = useFormatter();
       return <>{format.number(value, options)}</>;
@@ -207,6 +207,11 @@ describe('number', () => {
   it('formats a number', () => {
     renderNumber(2948192329.12312);
     screen.getByText('2,948,192,329.123');
+  });
+
+  it('formats a bigint', () => {
+    renderNumber(123456789123456789n);
+    screen.getByText('123,456,789,123,456,789');
   });
 
   it('accepts options', () => {


### PR DESCRIPTION
Added a single `BigInt` test to each  `createFormatter` and `useFormatter`. I also noticed was no test for plain-old 'number' without currency. I thought it made sense to have one so I broke the existing test into two.

Closes #222 