### PR TITLE
docs: Add blog post for 3.0 RC

### DIFF
--- a/docs/components/CodeSnippets.tsx
+++ b/docs/components/CodeSnippets.tsx
@@ -348,7 +348,7 @@ function buildOutput() {
         <span style={{color: 'var(--shiki-color-text)'}}> kB</span>
         <span style={{color: 'var(--shiki-color-text)'}}>{'     '}</span>
         <span style={{color: 'var(--shiki-token-string-expression)'}}>
-          104 kB
+          87.6 kB
         </span>
       </span>
       <span className="line">
@@ -358,7 +358,7 @@ function buildOutput() {
         <span style={{color: 'var(--shiki-color-text)'}}> B</span>
         <span style={{color: 'var(--shiki-color-text)'}}>{'      '}</span>
         <span style={{color: 'var(--shiki-token-string-expression)'}}>
-          97.5 kB
+          80.2 kB
         </span>
       </span>
       <span className="line">
@@ -368,7 +368,7 @@ function buildOutput() {
         <span style={{color: 'var(--shiki-color-text)'}}> kB</span>
         <span style={{color: 'var(--shiki-color-text)'}}>{'    '}</span>
         <span style={{color: 'var(--shiki-token-string-expression)'}}>
-          106 kB
+          89.3 kB
         </span>
       </span>
       <span className="line"> </span>

--- a/docs/pages/blog/3-0-release-candidate.mdx
+++ b/docs/pages/blog/3-0-release-candidate.mdx
@@ -1,0 +1,45 @@
+---
+title: next-intl 3.0 release candidate
+---
+
+# next-intl 3.0 release candidate
+
+<small>Sep 22, 2023 · by Jan Amann</small>
+
+Almost one year ago, on Oct 25, 2022, [Next.js 13 was announced](https://nextjs.org/blog/next-13) with beta support for the App Router and Server Components. Ever since then, `next-intl` began an exploration on what it means to provide an optimal experience for implementing i18n with these new capabilities.
+
+Today, [after 320 commits and the involvement of over 50 community members](https://github.com/amannn/next-intl/pull/149), I'm absolutely thrilled to share the first release candidate of `next-intl` 3.0, which is now App Router-first.
+
+If you're still happy with the Pages Router, rest assured that `next-intl` is dedicated to support this paradigm for as long as Next.js does. For those who already made the jump to the App Router, this means that `next-intl` now takes full advantage of the new capabilities.
+
+## New features
+
+1. [**Support for React Server Components**](/docs/environments/server-client-components): The APIs `useTranslations`, `useFormatter`, `useLocale`, `useNow` and `useTimeZone` can now be used in Server Components.
+2. [**New async APIs to handle i18n outside of components**](/docs/environments/metadata-route-handlers): To handle i18n in the Metadata API and Route Handlers, the APIs `getTranslator`, `getFormatter`, `getNow`, and `getTimeZone` have been added.
+3. [**Middleware for internationalized routing**](/docs/routing/middleware): While Next.js has built-in support for this with the Pages Router, the App Router doesn't include a built-in solution anymore. `next-intl` provides a drop-in solution that has you covered.
+4. [**Internationalized navigation APIs**](/docs/routing/navigation): Similar to the middleware, this provides a drop-in solution that adds i18n support for Next.js' navigation APIs: `Link`, `useRouter`, `usePathname` and `redirect`.
+
+The latter two have already been added in minor versions, but 3.0 cleans up the API and includes many improvements and fixes.
+
+## Breaking changes
+
+1. `next-intl` now requires two additional setup steps when you're using the App Router:
+   1. [The `i18n.ts` module](/docs/getting-started/app-router-server-components#i18nts) provides configuration for Server Components
+   2. [`next-intl/plugin`](/docs/getting-started/app-router-server-components#nextconfigjs) needs to be added to link your `i18n.ts` module to `next-intl`
+2. `next-intl` now uses [`exports` in `package.json`](https://nodejs.org/api/packages.html#subpath-exports) to clearly define which modules are exported. This should not affect you, unless you've previously imported undocumented internals.
+3. `NextIntlProvider` has been removed in favor of [`NextIntlClientProvider`](/docs/configuration#client-server-components)
+4. `NextIntlClientProvider` now needs to be imported from `next-intl` instead of `next-intl/client`.
+5. [The middleware](/docs/routing/middleware) now needs to be imported from `next-intl/middleware` instead of `next-intl/server`.
+6. `next@^13.4` is now required for the RSC APIs. Next.js 12 is still supported for the Pages Router integration.
+7. If you're using `NextIntlClientProvider` outside of the App Router (e.g. with the Pages Router), you need to define the `locale` prop explicitly.
+8. `useIntl` has been replaced with [`useFormatter`](/docs/usage/dates-times).
+
+If you've been part of the Server Components beta and have already tried out previous releases, first of all, thank you so much! Second: Some APIs saw iterations over the beta period, please upgrade to `next-intl@3.0.0-beta.19` and check if you see any deprecations in the console output of your app. If not, you should be able to upgrade to the release candidate without any changes.
+
+## Upgrade now
+
+We're still looking for more feedback, please try out the release candidate and [reach out](https://github.com/amannn/next-intl/pull/149) in case find something!
+
+```
+npm install next-intl@3.0.0-rc.1
+```

--- a/docs/pages/blog/3-0-release-candidate.mdx
+++ b/docs/pages/blog/3-0-release-candidate.mdx
@@ -33,6 +33,7 @@ The latter two have already been added in minor versions, but 3.0 cleans up the 
 6. `next@^13.4` is now required for the RSC APIs. Next.js 12 is still supported for the Pages Router integration.
 7. If you're using `NextIntlClientProvider` outside of the App Router (e.g. with the Pages Router), you need to define the `locale` prop explicitly.
 8. `useIntl` has been replaced with [`useFormatter`](/docs/usage/dates-times).
+9. `createIntl` has been replaced with [`createFormatter`](/docs/environments/core-library)
 
 If you've been part of the Server Components beta and have already tried out previous releases, first of all, thank you so much! Second: Some APIs saw iterations over the beta period, please upgrade to `next-intl@3.0.0-beta.19` and check if you see any deprecations in the console output of your app. If not, you should be able to upgrade to the release candidate without any changes.
 

--- a/docs/pages/blog/3-0-release-candidate.mdx
+++ b/docs/pages/blog/3-0-release-candidate.mdx
@@ -8,38 +8,73 @@ title: next-intl 3.0 release candidate
 
 Almost one year ago, on Oct 25, 2022, [Next.js 13 was announced](https://nextjs.org/blog/next-13) with beta support for the App Router and Server Components. Ever since then, `next-intl` began an exploration on what it means to provide an optimal experience for implementing i18n with these new capabilities.
 
-Today, [after 320 commits and the involvement of over 50 community members](https://github.com/amannn/next-intl/pull/149), I'm absolutely thrilled to share the first release candidate of `next-intl` 3.0, which is now App Router-first.
+Today, [after more than 300 commits and the involvement of over 50 community members](https://github.com/amannn/next-intl/pull/149), I'm absolutely thrilled to share the first release candidate of `next-intl` 3.0, which is now App Router-first.
 
-If you're still happy with the Pages Router, rest assured that `next-intl` is dedicated to support this paradigm for as long as Next.js does. For those who already made the jump to the App Router, this means that `next-intl` now takes full advantage of the new capabilities.
+If you're still happy with the Pages Router, rest assured that `next-intl` is dedicated to support this paradigm for as long as Next.js does. For those who already migrated to the App Router, this means that `next-intl` now takes full advantage of the new capabilities.
 
 ## New features
 
-1. [**Support for React Server Components**](/docs/environments/server-client-components): The APIs `useTranslations`, `useFormatter`, `useLocale`, `useNow` and `useTimeZone` can now be used in Server Components.
-2. [**New async APIs to handle i18n outside of components**](/docs/environments/metadata-route-handlers): To handle i18n in the Metadata API and Route Handlers, the APIs `getTranslator`, `getFormatter`, `getNow`, and `getTimeZone` have been added.
-3. [**Middleware for internationalized routing**](/docs/routing/middleware): While Next.js has built-in support for this with the Pages Router, the App Router doesn't include a built-in solution anymore. `next-intl` provides a drop-in solution that has you covered.
-4. [**Internationalized navigation APIs**](/docs/routing/navigation): Similar to the middleware, this provides a drop-in solution that adds i18n support for Next.js' navigation APIs: `Link`, `useRouter`, `usePathname` and `redirect`.
+1. **Support for React Server Components**: The APIs `useTranslations`, `useFormatter`, `useLocale`, `useNow` and `useTimeZone` can now be used in Server Components ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/environments/server-client-components)).
+2. **New async APIs to handle i18n outside of components**: To handle i18n in the Metadata API and Route Handlers, the APIs `getTranslator`, `getFormatter`, `getNow`, and `getTimeZone` have been added ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/environments/metadata-route-handlers)).
+3. **Middleware for internationalized routing**: While Next.js has built-in support for this with the Pages Router, the App Router doesn't include a built-in solution anymore. `next-intl` now provides a drop-in solution that has you covered ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware)).
+4. **Internationalized navigation APIs**: Similar to the middleware, this provides a drop-in solution that adds internationalization support for Next.js' navigation APIs: `Link`, `useRouter`, `usePathname` and `redirect` ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation)).
 
 The latter two have already been added in minor versions, but 3.0 cleans up the API and includes many improvements and fixes.
 
 ## Breaking changes
 
-1. `next-intl` now requires two additional setup steps when you're using the App Router:
-   1. [The `i18n.ts` module](/docs/getting-started/app-router-server-components#i18nts) provides configuration for Server Components
-   2. [`next-intl/plugin`](/docs/getting-started/app-router-server-components#nextconfigjs) needs to be added to link your `i18n.ts` module to `next-intl`
-2. `next-intl` now uses [`exports` in `package.json`](https://nodejs.org/api/packages.html#subpath-exports) to clearly define which modules are exported. This should not affect you, unless you've previously imported undocumented internals.
-3. `NextIntlProvider` has been removed in favor of [`NextIntlClientProvider`](/docs/configuration#client-server-components)
-4. `NextIntlClientProvider` now needs to be imported from `next-intl` instead of `next-intl/client`.
-5. [The middleware](/docs/routing/middleware) now needs to be imported from `next-intl/middleware` instead of `next-intl/server`.
-6. `next@^13.4` is now required for the RSC APIs. Next.js 12 is still supported for the Pages Router integration.
-7. If you're using `NextIntlClientProvider` outside of the App Router (e.g. with the Pages Router), you need to define the `locale` prop explicitly.
-8. `useIntl` has been replaced with [`useFormatter`](/docs/usage/dates-times).
-9. `createIntl` has been replaced with [`createFormatter`](/docs/environments/core-library)
+If you've been part of the Server Components beta and have already tried out previous releases, first of all, thank you so much! Second: Some APIs saw iterations over the beta period, please carefully review the breaking changes below, even if you're already using some of the new APIs.
 
-If you've been part of the Server Components beta and have already tried out previous releases, first of all, thank you so much! Second: Some APIs saw iterations over the beta period, please upgrade to `next-intl@3.0.0-beta.19` and check if you see any deprecations in the console output of your app. If not, you should be able to upgrade to the release candidate without any changes.
+### Updated setup
+
+`next-intl` now requires two additional setup steps when you're using the App Router:
+
+1.  [The `i18n.ts` module](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/getting-started/app-router-server-components#i18nts) provides configuration for Server Components
+2.  [`next-intl/plugin`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/getting-started/app-router-server-components#nextconfigjs) needs to be added to link your `i18n.ts` module to `next-intl`
+
+### New navigation APIs
+
+With [v2.14](https://github.com/amannn/next-intl/blob/main/CHANGELOG.md#2140-2023-05-10), the navigation APIs `useRouter`, `usePathname` and `Link` were added to `next-intl` that enabled you to use the APIs you're used to from Next.js while automatically considering a `locale` behind the scenes.
+
+With 3.0, we're cleaning up these APIs by moving them to a shared namespace as well as introducing type-safety for the `locale` prop that can be passed to these APIs.
+
+```diff
+- import Link from 'next-intl/link';
+- import {useRouter, usePathname} from 'next-intl/client';
+- import {redirect} from 'next-intl/server';
+
++ import {createSharedPathnamesNavigation} from 'next-intl/navigation';
++
++ const locales = ['en', 'de'] as const;
++ const {Link, useRouter, usePathname, redirect} = createSharedPathnamesNavigation({locales});
+```
+
+Typically, you'll want to call this factory function in a central place in your app where you can easily import from (see [the proposed navigation docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#shared-pathnames)).
+
+These changes bring the existing APIs in line with the new [`createLocalizedPathnamesNavigation` API](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#localized-pathnames) that allows you to localize pathnames. By using a similar API, you can upgrade from shared pathnames to localized pathnames by replacing the navigation factory function and potentially fix pathnames where necessary as reported by TypeScript (localized pathnames are fully typed).
+
+### Static rendering
+
+With the newly introduced Server Components support comes a temporary workaround for static rendering.
+
+If you call APIs like `useTranslations` in a Server Component, by default, the hook will opt the page into dynamic rendering. This is a temporary limitation that we aim to remove once `createServerContext` is supported in Next.js, but as a stopgap solution, we've added the [`unstable_setRequestLocale`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/getting-started/app-router-server-components#static-rendering) API so that you can keep your pages fully static.
+
+### Other notable changes
+
+1. `next-intl` now uses [`exports` in `package.json`](https://nodejs.org/api/packages.html#subpath-exports) to clearly define which modules are exported. This should not affect you, unless you've previously imported undocumented internals.
+2. `NextIntlProvider` has been removed in favor of [`NextIntlClientProvider`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/configuration#client-server-components)
+3. `NextIntlClientProvider` now needs to be imported from `next-intl` instead of `next-intl/client`.
+4. [The middleware](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware) now needs to be imported from `next-intl/middleware` instead of `next-intl/server`.
+5. `next@^13.4` is now required for the RSC APIs. Next.js 12 is still supported for the Pages Router integration.
+6. If you're using `NextIntlClientProvider` outside of the App Router (e.g. with the Pages Router), you need to define the `locale` prop explicitly.
+7. `useIntl` has been replaced with [`useFormatter`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/usage/dates-times) (deprecated since [v2.11](https://github.com/amannn/next-intl/blob/main/CHANGELOG.md#2110-2023-03-06)).
+8. `createIntl` has been replaced with [`createFormatter`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/environments/core-library) (deprecated since [v2.11](https://github.com/amannn/next-intl/blob/main/CHANGELOG.md#2110-2023-03-06)).
 
 ## Upgrade now
 
-We're still looking for more feedback, please try out the release candidate and [reach out](https://github.com/amannn/next-intl/pull/149) in case find something!
+Along with the release candidate also comes a [preview of the updated docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/).
+
+We're still looking for more feedback, please try out the release candidate and [reach out](https://github.com/amannn/next-intl/pull/149)!
 
 ```
 npm install next-intl@3.0.0-rc.1

--- a/docs/pages/blog/3-0-release-candidate.mdx
+++ b/docs/pages/blog/3-0-release-candidate.mdx
@@ -51,24 +51,37 @@ With 3.0, we're cleaning up these APIs by moving them to a shared namespace as w
 
 Typically, you'll want to call this factory function in a central place in your app where you can easily import from (see [the proposed navigation docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#shared-pathnames)).
 
-These changes bring the existing APIs in line with the new [`createLocalizedPathnamesNavigation` API](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#localized-pathnames) that allows you to localize pathnames. By using a similar API, you can upgrade from shared pathnames to localized pathnames by replacing the navigation factory function and potentially fix pathnames where necessary as reported by TypeScript (localized pathnames are fully typed).
+These changes bring the existing APIs in line with the new [`createLocalizedPathnamesNavigation` API](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#localized-pathnames) that allows you to localize pathnames. By using a similar API, you can upgrade from shared pathnames to localized pathnames by replacing the navigation factory function and potentially fix pathnames where necessary as reported by TypeScript since localized pathnames are fully typed.
 
-### Static rendering
+### Switching the middleware default of `localePrefix` to `always`
+
+Previously, the [`localePrefix` of the middleware](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#locale-prefix) defaulted to `as-necessary`, meaning that a locale prefix was only added for non-default locales.
+
+This default has now been changed to `always` since this has two advantages:
+
+1. We can recommend [a safer default `matcher`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#matcher-config) that needs no extra treatment for pathnames with dots (e.g. `/users/jane.doe`)
+2. It avoids an [edge case of `Link`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#locale-prefix-as-necessary) where we include a prefix for the default locale on the server side but patch this on the client side by removing the prefix (certain SEO tools might report a link pointing to a redirect in this case).
+
+If you want to stay on the `as-necessary` strategy, you can explicitly [configure this in the middleware](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#locale-prefix-as-necessary).
+
+### Static rendering of Server Components
 
 With the newly introduced Server Components support comes a temporary workaround for static rendering.
 
-If you call APIs like `useTranslations` in a Server Component, by default, the hook will opt the page into dynamic rendering. This is a temporary limitation that we aim to remove once `createServerContext` is supported in Next.js, but as a stopgap solution, we've added the [`unstable_setRequestLocale`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/getting-started/app-router-server-components#static-rendering) API so that you can keep your pages fully static.
+If you call APIs like `useTranslations` in a Server Component, by default, the hook will opt the page into dynamic rendering. This is a temporary limitation that we aim to remove once [`createServerContext`](https://react.dev/blog/2023/05/03/react-canaries#announcing-breaking-changes-and-new-features-early) is supported in Next.js, but as a stopgap solution, we've added the [`unstable_setRequestLocale`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/getting-started/app-router-server-components#static-rendering) API so that you can keep your pages fully static.
+
+Note that if you're using `next-intl` exclusively in Client Components, this doesn't apply to your app and static rendering will continue to work as it did before.
 
 ### Other notable changes
 
 1. `next-intl` now uses [`exports` in `package.json`](https://nodejs.org/api/packages.html#subpath-exports) to clearly define which modules are exported. This should not affect you, unless you've previously imported undocumented internals.
 2. `NextIntlProvider` has been removed in favor of [`NextIntlClientProvider`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/configuration#client-server-components)
 3. `NextIntlClientProvider` now needs to be imported from `next-intl` instead of `next-intl/client`.
-4. [The middleware](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware) now needs to be imported from `next-intl/middleware` instead of `next-intl/server`.
+4. [The middleware](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware) now needs to be imported from `next-intl/middleware` instead of `next-intl/server` (deprecated since v2.14).
 5. `next@^13.4` is now required for the RSC APIs. Next.js 12 is still supported for the Pages Router integration.
 6. If you're using `NextIntlClientProvider` outside of the App Router (e.g. with the Pages Router), you need to define the `locale` prop explicitly.
-7. `useIntl` has been replaced with [`useFormatter`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/usage/dates-times) (deprecated since [v2.11](https://github.com/amannn/next-intl/blob/main/CHANGELOG.md#2110-2023-03-06)).
-8. `createIntl` has been replaced with [`createFormatter`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/environments/core-library) (deprecated since [v2.11](https://github.com/amannn/next-intl/blob/main/CHANGELOG.md#2110-2023-03-06)).
+7. `useIntl` has been replaced with [`useFormatter`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/usage/dates-times) (deprecated since v2.11).
+8. `createIntl` has been replaced with [`createFormatter`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/environments/core-library) (deprecated since v2.11).
 
 ## Upgrade now
 

--- a/docs/pages/blog/_meta.json
+++ b/docs/pages/blog/_meta.json
@@ -2,6 +2,10 @@
   "index": {
     "title": "next-intl blog"
   },
+  "next-intl-3-0": {
+    "title": "next-intl 3.0",
+    "display": "hidden"
+  },
   "translations-outside-of-react-components": {
     "title": "How (not) to use translations outside of React components",
     "display": "hidden"

--- a/docs/pages/blog/index.mdx
+++ b/docs/pages/blog/index.mdx
@@ -2,9 +2,14 @@ import CommunityLink from 'components/CommunityLink';
 
 # next-intl blog
 
-Failed attempts at writing docs that somehow turned into blog posts.
 
 <div className="flex flex-col gap-4 py-8">
+  <CommunityLink
+    href="/blog/3-0-release-candidate"
+    title="next-intl 3.0 release candidate"
+    date="Sep 22, 2023"
+    author="By Jan Amann"
+  />
   <CommunityLink
     href="/blog/translations-outside-of-react-components"
     title="How (not) to use translations outside of React components"

--- a/docs/pages/blog/index.mdx
+++ b/docs/pages/blog/index.mdx
@@ -2,12 +2,11 @@ import CommunityLink from 'components/CommunityLink';
 
 # next-intl blog
 
-
 <div className="flex flex-col gap-4 py-8">
   <CommunityLink
-    href="/blog/3-0-release-candidate"
-    title="next-intl 3.0 release candidate"
-    date="Sep 22, 2023"
+    href="/blog/next-intl-3-0"
+    title="next-intl 3.0"
+    date="Sep 27, 2023"
     author="By Jan Amann"
   />
   <CommunityLink

--- a/docs/pages/blog/index.mdx
+++ b/docs/pages/blog/index.mdx
@@ -6,7 +6,7 @@ import CommunityLink from 'components/CommunityLink';
   <CommunityLink
     href="/blog/next-intl-3-0"
     title="next-intl 3.0"
-    date="Sep 27, 2023"
+    date="Sep 28, 2023"
     author="By Jan Amann"
   />
   <CommunityLink

--- a/docs/pages/blog/next-intl-3-0.mdx
+++ b/docs/pages/blog/next-intl-3-0.mdx
@@ -87,9 +87,9 @@ Previously, the [`localePrefix` of the middleware](https://next-intl-docs-git-fe
 This default has now been changed to `always` since this has two advantages:
 
 1. We can recommend [a safer default `matcher`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#matcher-config) that needs no extra treatment for pathnames with dots (e.g. `/users/jane.doe`)
-2. It avoids an [edge case of `Link`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#locale-prefix-as-necessary) where we include a prefix for the default locale on the server side but patch this on the client side by removing the prefix (certain SEO tools might report a link pointing to a redirect in this case).
+2. It avoids an [edge case of `Link`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#locale-prefix-as-necessary) where we include a prefix for the default locale on the server side but patch this on the client side by removing the prefix (certain SEO tools might report a hint that a link points to a redirect in this case).
 
-If you want to stay on the `as-necessary` strategy, you can explicitly [configure this in the middleware](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#locale-prefix-as-necessary).
+If you want to stay on the `as-necessary` strategy, you can [configure this option](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#locale-prefix-as-necessary) in the middleware.
 
 ### Static rendering of Server Components
 

--- a/docs/pages/blog/next-intl-3-0.mdx
+++ b/docs/pages/blog/next-intl-3-0.mdx
@@ -4,7 +4,7 @@ title: next-intl 3.0 release candidate
 
 # next-intl 3.0 release candidate
 
-<small>Sep 27, 2023 · by Jan Amann</small>
+<small>Sep 28, 2023 · by Jan Amann</small>
 
 Almost one year ago, on Oct 25, 2022, [Next.js 13 was announced](https://nextjs.org/blog/next-13) with beta support for the App Router and Server Components. Ever since then, `next-intl` began an exploration on what it means to provide an optimal experience for implementing i18n with these new capabilities.
 

--- a/docs/pages/blog/next-intl-3-0.mdx
+++ b/docs/pages/blog/next-intl-3-0.mdx
@@ -4,11 +4,11 @@ title: next-intl 3.0 release candidate
 
 # next-intl 3.0 release candidate
 
-<small>Sep 22, 2023 · by Jan Amann</small>
+<small>Sep 27, 2023 · by Jan Amann</small>
 
 Almost one year ago, on Oct 25, 2022, [Next.js 13 was announced](https://nextjs.org/blog/next-13) with beta support for the App Router and Server Components. Ever since then, `next-intl` began an exploration on what it means to provide an optimal experience for implementing i18n with these new capabilities.
 
-Today, [after more than 300 commits and the involvement of over 50 community members](https://github.com/amannn/next-intl/pull/149), I'm absolutely thrilled to share the first release candidate of `next-intl` 3.0, which is now App Router-first.
+Today, [after more than 300 commits and the involvement of over 50 community members](https://github.com/amannn/next-intl/pull/149), I'm absolutely thrilled to share the **first release candidate of `next-intl` 3.0**, which is now App Router-first.
 
 If you're still happy with the Pages Router, rest assured that `next-intl` is dedicated to support this paradigm for as long as Next.js does. For those who already migrated to the App Router, this means that `next-intl` now takes full advantage of the new capabilities.
 
@@ -17,9 +17,9 @@ If you're still happy with the Pages Router, rest assured that `next-intl` is de
 1. **Support for React Server Components**: The APIs `useTranslations`, `useFormatter`, `useLocale`, `useNow` and `useTimeZone` can now be used in Server Components ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/environments/server-client-components)).
 2. **New async APIs to handle i18n outside of components**: To handle i18n in the Metadata API and Route Handlers, the APIs `getTranslator`, `getFormatter`, `getNow`, and `getTimeZone` have been added ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/environments/metadata-route-handlers)).
 3. **Middleware for internationalized routing**: While Next.js has built-in support for this with the Pages Router, the App Router doesn't include a built-in solution anymore. `next-intl` now provides a drop-in solution that has you covered ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware)).
-4. **Internationalized navigation APIs**: Similar to the middleware, this provides a drop-in solution that adds internationalization support for Next.js' navigation APIs: `Link`, `useRouter`, `usePathname` and `redirect` ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation)).
+4. **Internationalized navigation APIs**: Similar to the middleware, this provides a drop-in solution that adds internationalization support for Next.js' navigation APIs: `Link`, `useRouter`, `usePathname` and `redirect`. These APIs allow you to handle locale prefixes behind the scenes and also provide support for localizing pathnames (e.g. `/en/about` vs. `/de/ueber-uns`, see the [proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation)).
 
-The latter two have already been added in minor versions, but 3.0 cleans up the API and includes many improvements and fixes.
+The latter two have already been added in minor versions, but 3.0 cleans up the API and includes many improvements and bug fixes.
 
 ## Breaking changes
 
@@ -51,7 +51,7 @@ With 3.0, we're cleaning up these APIs by moving them to a shared namespace as w
 
 Typically, you'll want to call this factory function in a central place in your app where you can easily import from (see [the proposed navigation docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#shared-pathnames)).
 
-These changes bring the existing APIs in line with the new [`createLocalizedPathnamesNavigation` API](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#localized-pathnames) that allows you to localize pathnames. By using a similar API, you can upgrade from shared pathnames to localized pathnames by replacing the navigation factory function and potentially fix pathnames where necessary as reported by TypeScript since localized pathnames are fully typed.
+These changes bring the existing APIs in line with the new [`createLocalizedPathnamesNavigation` API](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#localized-pathnames) that allows you to localize pathnames. By using a similar API, you can upgrade from shared pathnames to localized pathnames by replacing the factory function.
 
 ### Switching the middleware default of `localePrefix` to `always`
 

--- a/docs/pages/blog/next-intl-3-0.mdx
+++ b/docs/pages/blog/next-intl-3-0.mdx
@@ -8,16 +8,16 @@ title: next-intl 3.0 release candidate
 
 Almost one year ago, on Oct 25, 2022, [Next.js 13 was announced](https://nextjs.org/blog/next-13) with beta support for the App Router and Server Components. Ever since then, `next-intl` began an exploration on what it means to provide an ideal experience for implementing i18n with the newly added capabilities.
 
-Today, [after more than 300 commits and the involvement of over 50 community members](https://github.com/amannn/next-intl/pull/149), I'm absolutely thrilled to share the **first release candidate of `next-intl` 3.0**, which is now App Router-first.
+Today, [after more than 300 commits and the involvement of over 50 community members](https://github.com/amannn/next-intl/pull/149), I'm absolutely thrilled to share **the first release candidate of `next-intl` 3.0**, which is now App Router-first.
 
 If you're still happy with the Pages Router, rest assured that `next-intl` is dedicated to support this paradigm for as long as Next.js does. For those who already migrated to the App Router, this means that `next-intl` now takes full advantage of the new capabilities.
 
 ## New features
 
-1. **Support for React Server Components**: The APIs `useTranslations`, `useFormatter`, `useLocale`, `useNow` and `useTimeZone` can now be used in Server Components ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/environments/server-client-components)).
-2. **New async APIs to handle i18n outside of components**: To handle i18n in the Metadata API and Route Handlers, the APIs `getTranslator`, `getFormatter`, `getNow`, and `getTimeZone` have been added ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/environments/metadata-route-handlers)).
-3. **Middleware for internationalized routing**: While Next.js has built-in support for this with the Pages Router, the App Router doesn't include a built-in solution anymore. `next-intl` now provides a drop-in solution that has you covered ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware)).
-4. **Internationalized navigation APIs**: Similar to the middleware, this provides a drop-in solution that adds internationalization support for Next.js' navigation APIs: `Link`, `useRouter`, `usePathname` and `redirect`. These APIs allow you to handle locale prefixes behind the scenes and also provide support for localizing pathnames (e.g. `/en/about` vs. `/de/ueber-uns`, see the [proposed docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation)).
+1. **Support for React Server Components**: The APIs `useTranslations`, `useFormatter`, `useLocale`, `useNow` and `useTimeZone` can now be used in Server Components ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/environments/server-client-components)).
+2. **New async APIs to handle i18n outside of components**: To handle i18n in the Metadata API and Route Handlers, the APIs `getTranslator`, `getFormatter`, `getNow`, and `getTimeZone` have been added ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/environments/metadata-route-handlers)).
+3. **Middleware for internationalized routing**: While Next.js has built-in support for this with the Pages Router, the App Router doesn't include a built-in solution anymore. `next-intl` now provides a drop-in solution that has you covered ([proposed docs](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/routing/middleware)).
+4. **Internationalized navigation APIs**: Similar to the middleware, this provides a drop-in solution that adds internationalization support for Next.js' navigation APIs: `Link`, `useRouter`, `usePathname` and `redirect`. These APIs allow you to handle locale prefixes behind the scenes and also provide support for localizing pathnames (e.g. `/en/about` vs. `/de/ueber-uns`, see the [proposed docs](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/routing/navigation)).
 
 The latter two have already been added in minor versions, but 3.0 cleans up the API and includes many improvements and bug fixes.
 
@@ -29,8 +29,8 @@ If you've been part of the Server Components beta and have already tried out pre
 
 `next-intl` now requires two additional setup steps when you're using the App Router:
 
-1.  [The `i18n.ts` module](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/getting-started/app-router-server-components#i18nts) provides configuration for Server Components
-2.  [`next-intl/plugin`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/getting-started/app-router-server-components#nextconfigjs) needs to be added to link your `i18n.ts` module to `next-intl`
+1.  [The `i18n.ts` module](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/getting-started/app-router-server-components#i18nts) provides configuration for Server Components
+2.  [`next-intl/plugin`](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/getting-started/app-router-server-components#nextconfigjs) needs to be added to link your `i18n.ts` module to `next-intl`
 
 ### New navigation APIs
 
@@ -49,9 +49,9 @@ With 3.0, we're cleaning up these APIs by moving them to a shared namespace as w
 + const {Link, useRouter, usePathname, redirect} = createSharedPathnamesNavigation({locales});
 ```
 
-Typically, you'll want to call this factory function in a central place in your app where you can easily import from (see [the proposed navigation docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#shared-pathnames)).
+Typically, you'll want to call this factory function in a central place in your app where you can easily import from (see [the proposed navigation docs](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/routing/navigation#shared-pathnames)).
 
-These changes bring the existing APIs in line with the new [`createLocalizedPathnamesNavigation` API](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#localized-pathnames) that allows you to localize pathnames:
+These changes bring the existing APIs in line with the new [`createLocalizedPathnamesNavigation` API](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/routing/navigation#localized-pathnames) that allows you to localize pathnames:
 
 ```tsx filename="navigation.ts"
 import {createLocalizedPathnamesNavigation, Pathnames} from 'next-intl/navigation';
@@ -82,42 +82,42 @@ By using a similar API, you can upgrade from shared pathnames to localized pathn
 
 ### Switching the middleware default of `localePrefix` to `always`
 
-Previously, the [`localePrefix` of the middleware](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#locale-prefix) defaulted to `as-necessary`, meaning that a locale prefix was only added for non-default locales.
+Previously, the [`localePrefix` of the middleware](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/routing/middleware#locale-prefix) defaulted to `as-necessary`, meaning that a locale prefix was only added for non-default locales.
 
 This default has now been changed to `always` since this has two advantages:
 
-1. We can recommend [a safer default `matcher`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#matcher-config) that needs no extra treatment for pathnames with dots (e.g. `/users/jane.doe`)
-2. It avoids an [edge case of `Link`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#locale-prefix-as-necessary) where we include a prefix for the default locale on the server side but patch this on the client side by removing the prefix (certain SEO tools might report a hint that a link points to a redirect in this case).
+1. We can recommend [a safer default `matcher`](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/routing/middleware#matcher-config) that needs no extra treatment for pathnames with dots (e.g. `/users/jane.doe`)
+2. It avoids an [edge case of `Link`](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/routing/middleware#locale-prefix-as-necessary) where we include a prefix for the default locale on the server side but patch this on the client side by removing the prefix (certain SEO tools might report a hint that a link points to a redirect in this case).
 
-If you want to stay on the `as-necessary` strategy, you can [configure this option](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware#locale-prefix-as-necessary) in the middleware.
+If you want to stay on the `as-necessary` strategy, you can [configure this option](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/routing/middleware#locale-prefix-as-necessary) in the middleware.
 
 ### Static rendering of Server Components
 
 With the newly introduced Server Components support comes a temporary workaround for static rendering.
 
-If you call APIs like `useTranslations` in a Server Component, by default, the hook will opt the page into dynamic rendering. This is a temporary limitation that we aim to remove once [`createServerContext`](https://react.dev/blog/2023/05/03/react-canaries#announcing-breaking-changes-and-new-features-early) is supported in Next.js, but as a stopgap solution, we've added the [`unstable_setRequestLocale`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/getting-started/app-router-server-components#static-rendering) API so that you can keep your pages fully static.
+If you call APIs like `useTranslations` in a Server Component, by default, the hook will opt the page into dynamic rendering. This is a temporary limitation that we aim to remove once [`createServerContext`](https://react.dev/blog/2023/05/03/react-canaries#announcing-breaking-changes-and-new-features-early) is supported in Next.js, but as a stopgap solution, we've added the [`unstable_setRequestLocale`](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/getting-started/app-router-server-components#static-rendering) API so that you can keep your pages fully static.
 
 Note that if you're using `next-intl` exclusively in Client Components, this doesn't apply to your app and static rendering will continue to work as it did before.
 
 ### Other notable changes
 
 1. `next-intl` now uses [`exports` in `package.json`](https://nodejs.org/api/packages.html#subpath-exports) to clearly define which modules are exported. This should not affect you, unless you've previously imported undocumented internals.
-2. `NextIntlProvider` has been removed in favor of [`NextIntlClientProvider`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/configuration#client-server-components)
+2. `NextIntlProvider` has been removed in favor of [`NextIntlClientProvider`](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/configuration#client-server-components)
 3. `NextIntlClientProvider` now needs to be imported from `next-intl` instead of `next-intl/client`.
-4. [The middleware](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/middleware) now needs to be imported from `next-intl/middleware` instead of `next-intl/server` (deprecated since v2.14).
+4. [The middleware](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/routing/middleware) now needs to be imported from `next-intl/middleware` instead of `next-intl/server` (deprecated since v2.14).
 5. `next@^13.4` is now required for the RSC APIs. Next.js 12 is still supported for the Pages Router integration.
 6. If you're using `NextIntlClientProvider` outside of the App Router (e.g. with the Pages Router), you need to define the `locale` prop explicitly.
-7. `useIntl` has been replaced with [`useFormatter`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/usage/dates-times) (deprecated since v2.11).
-8. `createIntl` has been replaced with [`createFormatter`](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/environments/core-library) (deprecated since v2.11).
+7. `useIntl` has been replaced with [`useFormatter`](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/usage/dates-times) (deprecated since v2.11).
+8. `createIntl` has been replaced with [`createFormatter`](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/docs/environments/core-library) (deprecated since v2.11).
 
 ## Upgrade now
 
-Along with the release candidate also comes a [preview of the updated docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/).
+Along with the release candidate also comes a [preview of the updated docs](https://next-intl-docs-git-feat-next-13-rsc-next-intl.vercel.app/).
 
 We're still looking for more feedback, please try out the release candidate and [reach out](https://github.com/amannn/next-intl/pull/149)!
 
 ```
-npm install next-intl@3.0.0-rc.1
+npm install next-intl@3.0.0-rc.2
 ```
 
 This release was truly a team effort and couldn't be nearly where it is today without the involvement of the community. Thank you so much for being part of this!

--- a/docs/pages/blog/next-intl-3-0.mdx
+++ b/docs/pages/blog/next-intl-3-0.mdx
@@ -6,7 +6,7 @@ title: next-intl 3.0 release candidate
 
 <small>Sep 28, 2023 · by Jan Amann</small>
 
-Almost one year ago, on Oct 25, 2022, [Next.js 13 was announced](https://nextjs.org/blog/next-13) with beta support for the App Router and Server Components. Ever since then, `next-intl` began an exploration on what it means to provide an optimal experience for implementing i18n with these new capabilities.
+Almost one year ago, on Oct 25, 2022, [Next.js 13 was announced](https://nextjs.org/blog/next-13) with beta support for the App Router and Server Components. Ever since then, `next-intl` began an exploration on what it means to provide an ideal experience for implementing i18n with the newly added capabilities.
 
 Today, [after more than 300 commits and the involvement of over 50 community members](https://github.com/amannn/next-intl/pull/149), I'm absolutely thrilled to share the **first release candidate of `next-intl` 3.0**, which is now App Router-first.
 
@@ -51,7 +51,34 @@ With 3.0, we're cleaning up these APIs by moving them to a shared namespace as w
 
 Typically, you'll want to call this factory function in a central place in your app where you can easily import from (see [the proposed navigation docs](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#shared-pathnames)).
 
-These changes bring the existing APIs in line with the new [`createLocalizedPathnamesNavigation` API](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#localized-pathnames) that allows you to localize pathnames. By using a similar API, you can upgrade from shared pathnames to localized pathnames by replacing the factory function.
+These changes bring the existing APIs in line with the new [`createLocalizedPathnamesNavigation` API](https://next-intl-docs-git-feat-next-13-rsc-rc-next-intl.vercel.app/docs/routing/navigation#localized-pathnames) that allows you to localize pathnames:
+
+```tsx filename="navigation.ts"
+import {createLocalizedPathnamesNavigation, Pathnames} from 'next-intl/navigation';
+ 
+export const locales = ['en', 'de'] as const;
+ 
+// The `pathnames` object holds pairs of internal
+// and external paths, separated by locale.
+export const pathnames = {
+  // If all locales use the same pathname, a
+  // single external path can be provided.
+  '/': '/',
+  '/blog': '/blog',
+ 
+  // If locales use different paths, you can
+  // specify each external path per locale.
+  '/about': {
+    en: '/about',
+    de: '/ueber-uns'
+  }
+} satisfies Pathnames<typeof locales>;
+ 
+export const {Link, redirect, usePathname, useRouter} =
+  createLocalizedPathnamesNavigation({locales, pathnames});
+```
+
+By using a similar API, you can upgrade from shared pathnames to localized pathnames by replacing the factory function.
 
 ### Switching the middleware default of `localePrefix` to `always`
 
@@ -92,3 +119,5 @@ We're still looking for more feedback, please try out the release candidate and 
 ```
 npm install next-intl@3.0.0-rc.1
 ```
+
+This release was truly a team effort and couldn't be nearly where it is today without the involvement of the community. Thank you so much for being part of this!

--- a/docs/pages/blog/translations-outside-of-react-components.mdx
+++ b/docs/pages/blog/translations-outside-of-react-components.mdx
@@ -4,6 +4,8 @@ title: How (not) to use translations outside of React components
 
 # How (not) to use translations outside of React components
 
+<small>Apr 21, 2023 · by Jan Amann</small>
+
 Have you ever wondered why `next-intl` doesn’t provide an API to consume translations outside of React components?
 
 The traditional way to internationalize your app with `next-intl` is to use the `useTranslations` hook:

--- a/docs/pages/docs/getting-started/app-router-server-components.mdx
+++ b/docs/pages/docs/getting-started/app-router-server-components.mdx
@@ -13,7 +13,7 @@ Next.js 13 introduces support for [React Server Components](https://nextjs.org/d
 ## Current version
 
 ```
-npm install next-intl@3.0.0-rc.1
+npm install next-intl@3.0.0-rc.2
 ```
 
 This version was tested with `next@13.5.1`.

--- a/docs/pages/docs/getting-started/app-router-server-components.mdx
+++ b/docs/pages/docs/getting-started/app-router-server-components.mdx
@@ -3,20 +3,20 @@ import Steps from 'components/Steps';
 
 # Next.js 13: Internationalization (i18n) in Server Components
 
-Next.js 13 introduces support for [React Server Components](https://nextjs.org/docs/getting-started/react-essentials) with the App Router and unlocks [many benefits](/docs/environments/server-client-components) when handling internationalization entirely on the server side. `next-intl` is adopting the new capabilities and is currently offering a beta version to early adopters, who are already building apps with Server Components.
+Next.js 13 introduces support for [React Server Components](https://nextjs.org/docs/getting-started/react-essentials) with the App Router and unlocks [many benefits](/docs/environments/server-client-components) when handling internationalization entirely on the server side. `next-intl` is adopting the new capabilities and is currently offering a preview version to early adopters, who are already building apps with Server Components.
 
 <Callout type="warning">
-  Support for React Server Components is currently in beta. Please use it at
+  Support for React Server Components is currently available as a release candidate. Please use it at
   your own risk, knowing that you may have to migrate upon a stable release.
 </Callout>
 
-## Current beta version
+## Current version
 
 ```
-npm install next-intl@3.0.0-beta.19
+npm install next-intl@3.0.0-rc.1
 ```
 
-This beta version was tested with `next@13.5.1`.
+This version was tested with `next@13.5.1`.
 
 ## Roadmap
 
@@ -190,9 +190,9 @@ That's all it takes! Now you can internationalize your apps on the server side.
 
 ## Static rendering
 
-The support for using `next-intl` in React Server Components currently opts your pages into dynamic rendering. This is a limitation that will eventually be lifted once [`createServerContext`](https://react.dev/blog/2023/05/03/react-canaries#announcing-breaking-changes-and-new-features-early) is available and integrated in Next.js.
+By using APIs like `useTranslations` from `next-intl` in Server Components, your pages will currently opt into dynamic rendering. This is a limitation that will eventually be lifted once [`createServerContext`](https://react.dev/blog/2023/05/03/react-canaries#announcing-breaking-changes-and-new-features-early) is available and integrated in Next.js.
 
-If you have a strong need for static rendering, you can enable static rendering as follows:
+As a stopgap solution, `next-intl` provides a temporary API that can be used to enable static rendering:
 
 <Steps>
 
@@ -210,7 +210,7 @@ export function generateStaticParams() {
 
 ### Add `unstable_setRequestLocale` to all layouts and pages
 
-As a stopgap solution, `next-intl` provides a temporary API that can be used to distribute the locale that is received via `params` in a layout or page for usage in all Server Components that are rendered as part of the request.
+`next-intl` provides a temporary API that can be used to distribute the locale that is received via `params` in a layout or page for usage in all Server Components that are rendered as part of the request.
 
 ```tsx filename="app/[locale]/layout.tsx"
 import {unstable_setRequestLocale} from 'next-intl/server';
@@ -253,8 +253,6 @@ export default async function IndexPage({
 `unstable_setRequestLocale` is meant to be used as a stopgap solution and will eventually be replaced by an API that's based on `createServerContext`. When that time comes, you'll get a deprecation notice in a minor version and the API will be removed as part of a major version.
 
 Note that Next.js can render layouts and pages indepently. This means that e.g. when you navigate from `/settings/profile` to `/settings/privacy`, the `/settings` segment might not re-render as part of the request. Due to this, it's important that `unstable_setRequestLocale` is called not only in the parent `settings/layout.tsx`, but also in the individual pages `profile/page.tsx` and `settings/page.tsx`.
-
-Apart from that, the API can only be used for pages that receive `params` (i.e. not `not-found.tsx`).
 
 That being said, the API is expected to work reliably if you're cautious to apply it in all relevant places.
 

--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -1,5 +1,6 @@
 import Footer from 'components/Footer';
 import PartnerSidebar from 'components/PartnerSidebar';
+import Link from 'next/link';
 import {useRouter} from 'next/router';
 import {Navbar, ThemeSwitch} from 'nextra-theme-docs';
 
@@ -72,6 +73,17 @@ const logo = (
 export default {
   project: {
     link: 'https://github.com/amannn/next-intl'
+  },
+  banner: {
+    text: (
+      <>
+        Try out the{' '}
+        <Link className="underline" href="/blog/next-intl-3-0">
+          3.0 release candidate
+        </Link>
+        !
+      </>
+    )
   },
   docsRepositoryBase: 'https://github.com/amannn/next-intl/blob/main/docs',
   useNextSeoProps() {


### PR DESCRIPTION
Accompanying PR for https://github.com/amannn/next-intl/pull/522

**TODO:**
 - [x] Update docs link
 - [x] Link from RSC getting started docs
 - [x] Rename slug? Also update in other PR then.
- [x] Document breaking changes
    - [x] Default for `localePrefix` changed to `always`
    - [x] We now suggest a more reliable `matcher` based on the new `localePrefix` default
    - [x] API for shared navigation replaces `next-intl/link`, `redirect` from `next-intl/server` as well as `next-intl/client`
    - [x] `locale` of `Link` now requires a valid locale (not any string)