### PR TITLE
feat: Add `useLanguageDirection` hook

### DIFF
--- a/docs/pages/docs/usage/configuration.mdx
+++ b/docs/pages/docs/usage/configuration.mdx
@@ -142,3 +142,45 @@ function Component() {
   const timeZone = useTimeZone();
 }
 ```
+
+{/* useLanguageDirection */}
+## Language direction
+
+Sometimes it is necessary to know the direction of the current language, e.g. to apply the correct direction to the `html` element. This can be done with the `useLanguageDirection` hook:
+
+```tsx {2,6,9} filename="app/layout.tsx"
+import {useLocale} from 'next-intl';
+import {useLanguageDirection} from 'next-intl';
+
+export default function Layout({children, params}) {
+  const locale = useLocale();
+  const direction = useLanguageDirection(locale); // 'ltr' or 'rtl'
+  // ...
+  return (
+    <html lang={locale} dir={direction}>
+      <body>
+        {children}
+      </body>
+    </html>
+  );
+}
+```
+
+Or maybe you want to render a different icon depending on the language direction:
+
+```tsx {1,5,10} filename="components/BreadCrumb.tsx"
+import {useLanguageDirection} from 'next-intl';
+// ...
+
+export default function BreadCrumb({children, params}) {
+  const direction = useLanguageDirection();
+
+  return (
+    <div className={direction === 'ltr' ? 'text-left' : 'text-right'}>
+      <span>Docs</span>
+      <span>{direction === 'ltr' ? <ArrowRight /> : <ArrowLeft />}</span>
+      <span>Global Configuration</span>
+    </div>
+  );
+}
+```

--- a/docs/pages/docs/usage/configuration.mdx
+++ b/docs/pages/docs/usage/configuration.mdx
@@ -149,8 +149,7 @@ function Component() {
 Sometimes it is necessary to know the direction of the current language, e.g. to apply the correct direction to the `html` element. This can be done with the `useLanguageDirection` hook:
 
 ```tsx {2,6,9} filename="app/layout.tsx"
-import {useLocale} from 'next-intl';
-import {useLanguageDirection} from 'next-intl';
+import {useLocale, useLanguageDirection} from 'next-intl';
 
 export default function Layout({children, params}) {
   const locale = useLocale();

--- a/examples/example-next-13-next-auth/src/app/layout.tsx
+++ b/examples/example-next-13-next-auth/src/app/layout.tsx
@@ -1,12 +1,17 @@
 import {ReactNode} from 'react';
+import {useLocale, useLanguageDirection} from 'next-intl';
 
 type Props = {
   children: ReactNode;
 };
 
-// Even though this component is just passing its children through, the presence
-// of this file fixes an issue in Next.js 13.3.0 where link clicks that switch
-// the locale would otherwise be ignored.
-export default function RootLayout({children}: Props) {
-  return children;
+export default function Layout({children}: Props) {
+  const locale = useLocale();
+  const direction = useLanguageDirection(locale); // 'ltr' or 'rtl'
+
+  return (
+    <html lang={locale} dir={direction}>
+      <body>{children}</body>
+    </html>
+  );
 }

--- a/examples/example-next-13/src/app/layout.tsx
+++ b/examples/example-next-13/src/app/layout.tsx
@@ -1,13 +1,19 @@
 import {ReactNode} from 'react';
 import './styles.css';
 
+import {useLocale, useLanguageDirection} from 'next-intl';
+
 type Props = {
   children: ReactNode;
 };
 
-// Even though this component is just passing its children through, the presence
-// of this file fixes an issue in Next.js 13.4 where link clicks that switch
-// the locale would otherwise cause a full reload.
-export default function RootLayout({children}: Props) {
-  return children;
+export default function Layout({children}: Props) {
+  const locale = useLocale();
+  const direction = useLanguageDirection(locale); // 'ltr' or 'rtl'
+
+  return (
+    <html lang={locale} dir={direction}>
+      <body>{children}</body>
+    </html>
+  );
 }

--- a/packages/next-intl/src/react-server/index.tsx
+++ b/packages/next-intl/src/react-server/index.tsx
@@ -24,6 +24,7 @@ export const IntlProvider = notSupported;
 export const useTranslations = notSupported;
 export const useIntl = notSupported;
 export const useLocale = notSupported;
+export const useLanguageDirection = notSupported;
 export const useNow = notSupported;
 export const useTimeZone = notSupported;
 export const Link = notSupported;

--- a/packages/use-intl/src/react/index.tsx
+++ b/packages/use-intl/src/react/index.tsx
@@ -1,6 +1,7 @@
 export {default as IntlProvider} from './IntlProvider';
 export {default as useTranslations} from './useTranslations';
 export {default as useLocale} from './useLocale';
+export {default as useLanguageDirection} from './useLanguageDirection';
 export {default as useNow} from './useNow';
 export {default as useTimeZone} from './useTimeZone';
 export {default as useFormatter} from './useFormatter';

--- a/packages/use-intl/src/react/useLanguageDirection.tsx
+++ b/packages/use-intl/src/react/useLanguageDirection.tsx
@@ -1,0 +1,22 @@
+import useIntlContext from './useIntlContext';
+
+export default function useLanguageDirection(): 'ltr' | 'rtl' {
+  // We split the locale at the first dash to support locales such as `en-US` to be detected as `en`.
+  const locale = useIntlContext().locale.split('-')[0];
+
+  const rtlLanguages = [
+    'ar', // Arabic
+    'he', // Hebrew
+    'fa', // Persian
+    'ur', // Urdu
+    'ps', // Pashto
+    'yi', // Yiddish
+    'dv', // Divehi
+    'ku', // Kurdish
+    'sd', // Sindhi
+    'ckb', // Central Kurdish
+    'ug' // Uyghur
+  ];
+
+  return rtlLanguages.includes(locale) ? 'rtl' : 'ltr';
+}

--- a/packages/use-intl/test/react/useLanguageDirection.test.tsx
+++ b/packages/use-intl/test/react/useLanguageDirection.test.tsx
@@ -1,0 +1,20 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+import {IntlProvider, useLanguageDirection} from '../../src';
+
+// Test rtl language like Arabic
+it('returns the language direction', () => {
+  function Component() {
+    return <>{useLanguageDirection()}</>;
+  }
+
+  render(
+    <IntlProvider locale="ar">
+      <Component />
+    </IntlProvider>
+  );
+
+  screen.getByText('rtl');
+});
+
+

--- a/packages/use-intl/test/react/useLanguageDirection.test.tsx
+++ b/packages/use-intl/test/react/useLanguageDirection.test.tsx
@@ -17,4 +17,47 @@ it('returns the language direction', () => {
   screen.getByText('rtl');
 });
 
+// Test ltr language like English
+it('returns the language direction', () => {
+  function Component() {
+    return <>{useLanguageDirection()}</>;
+  }
 
+  render(
+    <IntlProvider locale="en">
+      <Component />
+    </IntlProvider>
+  );
+
+  screen.getByText('ltr');
+});
+
+// Test ltr language like English with region "en-US"
+it('returns the language direction', () => {
+  function Component() {
+    return <>{useLanguageDirection()}</>;
+  }
+
+  render(
+    <IntlProvider locale="en-US">
+      <Component />
+    </IntlProvider>
+  );
+
+  screen.getByText('ltr');
+});
+
+// Test rtl language like Arabic with region "ar-SA"
+it('returns the language direction', () => {
+  function Component() {
+    return <>{useLanguageDirection()}</>;
+  }
+
+  render(
+    <IntlProvider locale="ar-SA">
+      <Component />
+    </IntlProvider>
+  );
+
+  screen.getByText('rtl');
+});


### PR DESCRIPTION
This PR adds a new hook `useLanguageDirection` that returns the direction of the current locale; `ltr` or `rtl`. There are too many use cases for this hook, like setting html dir attribute, styling components based on the direction, etc. 

This PR also adds documentation, examples, and tests for the new hook.

The `useLanguageDirection` name is NOT final, it can be changed if there is a better name. such as `useDirection`, `useLangDirection`, `useLocaleDirection`, etc.