### PR TITLE
Fix: small typo that breaks a link

### DIFF
--- a/docs/pages/docs/usage/dates-times.mdx
+++ b/docs/pages/docs/usage/dates-times.mdx
@@ -7,7 +7,7 @@ The formatting of dates and times varies greatly between locales (e.g. "Apr 24, 
 
 <Callout>
 
-If you're formatting dates and times, you should [set up a global time zone](#/docs/usage/configuration#time-zone).
+If you're formatting dates and times, you should [set up a global time zone](/docs/usage/configuration#time-zone).
 
 </Callout>
 


### PR DESCRIPTION
```diff
- If you're formatting dates and times, you should [set up a global time zone](#/docs/usage/configuration#time-zone).
+ If you're formatting dates and times, you should [set up a global time zone](/docs/usage/configuration#time-zone).
```