### PR TITLE
docs: Update next-auth docs to narrow matcher regex

### DIFF
--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -362,7 +362,7 @@ const authMiddleware = withAuth(
 
 export default function middleware(req: NextRequest) {
   const publicPathnameRegex = RegExp(
-    `^(/(${locales.join('|')}))?(${publicPages.join('|')})?/?$`,
+    `^(/(${locales.join('|')}))?(${publicPages.join('|')})/?$`,
     'i'
   );
   const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);

--- a/examples/example-next-13-next-auth/src/middleware.tsx
+++ b/examples/example-next-13-next-auth/src/middleware.tsx
@@ -31,7 +31,7 @@ const authMiddleware = withAuth(
 
 export default function middleware(req: NextRequest) {
   const publicPathnameRegex = RegExp(
-    `^(/(${locales.join('|')}))?(${publicPages.join('|')})?/?$`,
+    `^(/(${locales.join('|')}))?(${publicPages.join('|')})/?$`,
     'i'
   );
   const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);


### PR DESCRIPTION
Currently the regex marks the index route `/` as public even if it's not included in the public pages array. Making the page a required component ensures this won't happen.