### PR TITLE
fix: public pages matcher in middleware

### DIFF
--- a/docs/pages/docs/next-13/middleware.mdx
+++ b/docs/pages/docs/next-13/middleware.mdx
@@ -276,7 +276,9 @@ const authMiddleware = withAuth(
 
 export default function middleware(req: NextRequest) {
   const publicPathnameRegex = RegExp(
-    `^(/(${locales.join('|')}))?(${publicPages.join('|')})?/?$`,
+    `^(/(${locales.join('|')}))?(${publicPages.join('|')})${
+      publicPages.includes("/") ? "?" : "+"
+    }/?$`,
     'i'
   );
   const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);


### PR DESCRIPTION
I found that when "/" is not included in the public pages, the regex would not work.