### PR TITLE
docs: add multiple locales command tip

### DIFF
--- a/packages/website/pages/docs/faq.mdx
+++ b/packages/website/pages/docs/faq.mdx
@@ -9,7 +9,7 @@
 
 1. This library is built around the concept of namespaces and that components consume a single namespace (however this is not required).
 2. This library offers a hooks-only API for message consumption. The reason for this is that the same API can be used for attributes as well as `children`.
-3. This library currently doesn't support AST-based extraction like `react-intl`.
+3. This library currently doesn't support AST-based extraction like `react-intl`. You can easily [work with multiple locales](#can-next-intl-update-locale-files-based-on-default-locale-file) though.
 4. This library is a bit smaller in size ([next-intl](https://bundlephobia.com/result?p=next-intl) vs [react-intl](https://bundlephobia.com/result?p=react-intl) on BundlePhobia).
 5. This library offers [type safety for message keys](/docs/usage/typescript).
 
@@ -43,3 +43,12 @@ Yes, see [the Remix example](https://github.com/amannn/next-intl/tree/main/packa
 ## Can `next-intl` be used with [React Native](https://reactnative.dev/)?
 
 Yes, see [the React Native example](https://github.com/amannn/next-intl/tree/main/packages/example-react-native).
+
+## Can `next-intl` update locale files based on default locale file?
+No, but on Unix-based systems you can use this command:
+
+```bash
+sed 's/: "/: "TODO: /' en.json | cat - by.json | jq add -s
+```
+
+In this case it will merge `by.json` and default `en.json`. Existing translations in `by.json` won't be replaced, but new messages from default `en.json` will be added with `TODO:` prefix, so you can easily search for them later in the process of translation. You can modify the prefix to be whatever works for you!


### PR DESCRIPTION
I found an easy way to merge locale files, figured this might be useful to add to the docs.

## The problem
Suppose I have default `en.json` file, which I was updating when I was developing the application and getting Typescript auto-completions from it:
```json
{
  "ProductPage": {
    "description": "Description",
    "location": "Location: {location}"
  },
  "Header": {
    "navigation": {
      "themeSwitch": "Toggle dark mode",
      "newRental": "Add new rental",
      "bookings": "My bookings",
      "favorites": "Favorite rentals",
      "avatar": "My profile"
    }
  }
}
```

Now let's say my application also supports BY locale, but my `by.json` is incomplete yet:
```json
{
  "ProductPage": {
    "description": "Апiсанне",
    "location": "Месцазнаходжанне: {location}"
  }
}
```

Adding new messages to BY locale manually sucks. What if I had more locales? What if I had more messages? Here's a quick command that I came up with to merge JSON files and mark missing translations with TODO:
```bash
sed 's/: "/: "TODO: /' en.json | cat - by.json | jq add -s
```
![image](https://user-images.githubusercontent.com/51545008/228773653-3e140348-cb40-4757-b636-032df9a73427.png)

This is not ideal of course (doesn't work on windows, depends on `jq`), we could probably write a JS script for that (some `_.mapValues` + `_.defaults` combination), there are many ways to do it, but I just wanted to raise this to see if there's already a better solution for it? And if not we can think about other possible options