### PR TITLE
Feat: Export localized pathnames link props Typescript helper

### DIFF
--- a/packages/next-intl/src/navigation/createLocalizedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/createLocalizedPathnamesNavigation.tsx
@@ -15,13 +15,16 @@ import {
   HrefOrUrlObjectWithParams
 } from './utils';
 
-export type LocalizedPathnamesLinkProps<Pathname extends keyof Pathnames<Locales>> = Omit<
+export type LocalizedPathnamesLinkProps<
+  Locales extends AllLocales,
+  Pathname extends keyof Pathnames<Locales>
+> = Omit<
   ComponentProps<typeof BaseLink>,
   'href' | 'name'
 > & {
   href: HrefOrUrlObjectWithParams<Pathname>;
   locale?: Locales[number];
-}
+};
 
 export default function createLocalizedPathnamesNavigation<
   Locales extends AllLocales,
@@ -31,7 +34,13 @@ export default function createLocalizedPathnamesNavigation<
     return useLocale() as (typeof locales)[number];
   }
 
-  type LinkProps<Pathname extends keyof PathnamesConfig> = LocalizedPathnamesLinkProps<Pathname>;
+  type LinkProps<Pathname extends keyof PathnamesConfig> = Omit<
+    ComponentProps<typeof BaseLink>,
+    'href' | 'name'
+  > & {
+    href: HrefOrUrlObjectWithParams<Pathname>;
+    locale?: Locales[number];
+  };
   function Link<Pathname extends keyof PathnamesConfig>(
     {href, locale, ...rest}: LinkProps<Pathname>,
     ref?: ComponentProps<typeof BaseLink>['ref']

--- a/packages/next-intl/src/navigation/createLocalizedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/createLocalizedPathnamesNavigation.tsx
@@ -15,6 +15,14 @@ import {
   HrefOrUrlObjectWithParams
 } from './utils';
 
+export type LocalizedPathnamesLinkProps<Pathname extends keyof Pathnames<Locales>> = Omit<
+  ComponentProps<typeof BaseLink>,
+  'href' | 'name'
+> & {
+  href: HrefOrUrlObjectWithParams<Pathname>;
+  locale?: Locales[number];
+}
+
 export default function createLocalizedPathnamesNavigation<
   Locales extends AllLocales,
   PathnamesConfig extends Pathnames<Locales>
@@ -23,13 +31,7 @@ export default function createLocalizedPathnamesNavigation<
     return useLocale() as (typeof locales)[number];
   }
 
-  type LinkProps<Pathname extends keyof PathnamesConfig> = Omit<
-    ComponentProps<typeof BaseLink>,
-    'href' | 'name'
-  > & {
-    href: HrefOrUrlObjectWithParams<Pathname>;
-    locale?: Locales[number];
-  };
+  type LinkProps<Pathname extends keyof PathnamesConfig> = LocalizedPathnamesLinkProps<Pathname>;
   function Link<Pathname extends keyof PathnamesConfig>(
     {href, locale, ...rest}: LinkProps<Pathname>,
     ref?: ComponentProps<typeof BaseLink>['ref']

--- a/packages/next-intl/src/navigation/index.tsx
+++ b/packages/next-intl/src/navigation/index.tsx
@@ -1,4 +1,4 @@
-export {default as createLocalizedPathnamesNavigation} from './createLocalizedPathnamesNavigation';
+export {default as createLocalizedPathnamesNavigation, LocalizedPathnamesLinkProps} from './createLocalizedPathnamesNavigation';
 export {Pathnames} from '../shared/types';
 
 // TODO: Possibly release after RFC


### PR DESCRIPTION
## Feat: Export localized pathnames link props Typescript helper

```ts
import { createLocalizedPathnamesNavigation, LocalizedPathnamesLinkProps } from 'next-intl/navigation'

const pathnames = {
  ...
}

const { Link } = createLocalizedPathnamesNavigation({ ..., pathnames })

type LinkProps = LocalizedPathnamesLinkProps<keyof typeof pathnames>
```


<img width="1391" alt="Screenshot 2023-08-31 at 23 08 42" src="https://github.com/amannn/next-intl/assets/69924001/f7d05a54-e35b-42ad-8289-49fc9ea4585e">

<img width="466" alt="Screenshot 2023-08-31 at 23 07 59" src="https://github.com/amannn/next-intl/assets/69924001/940acc12-dfed-48a6-8d7f-a919b1daddb4">
