### PR TITLE
fix: invalid i18n warning

### DIFF
--- a/packages/next-intl/plugin.d.ts
+++ b/packages/next-intl/plugin.d.ts
@@ -1,3 +1,3 @@
 import {NextConfig} from 'next';
 
-export default function withNextIntl(i18nPath: string): ((config: NextConfig) => unknown);
+export default function withNextIntl(i18nPath?: string): ((config: NextConfig) => unknown);

--- a/packages/next-intl/plugin.js
+++ b/packages/next-intl/plugin.js
@@ -39,7 +39,7 @@ module.exports = withNextIntl({
     }
   }
 
-  if ('i18n' in nextConfig) {
+  if (nextConfig.i18n != null) {
     console.warn(
       "\nnext-intl has found an `i18n` config in your next.config.js. This likely causes conflicts and should therefore be removed if you use the React Server Components integration.\n\nIf you're in progress of migrating from the `pages` folder, you can refer to this example: https://github.com/amannn/next-intl/tree/feat/next-13-rsc/packages/example-next-13-with-pages\n"
     );


### PR DESCRIPTION
The default configuration object provided when [dynamically constructing](https://nextjs.org/docs/api-reference/next.config.js/introduction) the Next.js configuration sets the `i18n` property to `null`, this causes `withNextIntl` to incorrectly emit a warning about the use of Next.js' builtin `i18n` library.

Additionally `withNextIntl` incorrectly types the `i18nPath` as `string` when it should be `string | undefined`.