### PR TITLE
fix(Next.js 13 RSC): Fix types when importing from `next-intl/server` with `moduleResolution: "node16"`

### DIFF
--- a/packages/next-intl/src/server/index.tsx
+++ b/packages/next-intl/src/server/index.tsx
@@ -33,6 +33,7 @@ Importing \`createMiddleware\` from \`next-intl/server\` is deprecated. Please u
   });
 }
 
+// Must match `./react-client/index.tsx`
 export {default as getRequestConfig} from './getRequestConfig';
 export {default as getIntl} from './getIntl';
 export {default as getFormatter} from './getFormatter';

--- a/packages/next-intl/src/server/react-client/index.tsx
+++ b/packages/next-intl/src/server/react-client/index.tsx
@@ -1,14 +1,39 @@
+import type {
+  getRequestConfig as getRequestConfig_type,
+  getIntl as getIntl_type,
+  getFormatter as getFormatter_type,
+  getLocale as getLocale_type,
+  getNow as getNow_type,
+  getTimeZone as getTimeZone_type,
+  getTranslations as getTranslations_type,
+  getTranslator as getTranslator_type,
+  getMessages as getMessages_type
+} from '..';
+
 function notSupported(name: string) {
   throw new Error(`\`${name}\` is not supported in Client Components.`);
 }
 
-export const getRequestConfig = notSupported('getRequestConfig');
-export const getIntl = notSupported('getIntl');
-export const getFormatter = notSupported('getFormatter');
-export const getLocale = notSupported('getLocale');
-export const getNow = notSupported('getNow');
-export const getTimeZone = notSupported('getTimeZone');
-export const getTranslations = notSupported('getTranslations');
+// Must match `../index.tsx`
+
+// prettier-ignore
+export const getRequestConfig = notSupported('getRequestConfig') as unknown as typeof getRequestConfig_type;
+// prettier-ignore
+export const getIntl = notSupported('getIntl') as unknown as typeof getIntl_type;
+// prettier-ignore
+export const getFormatter = notSupported('getFormatter') as unknown as typeof getFormatter_type;
+// prettier-ignore
+export const getLocale = notSupported('getLocale') as unknown as typeof getLocale_type;
+// prettier-ignore
+export const getNow = notSupported('getNow') as unknown as typeof getNow_type;
+// prettier-ignore
+export const getTimeZone = notSupported('getTimeZone') as unknown as typeof getTimeZone_type;
+// prettier-ignore
+export const getTranslations = notSupported('getTranslations') as unknown as typeof getTranslations_type;
+// prettier-ignore
+export const getTranslator = notSupported('getTranslator') as unknown as typeof getTranslator_type;
+// prettier-ignore
+export const getMessages = notSupported('getMessages') as unknown as typeof getMessages_type;
 
 // TODO: Since this is available in Client Comonents too, we should really
 // consider exporting this from `next-intl/navigation` instead. For now, for


### PR DESCRIPTION
Fixes #347
Fixes #360 