### PR TITLE
fix(RSC): Always read header in RSC render

### DIFF
--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -119,20 +119,9 @@ export default function createMiddleware<Locales extends AllLocales>(
     const hasUnknownHost = configWithDefaults.domains != null && !domain;
 
     function getResponseInit() {
-      const responseInit = {
-        request: {
-          headers: request.headers
-        }
-      };
-
-      if (hasOutdatedCookie) {
-        responseInit.request.headers = new Headers(
-          responseInit.request.headers
-        );
-        responseInit.request.headers.set(HEADER_LOCALE_NAME, locale);
-      }
-
-      return responseInit;
+      const headers = new Headers(request.headers);
+      headers.set(HEADER_LOCALE_NAME, locale);
+      return {request: {headers}};
     }
 
     function rewrite(url: string) {

--- a/packages/next-intl/src/server/getLocaleFromHeader.tsx
+++ b/packages/next-intl/src/server/getLocaleFromHeader.tsx
@@ -1,19 +1,12 @@
-import {cookies, headers} from 'next/headers';
+import {headers} from 'next/headers';
 import {cache} from 'react';
-import {COOKIE_LOCALE_NAME, HEADER_LOCALE_NAME} from '../shared/constants';
+import {HEADER_LOCALE_NAME} from '../shared/constants';
 
 const getLocaleFromHeader = cache(() => {
   let locale;
 
   try {
-    // A header is only set when we're changing the locale,
-    // otherwise we reuse an existing one from the cookie.
-    const requestHeaders = headers();
-    if (requestHeaders.has(HEADER_LOCALE_NAME)) {
-      locale = requestHeaders.get(HEADER_LOCALE_NAME);
-    } else {
-      locale = cookies().get(COOKIE_LOCALE_NAME)?.value;
-    }
+    locale = headers().get(HEADER_LOCALE_NAME);
   } catch (error) {
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -219,6 +219,16 @@ describe('prefix-based routing', () => {
       );
     });
 
+    it('always provides the locale via a request header, even if a cookie exists with the correct value (see https://github.com/amannn/next-intl/discussions/446)', () => {
+      middleware(createMockRequest('/', 'en', 'http://localhost:3000', 'en'));
+      expect(MockedNextResponse.rewrite).toHaveBeenCalled();
+      expect(
+        MockedNextResponse.rewrite.mock.calls[0][1]?.request?.headers?.get(
+          'x-next-intl-locale'
+        )
+      ).toBe('en');
+    });
+
     describe('localized pathnames', () => {
       const middlewareWithPathnames = createIntlMiddleware({
         defaultLocale: 'en',


### PR DESCRIPTION
Should fix https://github.com/amannn/next-intl/discussions/446

As far as I understand the issue currently, something like this happens:
1. The middleware receives a request where the `NEXT_LOCALE` cookie is set
2. During the RSC render, the `NEXT_LOCALE` cookie is suddenly not available

If this is the case, this would fix the issue.

If however the middlware doesn't run at all for some reason, this will not make a difference. However, since this doesn't seem to have any downsides (possible since newer Next.js versions), this might simplify the code anyway and is a welcome change.