### PR TITLE
feat: add next-intl/link to be used in locale switcher in next 13 example

### DIFF
--- a/examples/example-next-13-next-auth/src/components/LocaleSwitcher.tsx
+++ b/examples/example-next-13-next-auth/src/components/LocaleSwitcher.tsx
@@ -1,13 +1,15 @@
-import Link from 'next/link';
+import Link from 'next-intl/link';
 import {useLocale, useTranslations} from 'next-intl';
+import {usePathname} from 'next-intl/client';
 
 export default function LocaleSwitcher() {
   const t = useTranslations('LocaleSwitcher');
   const locale = useLocale();
   const otherLocale = locale === 'en' ? 'de' : 'en';
+  const pathname = usePathname();
 
   return (
-    <Link href={'/' + otherLocale} prefetch={false}>
+    <Link href={pathname} locale={otherLocale}>
       {t('switchLocale', {locale: otherLocale})}
     </Link>
   );

--- a/examples/example-next-13-next-auth/src/components/LocaleSwitcher.tsx
+++ b/examples/example-next-13-next-auth/src/components/LocaleSwitcher.tsx
@@ -1,6 +1,6 @@
-import Link from 'next-intl/link';
 import {useLocale, useTranslations} from 'next-intl';
 import {usePathname} from 'next-intl/client';
+import Link from 'next-intl/link';
 
 export default function LocaleSwitcher() {
   const t = useTranslations('LocaleSwitcher');


### PR DESCRIPTION
 improves locale switcher by making use of next-intl/link to be able to switch without losing current page