### PR TITLE
fix: Use correct port for alternate links when running behind a proxy…

### DIFF
--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -75,6 +75,7 @@
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
+    "@edge-runtime/vm": "^3.1.3",
     "@size-limit/preset-big-lib": "^8.2.6",
     "@testing-library/react": "^13.0.0",
     "@types/negotiator": "^0.6.1",

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -6,9 +6,12 @@ import {getHost, isLocaleSupportedOnDomain} from './utils';
 
 function getUnprefixedUrl(config: MiddlewareConfig, request: NextRequest) {
   const url = new URL(request.url);
-  url.host = getHost(request.headers) ?? url.host;
+  const host = getHost(request.headers);
+  if (host) {
+    url.port = '';
+    url.host = host;
+  }
   url.protocol = request.headers.get('x-forwarded-proto') ?? url.protocol;
-  url.port = request.headers.get('x-forwarded-host') ? '' : url.port;
 
   if (!url.pathname.endsWith('/')) {
     url.pathname += '/';

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -8,6 +8,7 @@ function getUnprefixedUrl(config: MiddlewareConfig, request: NextRequest) {
   const url = new URL(request.url);
   url.host = getHost(request.headers) ?? url.host;
   url.protocol = request.headers.get('x-forwarded-proto') ?? url.protocol;
+  url.port = request.headers.get('x-forwarded-host') ? '' : url.port;
 
   if (!url.pathname.endsWith('/')) {
     url.pathname += '/';

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -216,6 +216,33 @@ it('uses the external host name from headers instead of the url of the incoming 
   ]);
 });
 
+it('keeps the port of an external host if provided', () => {
+  const config: MiddlewareConfigWithDefaults = {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+    alternateLinks: true,
+    localePrefix: 'as-needed',
+    localeDetection: true
+  };
+
+  expect(
+    getAlternateLinksHeaderValue(
+      config,
+      new NextRequest('http://127.0.0.1/about', {
+        headers: {
+          host: 'example.com:3000',
+          'x-forwarded-host': 'example.com:3000',
+          'x-forwarded-proto': 'https'
+        }
+      })
+    ).split(', ')
+  ).toEqual([
+    '<https://example.com:3000/about>; rel="alternate"; hreflang="en"',
+    '<https://example.com:3000/es/about>; rel="alternate"; hreflang="es"',
+    '<https://example.com:3000/about>; rel="alternate"; hreflang="x-default"'
+  ]);
+});
+
 it('uses the external host name and the port from headers instead of the url with port of the incoming request (relevant when running the app behind a proxy)', () => {
   const config: MiddlewareConfigWithDefaults = {
     defaultLocale: 'en',

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment edge-runtime
+
 import {NextRequest} from 'next/server';
 import {it, expect} from 'vitest';
 import {MiddlewareConfigWithDefaults} from '../../src/middleware/NextIntlMiddlewareConfig';

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -215,3 +215,30 @@ it('uses the external host name from headers instead of the url of the incoming 
     '<https://example.com/about>; rel="alternate"; hreflang="x-default"'
   ]);
 });
+
+it('uses the external host name and the port from headers instead of the url with port of the incoming request (relevant when running the app behind a proxy)', () => {
+  const config: MiddlewareConfigWithDefaults = {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+    alternateLinks: true,
+    localePrefix: 'as-needed',
+    localeDetection: true
+  };
+
+  expect(
+    getAlternateLinksHeaderValue(
+      config,
+      new NextRequest('http://127.0.0.1:3000/about', {
+        headers: {
+          host: 'example.com',
+          'x-forwarded-host': 'example.com',
+          'x-forwarded-proto': 'https'
+        }
+      })
+    ).split(', ')
+  ).toEqual([
+    '<https://example.com/about>; rel="alternate"; hreflang="en"',
+    '<https://example.com/es/about>; rel="alternate"; hreflang="es"',
+    '<https://example.com/about>; rel="alternate"; hreflang="x-default"'
+  ]);
+});

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment edge-runtime
+
 import {RequestCookies} from 'next/dist/compiled/@edge-runtime/cookies';
 import {NextRequest, NextResponse} from 'next/server';
 import {pathToRegexp} from 'path-to-regexp';
@@ -6,7 +8,7 @@ import createIntlMiddleware from '../../src/middleware';
 import {COOKIE_LOCALE_NAME} from '../../src/shared/constants';
 
 vi.mock('next/server', () => {
-  type MiddlewareResponseInit = Parameters<(typeof NextResponse)['next']>[0];
+  type MiddlewareResponseInit = Parameters<typeof NextResponse['next']>[0];
 
   function createResponse(init: MiddlewareResponseInit) {
     const response = new Response(null, init);
@@ -60,9 +62,9 @@ function createMockRequest(
 }
 
 const MockedNextResponse = NextResponse as unknown as {
-  next: Mock<Parameters<(typeof NextResponse)['next']>>;
-  rewrite: Mock<Parameters<(typeof NextResponse)['rewrite']>>;
-  redirect: Mock<Parameters<(typeof NextResponse)['redirect']>>;
+  next: Mock<Parameters<typeof NextResponse['next']>>;
+  rewrite: Mock<Parameters<typeof NextResponse['rewrite']>>;
+  redirect: Mock<Parameters<typeof NextResponse['redirect']>>;
 };
 
 beforeEach(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,13 +65,13 @@ importers:
         version: 8.46.0
       eslint-config-molindo:
         specifier: ^7.0.0
-        version: 7.0.0(eslint@8.46.0)(tailwindcss@3.3.2)(typescript@5.0.4)
+        version: 7.0.0(eslint@8.46.0)(jest@29.5.0)(tailwindcss@3.3.2)(typescript@5.0.4)
       eslint-config-next:
         specifier: ^13.4.0
         version: 13.4.0(eslint@8.46.0)(typescript@5.0.4)
       next-sitemap:
         specifier: ^4.0.7
-        version: 4.0.7(@next/env@13.4.12)(next@13.5.1)
+        version: 4.0.7(@next/env@13.5.1)(next@13.5.1)
       typescript:
         specifier: ^5.0.0
         version: 5.0.4
@@ -108,7 +108,7 @@ importers:
         version: 8.46.0
       eslint-config-molindo:
         specifier: ^7.0.0
-        version: 7.0.0(eslint@8.46.0)(jest@27.5.1)(tailwindcss@3.3.3)(typescript@5.0.4)
+        version: 7.0.0(eslint@8.46.0)(tailwindcss@3.3.3)(typescript@5.0.4)
       eslint-config-next:
         specifier: ^13.4.0
         version: 13.4.0(eslint@8.46.0)(typescript@5.0.4)
@@ -279,7 +279,7 @@ importers:
         version: 8.46.0
       eslint-config-molindo:
         specifier: ^7.0.0
-        version: 7.0.0(eslint@8.46.0)(jest@27.5.1)(tailwindcss@3.3.3)(typescript@5.0.4)
+        version: 7.0.0(eslint@8.46.0)(tailwindcss@3.3.3)(typescript@5.0.4)
       eslint-config-next:
         specifier: ^13.4.0
         version: 13.4.0(eslint@8.46.0)(typescript@5.0.4)
@@ -359,7 +359,7 @@ importers:
         version: 8.46.0
       eslint-config-molindo:
         specifier: ^7.0.0
-        version: 7.0.0(eslint@8.46.0)(jest@27.5.1)(tailwindcss@3.3.3)(typescript@5.0.4)
+        version: 7.0.0(eslint@8.46.0)(tailwindcss@3.3.3)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.0
         version: 5.0.4
@@ -376,6 +376,9 @@ importers:
         specifier: ^2.20.0
         version: link:../use-intl
     devDependencies:
+      '@edge-runtime/vm':
+        specifier: ^3.1.3
+        version: 3.1.3
       '@size-limit/preset-big-lib':
         specifier: ^8.2.6
         version: 8.2.6(size-limit@8.2.6)
@@ -423,7 +426,7 @@ importers:
         version: 5.0.4
       vitest:
         specifier: ^0.32.2
-        version: 0.32.2
+        version: 0.32.2(@edge-runtime/vm@3.1.3)
 
   packages/use-intl:
     dependencies:
@@ -472,7 +475,7 @@ importers:
         version: 5.0.4
       vitest:
         specifier: ^0.32.2
-        version: 0.32.2
+        version: 0.32.2(@edge-runtime/vm@3.1.3)
 
 packages:
 
@@ -3163,6 +3166,18 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
+  /@edge-runtime/primitives@4.0.1:
+    resolution: {integrity: sha512-hxWUzx1SeyOed/Ea9Z6y6tyFKSj8gQWIdLilybTR2ene1IthLZE01A1SLGoch1szUdhFlUwpWDaYBYQw00lj2g==}
+    engines: {node: '>=16'}
+    dev: true
+
+  /@edge-runtime/vm@3.1.3:
+    resolution: {integrity: sha512-LkEtuVtT1kgOEghxFAEJZ+BeIpGz3XfI2l1Ts74HXzd3JneMmmx6RRkNiEE85DVBpuvv9d8KB1u+lc1CHTmz/g==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@edge-runtime/primitives': 4.0.1
+    dev: true
+
   /@emotion/hash@0.9.0:
     resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
     dev: true
@@ -5010,10 +5025,6 @@ packages:
       '@napi-rs/simple-git-win32-arm64-msvc': 0.1.8
       '@napi-rs/simple-git-win32-x64-msvc': 0.1.8
     dev: false
-
-  /@next/env@13.4.12:
-    resolution: {integrity: sha512-RmHanbV21saP/6OEPBJ7yJMuys68cIf8OBBWd7+uj40LdpmswVAwe1uzeuFyUsd6SfeITWT3XnQfn6wULeKwDQ==}
-    dev: true
 
   /@next/env@13.5.1:
     resolution: {integrity: sha512-CIMWiOTyflFn/GFx33iYXkgLSQsMQZV4jB91qaj/TfxGaGOXxn8C1j72TaUSPIyN7ziS/AYG46kGmnvuk1oOpg==}
@@ -11674,7 +11685,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-config-molindo@7.0.0(eslint@8.46.0)(tailwindcss@3.3.2)(typescript@5.0.4):
+  /eslint-config-molindo@7.0.0(eslint@8.46.0)(tailwindcss@3.3.3)(typescript@5.0.4):
     resolution: {integrity: sha512-jsy+1xutRhBYOD8EyyOlQRPK9n23yxixfXWEl6ttzTNhV/B8893e09sZDGRc+VK7z4yGW6Pe6cQM9oZkJuEu3Q==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -11686,13 +11697,13 @@ packages:
       eslint: 8.46.0
       eslint-plugin-css-modules: 2.11.0(eslint@8.46.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.4.1)(eslint@8.46.0)
-      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.4.1)(eslint@8.46.0)(jest@27.5.1)(typescript@5.0.4)
+      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.4.1)(eslint@8.46.0)(jest@29.5.0)(typescript@5.0.4)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.46.0)
       eslint-plugin-prettier: 5.0.0(eslint@8.46.0)(prettier@3.0.2)
       eslint-plugin-react: 7.33.2(eslint@8.46.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.46.0)
       eslint-plugin-sort-destructure-keys: 1.5.0(eslint@8.46.0)
-      eslint-plugin-tailwindcss: 3.13.0(tailwindcss@3.3.2)
+      eslint-plugin-tailwindcss: 3.13.0(tailwindcss@3.3.3)
       eslint-plugin-unicorn: 48.0.1(eslint@8.46.0)
       prettier: 3.0.2
     transitivePeerDependencies:
@@ -18749,7 +18760,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /next-sitemap@4.0.7(@next/env@13.4.12)(next@13.5.1):
+  /next-sitemap@4.0.7(@next/env@13.5.1)(next@13.5.1):
     resolution: {integrity: sha512-S2g5IwJeO0+ecmFq981fb+Mw9YWmntOuN/qTCxclSkUibOJ8qKIOye0vn6NEJ1S4tKhbY+MTYKgJpNdFZYxLoA==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -18758,7 +18769,7 @@ packages:
       next: '*'
     dependencies:
       '@corex/deepmerge': 4.0.43
-      '@next/env': 13.4.12
+      '@next/env': 13.5.1
       minimist: 1.2.8
       next: 13.5.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
     dev: true
@@ -24804,7 +24815,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest@0.32.2:
+  /vitest@0.32.2(@edge-runtime/vm@3.1.3):
     resolution: {integrity: sha512-hU8GNNuQfwuQmqTLfiKcqEhZY72Zxb7nnN07koCUNmntNxbKQnVbeIS6sqUgR3eXSlbOpit8+/gr1KpqoMgWCQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -24835,6 +24846,7 @@ packages:
       webdriverio:
         optional: true
     dependencies:
+      '@edge-runtime/vm': 3.1.3
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
       '@types/node': 17.0.23


### PR DESCRIPTION
When the application runs behind a proxy, the `x-forwarded-host` header contains the correct host and port information. However, the port in the `request.url` may not match the actual port used by the proxy. By overriding the port with an empty string, we ensure that alternate links are generated correctly, reflecting the proxy's host and eliminating potential inconsistencies.
