### PR TITLE
feat: add Intl.ListFormat to useFormatter

### DIFF
--- a/packages/use-intl/src/core/Formats.tsx
+++ b/packages/use-intl/src/core/Formats.tsx
@@ -4,6 +4,7 @@ import NumberFormatOptions from './NumberFormatOptions';
 type Formats = {
   number: Record<string, NumberFormatOptions>;
   dateTime: Record<string, DateTimeFormatOptions>;
+  list: Record<string, Intl.ListFormatOptions>;
 };
 
 export default Formats;

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -177,5 +177,17 @@ export default function createFormatter({
     }
   }
 
-  return {dateTime, number, relativeTime};
+	function list(
+    value: Iterable<string>,
+    formatOrOptions?: string | Intl.ListFormatOptions
+  ) {
+    return getFormattedValue(
+      value,
+      formatOrOptions,
+      formats?.list,
+      (options) => new Intl.ListFormat(locale, options).format(value)
+    );
+  }
+
+  return {dateTime, number, relativeTime, list};
 }

--- a/packages/use-intl/test/core/createFormatter.test.tsx
+++ b/packages/use-intl/test/core/createFormatter.test.tsx
@@ -39,3 +39,9 @@ it('formats a relative time', () => {
     )
   ).toBe('2 hours ago');
 });
+
+it('formats a list', () => {
+	expect(
+		intl.list(['apple', 'banana', 'orange'], {type: 'disjunction'})
+	).toBe('apple, banana, or orange');
+})


### PR DESCRIPTION
This adds a `list` method to `useFormatter()` to format lists with `Intl.ListFormat`.

closes #326