### PR TITLE
fix(docs): fix small typo in the docs

### DIFF
--- a/docs/pages/docs/getting-started/app-router-server-components.mdx
+++ b/docs/pages/docs/getting-started/app-router-server-components.mdx
@@ -252,7 +252,7 @@ export default async function IndexPage({
 
 `unstable_setRequestLocale` is meant to be used as a stopgap solution and will eventually be replaced by an API that's based on `createServerContext`. When that time comes, you'll get a deprecation notice in a minor version and the API will be removed as part of a major version.
 
-Note that Next.js can render layouts and pages indepently. This means that e.g. when you navigate from `/settings/profile` to `/settings/privacy`, the `/settings` segment might not re-render as part of the request. Due to this, it's important that `unstable_setRequestLocale` is called not only in the parent `settings/layout.tsx`, but also in the individual pages `profile/page.tsx` and `settings/page.tsx`.
+Note that Next.js can render layouts and pages indepently. This means that e.g. when you navigate from `/settings/profile` to `/settings/privacy`, the `/settings` segment might not re-render as part of the request. Due to this, it's important that `unstable_setRequestLocale` is called not only in the parent `settings/layout.tsx`, but also in the individual pages `profile/page.tsx` and `privacy/page.tsx`.
 
 Apart from that, the API can only be used for pages that receive `params` (i.e. not `not-found.tsx`).
 


### PR DESCRIPTION
## Before
> (...) it's important that unstable_setRequestLocale is called not only in the parent `settings/layout.tsx`, but also in the individual pages `profile/page.tsx` and `settings/page.tsx`.

## After 
```diff
- but also in the individual pages `profile/page.tsx` and `settings/page.tsx`.
+ but also in the individual pages `profile/page.tsx` and `privacy/page.tsx`.
```
