### PR TITLE
docs: match example with the messages

### DIFF
--- a/docs/pages/docs/usage/dates-times.mdx
+++ b/docs/pages/docs/usage/dates-times.mdx
@@ -176,8 +176,8 @@ To use custom formats in messages, you can provide formatters based on [`DateTim
 
 ```js
 t(
-  'orderDate',
-  {date: new Date('2020-11-20T10:36:01.516Z')},
+  'ordered',
+  {orderDate: new Date('2020-11-20T10:36:01.516Z')},
   {
     dateTime: {
       short: {


### PR DESCRIPTION
To match the example with the above dictionary/messages json as it's currently incorrect.

![image](https://github.com/amannn/next-intl/assets/75290989/9ce6ab5e-c8e8-4e23-9ad8-ce4b70608901)
