### PR TITLE
refactor: Remove experimental config for appDir and @next/font

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: 8.4.0
+          version: 8.6.0
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: 8.4.0
+          version: 8.6.0
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -9,9 +9,6 @@ const withNextra = require('nextra')({
 });
 
 module.exports = withNextra({
-  experimental: {
-    appDir: true
-  },
   redirects: () => [
     // Index pages
     {

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.17",
-    "@next/font": "^13.1.6",
     "@tailwindcss/typography": "^0.5.9",
     "clsx": "^1.2.1",
     "http-status-codes": "^2.2.0",

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,6 +1,6 @@
-import {Inter} from 'next/font/google';
 import Analytics from 'components/Analytics';
 import {AppProps} from 'next/app';
+import {Inter} from 'next/font/google';
 import {ReactNode} from 'react';
 import 'nextra-theme-docs/style.css';
 import '../styles.css';

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,4 +1,4 @@
-import {Inter} from '@next/font/google';
+import {Inter} from 'next/font/google';
 import Analytics from 'components/Analytics';
 import {AppProps} from 'next/app';
 import {ReactNode} from 'react';

--- a/examples/example-next-13-next-auth/next.config.js
+++ b/examples/example-next-13-next-auth/next.config.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/examples/example-next-13-next-auth/next.config.js
+++ b/examples/example-next-13-next-auth/next.config.js
@@ -1,3 +1,1 @@
-module.exports = {
-  experimental: {appDir: true}
-};
+module.exports = {};

--- a/examples/example-next-13/next.config.js
+++ b/examples/example-next-13/next.config.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/examples/example-next-13/next.config.js
+++ b/examples/example-next-13/next.config.js
@@ -1,3 +1,1 @@
-module.exports = {
-  experimental: {appDir: true}
-};
+module.exports = {};

--- a/examples/example-next-13/package.json
+++ b/examples/example-next-13/package.json
@@ -10,7 +10,6 @@
     "start": "next start"
   },
   "dependencies": {
-    "@next/font": "^13.1.6",
     "clsx": "^1.2.1",
     "next": "^13.4.0",
     "next-intl": "^2.14.3",

--- a/examples/example-next-13/src/app/[locale]/layout.tsx
+++ b/examples/example-next-13/src/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
-import {Inter} from 'next/font/google';
 import clsx from 'clsx';
+import {Inter} from 'next/font/google';
 import {notFound} from 'next/navigation';
 import {createTranslator, NextIntlClientProvider} from 'next-intl';
 import {ReactNode} from 'react';

--- a/examples/example-next-13/src/app/[locale]/layout.tsx
+++ b/examples/example-next-13/src/app/[locale]/layout.tsx
@@ -1,4 +1,4 @@
-import {Inter} from '@next/font/google';
+import {Inter} from 'next/font/google';
 import clsx from 'clsx';
 import {notFound} from 'next/navigation';
 import {createTranslator, NextIntlClientProvider} from 'next-intl';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 
@@ -30,7 +34,7 @@ importers:
         version: 2.2.0
       next:
         specifier: ^13.4.0
-        version: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
       nextra:
         specifier: ^2.4.2
         version: 2.4.2(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)
@@ -58,7 +62,7 @@ importers:
         version: 8.39.0
       eslint-config-molindo:
         specifier: ^6.0.0
-        version: 6.0.0(eslint@8.39.0)
+        version: 6.0.0(eslint@8.39.0)(jest@29.5.0)
       eslint-config-next:
         specifier: ^13.4.0
         version: 13.4.0(eslint@8.39.0)(typescript@4.9.5)
@@ -166,15 +170,12 @@ importers:
 
   examples/example-next-13:
     dependencies:
-      '@next/font':
-        specifier: ^13.1.6
-        version: 13.1.6
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
       next:
         specifier: ^13.4.0
-        version: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.0(react-dom@18.2.0)(react@18.2.0)
       next-intl:
         specifier: ^2.14.3
         version: link:../../packages/next-intl
@@ -208,7 +209,7 @@ importers:
         version: 8.39.0
       eslint-config-molindo:
         specifier: ^6.0.0
-        version: 6.0.0(eslint@8.39.0)(jest@29.5.0)
+        version: 6.0.0(eslint@8.39.0)
       eslint-config-next:
         specifier: ^13.4.0
         version: 13.4.0(eslint@8.39.0)(typescript@4.9.5)
@@ -7907,6 +7908,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
 
   /debug@4.3.4(supports-color@6.1.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -14983,7 +14985,7 @@ packages:
     resolution: {integrity: sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==}
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@6.1.0)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.0.6
       micromark-factory-space: 1.0.0
@@ -15505,7 +15507,7 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -15521,7 +15523,7 @@ packages:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.4.0
       minimist: 1.2.8
-      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
     dev: true
 
   /next-themes@0.2.1(next@13.4.0)(react-dom@18.2.0)(react@18.2.0):
@@ -15531,7 +15533,7 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -15623,6 +15625,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    dev: false
 
   /nextra-theme-docs@2.4.2(next@13.4.0)(nextra@2.4.2)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-5H6NJ38TlbgetNx9HjMmQcNpsp6GFH26TfjLVC0RWxhEPuoutSFpJ8RjWKXv6WEaWaL500CoErW0/DeXzuQGUg==}
@@ -15640,7 +15643,7 @@ packages:
       git-url-parse: 13.1.0
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
-      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
       next-seo: 6.0.0(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)
       nextra: 2.4.2(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)
@@ -15666,7 +15669,7 @@ packages:
       gray-matter: 4.0.3
       katex: 0.16.7
       lodash.get: 4.4.2
-      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
       next-mdx-remote: 4.4.1(react-dom@18.2.0)(react@18.2.0)
       p-limit: 3.1.0
       react: 18.2.0
@@ -19894,6 +19897,7 @@ packages:
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
+    dev: false
 
   /stylehacks@4.0.3:
     resolution: {integrity: sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@heroicons/react':
         specifier: ^2.0.17
         version: 2.0.17(react@18.2.0)
-      '@next/font':
-        specifier: ^13.1.6
-        version: 13.1.6
       '@tailwindcss/typography':
         specifier: ^0.5.9
         version: 0.5.9(tailwindcss@3.2.4)
@@ -34,7 +31,7 @@ importers:
         version: 2.2.0
       next:
         specifier: ^13.4.0
-        version: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.0(react-dom@18.2.0)(react@18.2.0)
       nextra:
         specifier: ^2.4.2
         version: 2.4.2(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)
@@ -62,7 +59,7 @@ importers:
         version: 8.39.0
       eslint-config-molindo:
         specifier: ^6.0.0
-        version: 6.0.0(eslint@8.39.0)(jest@29.5.0)
+        version: 6.0.0(eslint@8.39.0)
       eslint-config-next:
         specifier: ^13.4.0
         version: 13.4.0(eslint@8.39.0)(typescript@4.9.5)
@@ -3418,10 +3415,6 @@ packages:
     dependencies:
       glob: 7.1.7
     dev: true
-
-  /@next/font@13.1.6:
-    resolution: {integrity: sha512-AITjmeb1RgX1HKMCiA39ztx2mxeAyxl4ljv2UoSBUGAbFFMg8MO7YAvjHCgFhD39hL7YTbFjol04e/BPBH5RzQ==}
-    dev: false
 
   /@next/swc-darwin-arm64@13.4.0:
     resolution: {integrity: sha512-C39AGL3ANXA+P3cFclQjFZaJ4RHPmuBhskmyy0N3VyCntDmRrNkS4aXeNY4Xwure9IL1nuw02D8bM55I+FsbuQ==}
@@ -7908,7 +7901,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /debug@4.3.4(supports-color@6.1.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -14985,7 +14977,7 @@ packages:
     resolution: {integrity: sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==}
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.3.4(supports-color@6.1.0)
+      debug: 4.3.4
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.0.6
       micromark-factory-space: 1.0.0
@@ -15507,7 +15499,7 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      next: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -15523,7 +15515,7 @@ packages:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.4.0
       minimist: 1.2.8
-      next: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
     dev: true
 
   /next-themes@0.2.1(next@13.4.0)(react-dom@18.2.0)(react@18.2.0):
@@ -15533,7 +15525,7 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -15625,7 +15617,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    dev: false
 
   /nextra-theme-docs@2.4.2(next@13.4.0)(nextra@2.4.2)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-5H6NJ38TlbgetNx9HjMmQcNpsp6GFH26TfjLVC0RWxhEPuoutSFpJ8RjWKXv6WEaWaL500CoErW0/DeXzuQGUg==}
@@ -15643,7 +15634,7 @@ packages:
       git-url-parse: 13.1.0
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
-      next: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
       next-seo: 6.0.0(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)
       nextra: 2.4.2(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)
@@ -15669,7 +15660,7 @@ packages:
       gray-matter: 4.0.3
       katex: 0.16.7
       lodash.get: 4.4.2
-      next: 13.4.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
       next-mdx-remote: 4.4.1(react-dom@18.2.0)(react@18.2.0)
       p-limit: 3.1.0
       react: 18.2.0
@@ -19897,7 +19888,6 @@ packages:
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
-    dev: false
 
   /stylehacks@4.0.3:
     resolution: {integrity: sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==}


### PR DESCRIPTION
Changes:
- Removed experimental config for appDir because starting from nextjs v13.4, this feature is stable (for now in the console at development mode we have some warns about that this config is necessary but it was fixed in the latest version of nextjs),
- Removed the `@next/font` package since it is now built into nextjs itself.