### PR TITLE
fix: Allow usage of `getTranslations({namespace})` without TypeScript integration for messages

### DIFF
--- a/examples/example-app-router/global.d.ts
+++ b/examples/example-app-router/global.d.ts
@@ -1,3 +1,3 @@
 // Use type safe message keys with `next-intl`
-type Messages = typeof import('./messages/en.json');
-declare interface IntlMessages extends Messages {}
+// type Messages = typeof import('./messages/en.json');
+// declare interface IntlMessages extends Messages {}

--- a/examples/example-app-router/global.d.ts
+++ b/examples/example-app-router/global.d.ts
@@ -1,3 +1,3 @@
 // Use type safe message keys with `next-intl`
-// type Messages = typeof import('./messages/en.json');
-// declare interface IntlMessages extends Messages {}
+type Messages = typeof import('./messages/en.json');
+declare interface IntlMessages extends Messages {}

--- a/packages/next-intl/src/server/getTranslations.tsx
+++ b/packages/next-intl/src/server/getTranslations.tsx
@@ -41,7 +41,7 @@ Promise<{
       >
     >
   >(
-    key: TargetKey,
+    key: [TargetKey] extends [never] ? string : TargetKey,
     values?: TranslationValues,
     formats?: Partial<Formats>
   ): string;
@@ -61,7 +61,7 @@ Promise<{
       >
     >
   >(
-    key: TargetKey,
+    key: [TargetKey] extends [never] ? string : TargetKey,
     values?: RichTranslationValues,
     formats?: Partial<Formats>
   ): string | ReactElement | ReactNodeArray;
@@ -81,7 +81,7 @@ Promise<{
       >
     >
   >(
-    key: TargetKey,
+    key: [TargetKey] extends [never] ? string : TargetKey,
     values?: MarkupTranslationValues,
     formats?: Partial<Formats>
   ): string;
@@ -101,7 +101,7 @@ Promise<{
       >
     >
   >(
-    key: TargetKey
+    key: [TargetKey] extends [never] ? string : TargetKey
   ): any;
 }>;
 function getTranslations<


### PR DESCRIPTION
Fixes #625