### PR TITLE
fix: Detect host and protocol for alternate links correctly when running behind a proxy

### DIFF
--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -5,7 +5,7 @@ import MiddlewareConfig, {
 import {isLocaleSupportedOnDomain} from './utils';
 
 function getUnprefixedUrl(config: MiddlewareConfig, request: NextRequest) {
-  const url = new URL(request.url);
+  const url = request.nextUrl.clone();
   if (!url.pathname.endsWith('/')) {
     url.pathname += '/';
   }

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -7,6 +7,8 @@ import {getHost, isLocaleSupportedOnDomain} from './utils';
 function getUnprefixedUrl(config: MiddlewareConfig, request: NextRequest) {
   const url = new URL(request.url);
   url.host = getHost(request.headers) ?? url.host;
+  url.protocol = request.headers.get('x-forwarded-proto') ?? url.protocol;
+
   if (!url.pathname.endsWith('/')) {
     url.pathname += '/';
   }

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -2,10 +2,11 @@ import {NextRequest} from 'next/server';
 import MiddlewareConfig, {
   MiddlewareConfigWithDefaults
 } from './NextIntlMiddlewareConfig';
-import {isLocaleSupportedOnDomain} from './utils';
+import {getHost, isLocaleSupportedOnDomain} from './utils';
 
 function getUnprefixedUrl(config: MiddlewareConfig, request: NextRequest) {
-  const url = request.nextUrl.clone();
+  const url = new URL(request.url);
+  url.host = getHost(request.headers) ?? url.host;
   if (!url.pathname.endsWith('/')) {
     url.pathname += '/';
   }

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -7,7 +7,6 @@ import getAlternateLinksHeaderValue from './getAlternateLinksHeaderValue';
 import resolveLocale from './resolveLocale';
 import {
   getBestMatchingDomain,
-  getHost,
   getLocaleFromPathname,
   isLocaleSupportedOnDomain
 } from './utils';
@@ -33,9 +32,6 @@ export default function createMiddleware(config: MiddlewareConfig) {
   const matcher: Array<string> | undefined = (config as any)._matcher;
 
   return function middleware(request: NextRequest) {
-    // if Next.js behind a reverse proxy, it cannot get the correct host. ex) localhost, 172.x.x.x
-    // We need to set the host here, because Next.js doesn't do it for us
-    request.nextUrl.host = getHost(request.headers) ?? request.nextUrl.host;
     const matches =
       !matcher ||
       matcher.some((pattern) => request.nextUrl.pathname.match(pattern));

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -68,10 +68,7 @@ export default function createMiddleware(config: MiddlewareConfig) {
     }
 
     function rewrite(url: string) {
-      return NextResponse.rewrite(
-        new URL(url, request.nextUrl.href),
-        getResponseInit()
-      );
+      return NextResponse.rewrite(new URL(url, request.url), getResponseInit());
     }
 
     function next() {
@@ -79,7 +76,7 @@ export default function createMiddleware(config: MiddlewareConfig) {
     }
 
     function redirect(url: string, host?: string) {
-      const urlObj = new URL(url, request.nextUrl.href);
+      const urlObj = new URL(url, request.url);
 
       if (domainConfigs.length > 0) {
         if (!host) {

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -189,7 +189,7 @@ it("works for type domain with `localePrefix: 'always'`", () => {
   ]);
 });
 
-it('use the external host name from headers instead of the url of the incoming request (relevant when running the app behind a proxy)', () => {
+it('uses the external host name from headers instead of the url of the incoming request (relevant when running the app behind a proxy)', () => {
   const config: MiddlewareConfigWithDefaults = {
     defaultLocale: 'en',
     locales: ['en', 'es'],

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -1,13 +1,7 @@
 import {NextRequest} from 'next/server';
-import {expect, it} from 'vitest';
+import {it, expect} from 'vitest';
 import {MiddlewareConfigWithDefaults} from '../../src/middleware/NextIntlMiddlewareConfig';
 import getAlternateLinksHeaderValue from '../../src/middleware/getAlternateLinksHeaderValue';
-
-function getRequest(url = 'https://internal-url.com/') {
-  return new NextRequest(url, {
-    headers: {host: 'example.com', 'x-forwarded-host': 'example.com'}
-  });
-}
 
 it('works for prefixed routing (as-needed)', () => {
   const config: MiddlewareConfigWithDefaults = {
@@ -19,7 +13,10 @@ it('works for prefixed routing (as-needed)', () => {
   };
 
   expect(
-    getAlternateLinksHeaderValue(config, getRequest()).split(', ')
+    getAlternateLinksHeaderValue(
+      config,
+      new NextRequest('https://example.com/')
+    ).split(', ')
   ).toEqual([
     '<https://example.com/>; rel="alternate"; hreflang="en"',
     '<https://example.com/es>; rel="alternate"; hreflang="es"',
@@ -29,7 +26,7 @@ it('works for prefixed routing (as-needed)', () => {
   expect(
     getAlternateLinksHeaderValue(
       config,
-      getRequest('https://example.com/about')
+      new NextRequest('https://example.com/about')
     ).split(', ')
   ).toEqual([
     '<https://example.com/about>; rel="alternate"; hreflang="en"',
@@ -48,7 +45,10 @@ it('works for prefixed routing (always)', () => {
   };
 
   expect(
-    getAlternateLinksHeaderValue(config, getRequest()).split(', ')
+    getAlternateLinksHeaderValue(
+      config,
+      new NextRequest('https://example.com/')
+    ).split(', ')
   ).toEqual([
     '<https://example.com/en>; rel="alternate"; hreflang="en"',
     '<https://example.com/es>; rel="alternate"; hreflang="es"',
@@ -58,7 +58,7 @@ it('works for prefixed routing (always)', () => {
   expect(
     getAlternateLinksHeaderValue(
       config,
-      getRequest('https://example.com/about')
+      new NextRequest('https://example.com/about')
     ).split(', ')
   ).toEqual([
     '<https://example.com/en/about>; rel="alternate"; hreflang="en"',
@@ -94,10 +94,13 @@ it("works for type domain with `localePrefix: 'as-needed'`", () => {
   };
 
   [
-    getAlternateLinksHeaderValue(config, getRequest()).split(', '),
     getAlternateLinksHeaderValue(
       config,
-      getRequest('https://example.es/')
+      new NextRequest('https://example.com/')
+    ).split(', '),
+    getAlternateLinksHeaderValue(
+      config,
+      new NextRequest('https://example.es/')
     ).split(', ')
   ].forEach((links) => {
     expect(links).toEqual([
@@ -113,7 +116,7 @@ it("works for type domain with `localePrefix: 'as-needed'`", () => {
   expect(
     getAlternateLinksHeaderValue(
       config,
-      getRequest('https://example.com/about')
+      new NextRequest('https://example.com/about')
     ).split(', ')
   ).toEqual([
     '<https://example.com/about>; rel="alternate"; hreflang="en"',
@@ -152,10 +155,13 @@ it("works for type domain with `localePrefix: 'always'`", () => {
   };
 
   [
-    getAlternateLinksHeaderValue(config, getRequest()).split(', '),
     getAlternateLinksHeaderValue(
       config,
-      getRequest('https://example.es/')
+      new NextRequest('https://example.com/')
+    ).split(', '),
+    getAlternateLinksHeaderValue(
+      config,
+      new NextRequest('https://example.es/')
     ).split(', ')
   ].forEach((links) => {
     expect(links).toEqual([
@@ -171,7 +177,7 @@ it("works for type domain with `localePrefix: 'always'`", () => {
   expect(
     getAlternateLinksHeaderValue(
       config,
-      getRequest('https://example.com/about')
+      new NextRequest('https://example.com/about')
     ).split(', ')
   ).toEqual([
     '<https://example.com/en/about>; rel="alternate"; hreflang="en"',
@@ -180,5 +186,32 @@ it("works for type domain with `localePrefix: 'always'`", () => {
     '<https://example.es/es/about>; rel="alternate"; hreflang="es"',
     '<https://example.com/fr/about>; rel="alternate"; hreflang="fr"',
     '<https://example.ca/fr/about>; rel="alternate"; hreflang="fr"'
+  ]);
+});
+
+it('use the external host name from headers instead of the url of the incoming request (relevant when running the app behind a proxy)', () => {
+  const config: MiddlewareConfigWithDefaults = {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+    alternateLinks: true,
+    localePrefix: 'as-needed',
+    localeDetection: true
+  };
+
+  expect(
+    getAlternateLinksHeaderValue(
+      config,
+      new NextRequest('http://127.0.0.1/about', {
+        headers: {
+          host: 'example.com',
+          'x-forwarded-host': 'example.com',
+          'x-forwarded-proto': 'https'
+        }
+      })
+    ).split(', ')
+  ).toEqual([
+    '<https://example.com/about>; rel="alternate"; hreflang="en"',
+    '<https://example.com/es/about>; rel="alternate"; hreflang="es"',
+    '<https://example.com/about>; rel="alternate"; hreflang="x-default"'
   ]);
 });

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -3,8 +3,10 @@ import {expect, it} from 'vitest';
 import {MiddlewareConfigWithDefaults} from '../../src/middleware/NextIntlMiddlewareConfig';
 import getAlternateLinksHeaderValue from '../../src/middleware/getAlternateLinksHeaderValue';
 
-function getRequest(url = 'https://example.com/') {
-  return new NextRequest(url);
+function getRequest(url = 'https://internal-url.com/') {
+  return new NextRequest(url, {
+    headers: {host: 'example.com', 'x-forwarded-host': 'example.com'}
+  });
 }
 
 it('works for prefixed routing (as-needed)', () => {

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -1,10 +1,10 @@
 import {NextRequest} from 'next/server';
-import {it, expect} from 'vitest';
+import {expect, it} from 'vitest';
 import {MiddlewareConfigWithDefaults} from '../../src/middleware/NextIntlMiddlewareConfig';
 import getAlternateLinksHeaderValue from '../../src/middleware/getAlternateLinksHeaderValue';
 
 function getRequest(url = 'https://example.com/') {
-  return {url} as NextRequest;
+  return new NextRequest(url);
 }
 
 it('works for prefixed routing (as-needed)', () => {


### PR DESCRIPTION
We are currently utilizing a reverse proxy in front of Next.js.
`request.url` is returning an internal address instead of an external one.
Consequently, the rewrite functionality is not behaving as expected, and the `alternatelink` header is inadvertently exposing the internal address.