### PR TITLE
fix(examples/with-next-auth): fix regex in middleware

### DIFF
--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -470,7 +470,7 @@ const authMiddleware = withAuth(
 
 export default function middleware(req: NextRequest) {
   const publicPathnameRegex = RegExp(
-    `^(/(${locales.join('|')}))?(${publicPages.join('|')})?/?$`,
+    `^(/(${locales.join('|')}))?(${publicPages.join('|')})/?$`,
     'i'
   );
   const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);

--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -470,11 +470,11 @@ const authMiddleware = withAuth(
 
 export default function middleware(req: NextRequest) {
   const publicPathnameRegex = RegExp(
-		`^(/(${locales.join("|")}))?(${publicPages
-			.flatMap((p) => (p === "/" ? ["", "/"] : p))
-			.join("|")})/?$`,
-		"i"
-	);
+    `^(/(${locales.join('|')}))?(${publicPages
+      .flatMap((p) => (p === '/' ? ['', '/'] : p))
+      .join('|')})/?$`,
+    'i'
+  );
   const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);
 
   if (isPublicPage) {

--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -470,9 +470,11 @@ const authMiddleware = withAuth(
 
 export default function middleware(req: NextRequest) {
   const publicPathnameRegex = RegExp(
-    `^(/(${locales.join('|')}))?(${publicPages.join('|')}|)/?$`,
-    'i'
-  );
+		`^(/(${locales.join("|")}))?(${publicPages
+			.flatMap((p) => (p === "/" ? ["", "/"] : p))
+			.join("|")})/?$`,
+		"i"
+	);
   const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);
 
   if (isPublicPage) {

--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -470,7 +470,7 @@ const authMiddleware = withAuth(
 
 export default function middleware(req: NextRequest) {
   const publicPathnameRegex = RegExp(
-    `^(/(${locales.join('|')}))?(${publicPages.join('|')})/?$`,
+    `^(/(${locales.join('|')}))?(${publicPages.join('|')}|)/?$`,
     'i'
   );
   const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);

--- a/examples/example-app-router-next-auth/src/middleware.ts
+++ b/examples/example-app-router-next-auth/src/middleware.ts
@@ -32,7 +32,7 @@ const authMiddleware = withAuth(
 
 export default function middleware(req: NextRequest) {
   const publicPathnameRegex = RegExp(
-    `^(/(${locales.join('|')}))?(${publicPages.join('|')})/?$`,
+    `^(/(${locales.join('|')}))?(${publicPages.join('|')}|)/?$`,
     'i'
   );
   const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);

--- a/examples/example-app-router-next-auth/src/middleware.ts
+++ b/examples/example-app-router-next-auth/src/middleware.ts
@@ -32,7 +32,7 @@ const authMiddleware = withAuth(
 
 export default function middleware(req: NextRequest) {
   const publicPathnameRegex = RegExp(
-    `^(/(${locales.join('|')}))?(${publicPages.join('|')})?/?$`,
+    `^(/(${locales.join('|')}))?(${publicPages.join('|')})/?$`,
     'i'
   );
   const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);

--- a/examples/example-app-router-next-auth/src/middleware.ts
+++ b/examples/example-app-router-next-auth/src/middleware.ts
@@ -32,10 +32,10 @@ const authMiddleware = withAuth(
 
 export default function middleware(req: NextRequest) {
   const publicPathnameRegex = RegExp(
-		`^(/(${locales.join("|")}))?(${publicPages
-			.flatMap((p) => (p === "/" ? ["", "/"] : p))
-			.join("|")})/?$`,
-		"i"
+    `^(/(${locales.join('|')}))?(${publicPages
+      .flatMap((p) => (p === '/' ? ['', '/'] : p))
+      .join('|')})/?$`,
+    'i'
   );
   const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);
 

--- a/examples/example-app-router-next-auth/src/middleware.ts
+++ b/examples/example-app-router-next-auth/src/middleware.ts
@@ -32,8 +32,10 @@ const authMiddleware = withAuth(
 
 export default function middleware(req: NextRequest) {
   const publicPathnameRegex = RegExp(
-    `^(/(${locales.join('|')}))?(${publicPages.join('|')}|)/?$`,
-    'i'
+		`^(/(${locales.join("|")}))?(${publicPages
+			.flatMap((p) => (p === "/" ? ["", "/"] : p))
+			.join("|")})/?$`,
+		"i"
   );
   const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);
 


### PR DESCRIPTION
The regex `^(/(${locales.join('|')}))?(${publicPages.join('|')})/?$` considers `/` or `/${locale}/` public.

This PR fixes that
