### PR TITLE
feat: Experimental support for `--turbo` (requires `next@^14.0.3`)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "@vercel/analytics": "1.1.0",
     "clsx": "^1.2.1",
     "http-status-codes": "^2.2.0",
-    "next": "14.0.1",
+    "next": "14.0.3",
     "nextra": "^2.13.2",
     "nextra-theme-docs": "^2.13.2",
     "react": "^18.2.0",

--- a/examples/example-app-router-migration/package.json
+++ b/examples/example-app-router-migration/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "next": "14.0.3",
-    "next-intl": "^2.13.2",
+    "next-intl": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/example-app-router-migration/package.json
+++ b/examples/example-app-router-migration/package.json
@@ -10,7 +10,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "14.0.1",
+    "next": "14.0.3",
     "next-intl": "^2.13.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/example-app-router-next-auth/package.json
+++ b/examples/example-app-router-next-auth/package.json
@@ -10,7 +10,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "14.0.1",
+    "next": "14.0.3",
     "next-auth": "^4.24.4",
     "next-intl": "latest",
     "react": "^18.2.0",

--- a/examples/example-app-router-playground/package.json
+++ b/examples/example-app-router-playground/package.json
@@ -14,7 +14,7 @@
     "lodash": "^4.17.21",
     "ms": "2.1.3",
     "next": "14.0.3",
-    "next-intl": "^2.13.2",
+    "next-intl": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/example-app-router-playground/package.json
+++ b/examples/example-app-router-playground/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "ms": "2.1.3",
-    "next": "14.0.1",
+    "next": "14.0.3",
     "next-intl": "^2.13.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/example-app-router/next.config.js
+++ b/examples/example-app-router/next.config.js
@@ -2,4 +2,7 @@
 
 const withNextIntl = require('next-intl/plugin')();
 
-module.exports = withNextIntl();
+/** @type {import('next').NextConfig} */
+const config = {};
+
+module.exports = withNextIntl(config);

--- a/examples/example-app-router/package.json
+++ b/examples/example-app-router/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "clsx": "^1.2.1",
-    "next": "14.0.1",
+    "next": "14.0.3",
     "next-intl": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/example-app-router/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router/src/app/[locale]/layout.tsx
@@ -4,7 +4,7 @@ import {notFound} from 'next/navigation';
 import {getTranslations, unstable_setRequestLocale} from 'next-intl/server';
 import {ReactNode} from 'react';
 import Navigation from 'components/Navigation';
-import {locales} from 'config';
+import {locales} from '../../config';
 
 const inter = Inter({subsets: ['latin']});
 

--- a/examples/example-app-router/src/app/[locale]/page.tsx
+++ b/examples/example-app-router/src/app/[locale]/page.tsx
@@ -2,7 +2,7 @@ import {notFound} from 'next/navigation';
 import {useTranslations} from 'next-intl';
 import {unstable_setRequestLocale} from 'next-intl/server';
 import PageLayout from 'components/PageLayout';
-import {locales} from 'config';
+import {locales} from '../../config';
 
 type Props = {
   params: {locale: string};

--- a/examples/example-app-router/src/i18n.ts
+++ b/examples/example-app-router/src/i18n.ts
@@ -1,5 +1,10 @@
 import {getRequestConfig} from 'next-intl/server';
 
 export default getRequestConfig(async ({locale}) => ({
-  messages: (await import(`../messages/${locale}.json`)).default
+  messages: (
+    await (locale === 'en'
+      ? // When using Turbopack, this will enable HMR for `en`
+        import(`../messages/en.json`)
+      : import(`../messages/${locale}.json`))
+  ).default
 }));

--- a/examples/example-app-router/src/i18n.ts
+++ b/examples/example-app-router/src/i18n.ts
@@ -4,7 +4,7 @@ export default getRequestConfig(async ({locale}) => ({
   messages: (
     await (locale === 'en'
       ? // When using Turbopack, this will enable HMR for `en`
-        import(`../messages/en.json`)
+        import('../messages/en.json')
       : import(`../messages/${locale}.json`))
   ).default
 }));

--- a/examples/example-pages-router-advanced/package.json
+++ b/examples/example-pages-router-advanced/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "accept-language-parser": "^1.5.0",
     "lodash": "^4.17.21",
-    "next": "14.0.1",
+    "next": "14.0.3",
     "next-intl": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/example-pages-router/package.json
+++ b/examples/example-pages-router/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "date-fns": "^2.16.1",
-    "next": "14.0.1",
+    "next": "14.0.3",
     "next-intl": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -89,7 +89,7 @@
     "eslint": "^8.46.0",
     "eslint-config-molindo": "^7.0.0",
     "eslint-plugin-deprecation": "^1.4.1",
-    "next": "14.0.1",
+    "next": "14.0.3",
     "path-to-regexp": "^6.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/next-intl/src/plugin.tsx
+++ b/packages/next-intl/src/plugin.tsx
@@ -72,6 +72,7 @@ function initPlugin(i18nPath?: string, nextConfig?: NextConfig): NextConfig {
 
     nextIntlConfig = {
       experimental: {
+        ...nextConfig?.experimental,
         turbo: {
           ...nextConfig?.experimental?.turbo,
           resolveAlias: {

--- a/packages/next-intl/src/plugin.tsx
+++ b/packages/next-intl/src/plugin.tsx
@@ -62,10 +62,6 @@ function initPlugin(i18nPath?: string, nextConfig?: NextConfig): NextConfig {
 
   let nextIntlConfig;
   if (useTurbo) {
-    console.warn(
-      '\n⚠️ Turbopack support for next-intl is currently experimental.\n'
-    );
-
     if (i18nPath && i18nPath.startsWith('/')) {
       throw new Error(
         "Turbopack support for next-intl currently does not support absolute paths, please provide a relative one (e.g. './src/i18n/config.ts').\n\nFound: " +
@@ -92,8 +88,7 @@ function initPlugin(i18nPath?: string, nextConfig?: NextConfig): NextConfig {
       webpack(
         ...[config, options]: Parameters<NonNullable<NextConfig['webpack']>>
       ) {
-        // Webpack docs teach alias with `require.resolve`,
-        // let's use that and provide an absolute path
+        // Webpack requires absolute paths
         config.resolve.alias['next-intl/config'] = path.resolve(
           config.context,
           resolveI18nPath(i18nPath, config.context)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
         version: 13.4.0(eslint@8.46.0)(typescript@5.2.2)
       next-sitemap:
         specifier: ^4.0.7
-        version: 4.0.7(@next/env@14.0.1)(next@14.0.3)
+        version: 4.0.7(@next/env@14.0.3)(next@14.0.3)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -188,8 +188,8 @@ importers:
         specifier: 14.0.3
         version: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       next-intl:
-        specifier: ^2.13.2
-        version: 2.22.3(next@14.0.3)(react@18.2.0)
+        specifier: latest
+        version: link:../../packages/next-intl
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -274,8 +274,8 @@ importers:
         specifier: 14.0.3
         version: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       next-intl:
-        specifier: ^2.13.2
-        version: 2.22.3(next@14.0.3)(react@18.2.0)
+        specifier: latest
+        version: link:../../packages/next-intl
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -5238,10 +5238,6 @@ packages:
       '@napi-rs/simple-git-win32-arm64-msvc': 0.1.9
       '@napi-rs/simple-git-win32-x64-msvc': 0.1.9
     dev: false
-
-  /@next/env@14.0.1:
-    resolution: {integrity: sha512-Ms8ZswqY65/YfcjrlcIwMPD7Rg/dVjdLapMcSHG26W6O67EJDF435ShW4H4LXi1xKO1oRc97tLXUpx8jpLe86A==}
-    dev: true
 
   /@next/env@14.0.3:
     resolution: {integrity: sha512-7xRqh9nMvP5xrW4/+L0jgRRX+HoNRGnfJpD+5Wq6/13j3dsdzxO3BCXn7D3hMqsDb+vjZnJq+vI7+EtgrYZTeA==}
@@ -17889,20 +17885,6 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /next-intl@2.22.3(next@14.0.3)(react@18.2.0):
-    resolution: {integrity: sha512-6HNPxWPO7JRKhrMKJJQTsq6AOd3Neu5fsH0EUCYCwkIMqlrud24BkI6zBocWoOgAaqVrNylXtn53xbVTw6hdYg==}
-    deprecated: This was intended as 3.0, but CI accidentally published it as 2.22.3. Either stay on 2.22.1 or upgrade to 3.0
-    peerDependencies:
-      next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@formatjs/intl-localematcher': 0.2.32
-      negotiator: 0.6.3
-      next: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
-      react: 18.2.0
-      use-intl: 2.22.3(react@18.2.0)
-    dev: false
-
   /next-mdx-remote@4.4.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-1BvyXaIou6xy3XoNF4yaMZUCb6vD2GTAa5ciOa6WoO+gAUTYsb1K4rI/HSC2ogAWLrb/7VSV52skz07vOzmqIQ==}
     engines: {node: '>=14', npm: '>=7'}
@@ -17932,7 +17914,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /next-sitemap@4.0.7(@next/env@14.0.1)(next@14.0.3):
+  /next-sitemap@4.0.7(@next/env@14.0.3)(next@14.0.3):
     resolution: {integrity: sha512-S2g5IwJeO0+ecmFq981fb+Mw9YWmntOuN/qTCxclSkUibOJ8qKIOye0vn6NEJ1S4tKhbY+MTYKgJpNdFZYxLoA==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -17941,7 +17923,7 @@ packages:
       next: '*'
     dependencies:
       '@corex/deepmerge': 4.0.43
-      '@next/env': 14.0.1
+      '@next/env': 14.0.3
       minimist: 1.2.8
       next: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
     dev: true
@@ -23686,17 +23668,6 @@ packages:
   /use-intl@2.14.3(react@18.2.0):
     resolution: {integrity: sha512-sOjd1IrlyyGioVqTauQ0/pYtVlVbSnOU91VGKVI8d4YpGw9JXmGK23nIa9SY5LOYz6ZXKpDKAhrAlEPf14j90g==}
     engines: {node: '>=10'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      intl-messageformat: 9.3.18
-      react: 18.2.0
-    dev: false
-
-  /use-intl@2.22.3(react@18.2.0):
-    resolution: {integrity: sha512-aGBsRvVoincUV+skTg1qYInU9bu4OuCBx02uGa0er9X+eR43ZqaZehIZk7zAVubyVZNLyKbawxX+SXvdxOUKcA==}
-    deprecated: This was intended as 3.0, but CI accidentally published it as 2.22.3. Either stay on 2.22.1 or upgrade to 3.0
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -69,14 +69,14 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       next:
-        specifier: 14.0.1
-        version: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 14.0.3
+        version: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       nextra:
         specifier: ^2.13.2
-        version: 2.13.2(next@14.0.1)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.13.2(next@14.0.3)(react-dom@18.2.0)(react@18.2.0)
       nextra-theme-docs:
         specifier: ^2.13.2
-        version: 2.13.2(next@14.0.1)(nextra@2.13.2)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.13.2(next@14.0.3)(nextra@2.13.2)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -101,13 +101,13 @@ importers:
         version: 8.46.0
       eslint-config-molindo:
         specifier: ^7.0.0
-        version: 7.0.0(eslint@8.46.0)(jest@29.5.0)(tailwindcss@3.3.3)(typescript@5.2.2)
+        version: 7.0.0(eslint@8.46.0)(tailwindcss@3.3.2)(typescript@5.2.2)
       eslint-config-next:
         specifier: ^13.4.0
         version: 13.4.0(eslint@8.46.0)(typescript@5.2.2)
       next-sitemap:
         specifier: ^4.0.7
-        version: 4.0.7(@next/env@14.0.1)(next@14.0.1)
+        version: 4.0.7(@next/env@14.0.1)(next@14.0.3)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -118,8 +118,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       next:
-        specifier: 14.0.1
-        version: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 14.0.3
+        version: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       next-intl:
         specifier: latest
         version: link:../../packages/next-intl
@@ -185,11 +185,11 @@ importers:
   examples/example-app-router-migration:
     dependencies:
       next:
-        specifier: 14.0.1
-        version: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 14.0.3
+        version: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       next-intl:
         specifier: ^2.13.2
-        version: 2.22.3(next@14.0.1)(react@18.2.0)
+        version: 2.22.3(next@14.0.3)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -222,11 +222,11 @@ importers:
   examples/example-app-router-next-auth:
     dependencies:
       next:
-        specifier: 14.0.1
-        version: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 14.0.3
+        version: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       next-auth:
         specifier: ^4.24.4
-        version: 4.24.4(next@14.0.1)(react-dom@18.2.0)(react@18.2.0)
+        version: 4.24.4(next@14.0.3)(react-dom@18.2.0)(react@18.2.0)
       next-intl:
         specifier: latest
         version: link:../../packages/next-intl
@@ -271,11 +271,11 @@ importers:
         specifier: 2.1.3
         version: 2.1.3
       next:
-        specifier: 14.0.1
-        version: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 14.0.3
+        version: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       next-intl:
         specifier: ^2.13.2
-        version: 2.22.3(next@14.0.1)(react@18.2.0)
+        version: 2.22.3(next@14.0.3)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -320,8 +320,8 @@ importers:
         specifier: ^2.16.1
         version: 2.16.1
       next:
-        specifier: 14.0.1
-        version: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 14.0.3
+        version: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       next-intl:
         specifier: latest
         version: link:../../packages/next-intl
@@ -363,8 +363,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       next:
-        specifier: 14.0.1
-        version: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 14.0.3
+        version: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       next-intl:
         specifier: latest
         version: link:../../packages/next-intl
@@ -529,8 +529,8 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1(eslint@8.46.0)(typescript@5.2.2)
       next:
-        specifier: 14.0.1
-        version: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 14.0.3
+        version: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       path-to-regexp:
         specifier: ^6.2.1
         version: 6.2.1
@@ -5241,6 +5241,10 @@ packages:
 
   /@next/env@14.0.1:
     resolution: {integrity: sha512-Ms8ZswqY65/YfcjrlcIwMPD7Rg/dVjdLapMcSHG26W6O67EJDF435ShW4H4LXi1xKO1oRc97tLXUpx8jpLe86A==}
+    dev: true
+
+  /@next/env@14.0.3:
+    resolution: {integrity: sha512-7xRqh9nMvP5xrW4/+L0jgRRX+HoNRGnfJpD+5Wq6/13j3dsdzxO3BCXn7D3hMqsDb+vjZnJq+vI7+EtgrYZTeA==}
 
   /@next/eslint-plugin-next@13.4.0:
     resolution: {integrity: sha512-ZqQi1slguDavpuNUcl9va8+WtHHpgymIW2g+4Gs9FdI+5rjAvrUqqjfCec2hi3Cjbbp7zULFQuAiPwASKHbrxw==}
@@ -5248,72 +5252,72 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/swc-darwin-arm64@14.0.1:
-    resolution: {integrity: sha512-JyxnGCS4qT67hdOKQ0CkgFTp+PXub5W1wsGvIq98TNbF3YEIN7iDekYhYsZzc8Ov0pWEsghQt+tANdidITCLaw==}
+  /@next/swc-darwin-arm64@14.0.3:
+    resolution: {integrity: sha512-64JbSvi3nbbcEtyitNn2LEDS/hcleAFpHdykpcnrstITFlzFgB/bW0ER5/SJJwUPj+ZPY+z3e+1jAfcczRLVGw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@next/swc-darwin-x64@14.0.1:
-    resolution: {integrity: sha512-625Z7bb5AyIzswF9hvfZWa+HTwFZw+Jn3lOBNZB87lUS0iuCYDHqk3ujuHCkiyPtSC0xFBtYDLcrZ11mF/ap3w==}
+  /@next/swc-darwin-x64@14.0.3:
+    resolution: {integrity: sha512-RkTf+KbAD0SgYdVn1XzqE/+sIxYGB7NLMZRn9I4Z24afrhUpVJx6L8hsRnIwxz3ERE2NFURNliPjJ2QNfnWicQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@next/swc-linux-arm64-gnu@14.0.1:
-    resolution: {integrity: sha512-iVpn3KG3DprFXzVHM09kvb//4CNNXBQ9NB/pTm8LO+vnnnaObnzFdS5KM+w1okwa32xH0g8EvZIhoB3fI3mS1g==}
+  /@next/swc-linux-arm64-gnu@14.0.3:
+    resolution: {integrity: sha512-3tBWGgz7M9RKLO6sPWC6c4pAw4geujSwQ7q7Si4d6bo0l6cLs4tmO+lnSwFp1Tm3lxwfMk0SgkJT7EdwYSJvcg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@next/swc-linux-arm64-musl@14.0.1:
-    resolution: {integrity: sha512-mVsGyMxTLWZXyD5sen6kGOTYVOO67lZjLApIj/JsTEEohDDt1im2nkspzfV5MvhfS7diDw6Rp/xvAQaWZTv1Ww==}
+  /@next/swc-linux-arm64-musl@14.0.3:
+    resolution: {integrity: sha512-v0v8Kb8j8T23jvVUWZeA2D8+izWspeyeDGNaT2/mTHWp7+37fiNfL8bmBWiOmeumXkacM/AB0XOUQvEbncSnHA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@next/swc-linux-x64-gnu@14.0.1:
-    resolution: {integrity: sha512-wMqf90uDWN001NqCM/auRl3+qVVeKfjJdT9XW+RMIOf+rhUzadmYJu++tp2y+hUbb6GTRhT+VjQzcgg/QTD9NQ==}
+  /@next/swc-linux-x64-gnu@14.0.3:
+    resolution: {integrity: sha512-VM1aE1tJKLBwMGtyBR21yy+STfl0MapMQnNrXkxeyLs0GFv/kZqXS5Jw/TQ3TSUnbv0QPDf/X8sDXuMtSgG6eg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@next/swc-linux-x64-musl@14.0.1:
-    resolution: {integrity: sha512-ol1X1e24w4j4QwdeNjfX0f+Nza25n+ymY0T2frTyalVczUmzkVD7QGgPTZMHfR1aLrO69hBs0G3QBYaj22J5GQ==}
+  /@next/swc-linux-x64-musl@14.0.3:
+    resolution: {integrity: sha512-64EnmKy18MYFL5CzLaSuUn561hbO1Gk16jM/KHznYP3iCIfF9e3yULtHaMy0D8zbHfxset9LTOv6cuYKJgcOxg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@next/swc-win32-arm64-msvc@14.0.1:
-    resolution: {integrity: sha512-WEmTEeWs6yRUEnUlahTgvZteh5RJc4sEjCQIodJlZZ5/VJwVP8p2L7l6VhzQhT4h7KvLx/Ed4UViBdne6zpIsw==}
+  /@next/swc-win32-arm64-msvc@14.0.3:
+    resolution: {integrity: sha512-WRDp8QrmsL1bbGtsh5GqQ/KWulmrnMBgbnb+59qNTW1kVi1nG/2ndZLkcbs2GX7NpFLlToLRMWSQXmPzQm4tog==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@next/swc-win32-ia32-msvc@14.0.1:
-    resolution: {integrity: sha512-oFpHphN4ygAgZUKjzga7SoH2VGbEJXZa/KL8bHCAwCjDWle6R1SpiGOdUdA8EJ9YsG1TYWpzY6FTbUA+iAJeww==}
+  /@next/swc-win32-ia32-msvc@14.0.3:
+    resolution: {integrity: sha512-EKffQeqCrj+t6qFFhIFTRoqb2QwX1mU7iTOvMyLbYw3QtqTw9sMwjykyiMlZlrfm2a4fA84+/aeW+PMg1MjuTg==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@next/swc-win32-x64-msvc@14.0.1:
-    resolution: {integrity: sha512-FFp3nOJ/5qSpeWT0BZQ+YE1pSMk4IMpkME/1DwKBwhg4mJLB9L+6EXuJi4JEwaJdl5iN+UUlmUD3IsR1kx5fAg==}
+  /@next/swc-win32-x64-msvc@14.0.3:
+    resolution: {integrity: sha512-ERhKPSJ1vQrPiwrs15Pjz/rvDHZmkmvbf/BjPN/UCOI++ODftT0GtasDPi0j+y6PPJi5HsXw+dpRaXUaw4vjuQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -11445,7 +11449,7 @@ packages:
       confusing-browser-globals: 1.0.11
       eslint: 8.46.0
       eslint-plugin-css-modules: 2.11.0(eslint@8.46.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.4.1)(eslint@8.46.0)
       eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.4.1)(eslint@8.46.0)(jest@29.5.0)(typescript@5.2.2)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.46.0)
       eslint-plugin-prettier: 5.0.0(eslint@8.46.0)(prettier@3.0.2)
@@ -11453,6 +11457,38 @@ packages:
       eslint-plugin-react-hooks: 4.6.0(eslint@8.46.0)
       eslint-plugin-sort-destructure-keys: 1.5.0(eslint@8.46.0)
       eslint-plugin-tailwindcss: 3.13.0(tailwindcss@3.3.3)
+      eslint-plugin-unicorn: 48.0.1(eslint@8.46.0)
+      prettier: 3.0.2
+    transitivePeerDependencies:
+      - '@types/eslint'
+      - eslint-config-prettier
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - jest
+      - supports-color
+      - tailwindcss
+      - typescript
+    dev: true
+
+  /eslint-config-molindo@7.0.0(eslint@8.46.0)(tailwindcss@3.3.2)(typescript@5.2.2):
+    resolution: {integrity: sha512-jsy+1xutRhBYOD8EyyOlQRPK9n23yxixfXWEl6ttzTNhV/B8893e09sZDGRc+VK7z4yGW6Pe6cQM9oZkJuEu3Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^8.0.0
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.46.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.4.1(eslint@8.46.0)(typescript@5.2.2)
+      confusing-browser-globals: 1.0.11
+      eslint: 8.46.0
+      eslint-plugin-css-modules: 2.11.0(eslint@8.46.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.4.1)(eslint@8.46.0)
+      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.4.1)(eslint@8.46.0)(jest@29.5.0)(typescript@5.2.2)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.46.0)
+      eslint-plugin-prettier: 5.0.0(eslint@8.46.0)(prettier@3.0.2)
+      eslint-plugin-react: 7.33.2(eslint@8.46.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.46.0)
+      eslint-plugin-sort-destructure-keys: 1.5.0(eslint@8.46.0)
+      eslint-plugin-tailwindcss: 3.13.0(tailwindcss@3.3.2)
       eslint-plugin-unicorn: 48.0.1(eslint@8.46.0)
       prettier: 3.0.2
     transitivePeerDependencies:
@@ -11477,7 +11513,7 @@ packages:
       confusing-browser-globals: 1.0.11
       eslint: 8.46.0
       eslint-plugin-css-modules: 2.11.0(eslint@8.46.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.4.1)(eslint@8.46.0)
       eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.4.1)(eslint@8.46.0)(jest@29.5.0)(typescript@5.2.2)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.46.0)
       eslint-plugin-prettier: 5.0.0(eslint@8.46.0)(prettier@3.0.2)
@@ -11513,7 +11549,7 @@ packages:
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.46.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.4.1)(eslint@8.46.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.46.0)
       eslint-plugin-react: 7.32.2(eslint@8.46.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.46.0)
@@ -11544,7 +11580,7 @@ packages:
       enhanced-resolve: 5.13.0
       eslint: 8.46.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.4.1)(eslint@8.46.0)
       get-tsconfig: 4.5.0
       globby: 13.1.4
       is-core-module: 2.12.0
@@ -11587,6 +11623,35 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.7)(eslint@8.46.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.4.1(eslint@8.46.0)(typescript@5.2.2)
+      debug: 3.2.7(supports-color@6.1.0)
+      eslint: 8.46.0
+      eslint-import-resolver-node: 0.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-plugin-css-modules@2.11.0(eslint@8.46.0):
     resolution: {integrity: sha512-CLvQvJOMlCywZzaI4HVu7QH/ltgNXvCg7giJGiE+sA9wh5zQ+AqTgftAzrERV22wHe1p688wrU/Zwxt1Ry922w==}
     engines: {node: '>=4.0.0'}
@@ -11613,7 +11678,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0):
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.4.1)(eslint@8.46.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -11623,7 +11688,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.2(eslint@8.46.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.4.1(eslint@8.46.0)(typescript@5.2.2)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -11631,7 +11696,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.7)(eslint@8.46.0)
       has: 1.0.3
       is-core-module: 2.12.0
       is-glob: 4.0.3
@@ -11779,6 +11844,17 @@ packages:
     dependencies:
       eslint: 8.46.0
       natural-compare-lite: 1.4.0
+    dev: true
+
+  /eslint-plugin-tailwindcss@3.13.0(tailwindcss@3.3.2):
+    resolution: {integrity: sha512-Fcep4KDRLWaK3KmkQbdyKHG0P4GdXFmXdDaweTIPcgOP60OOuWFbh1++dufRT28Q4zpKTKaHwTsXPJ4O/EjU2Q==}
+    engines: {node: '>=12.13.0'}
+    peerDependencies:
+      tailwindcss: ^3.3.2
+    dependencies:
+      fast-glob: 3.2.12
+      postcss: 8.4.31
+      tailwindcss: 3.3.2
     dev: true
 
   /eslint-plugin-tailwindcss@3.13.0(tailwindcss@3.3.3):
@@ -17788,7 +17864,7 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: true
 
-  /next-auth@4.24.4(next@14.0.1)(react-dom@18.2.0)(react@18.2.0):
+  /next-auth@4.24.4(next@14.0.3)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-5DGffi+OpkbU62vPQIJ1z+hFnmow+ec5Qrn9m6eoglIO51m0DlrmLxBduZEwKAYDEg9k2joi1yelgmq1vqK3aQ==}
     peerDependencies:
       next: ^12.2.5 || ^13 || ^14
@@ -17803,7 +17879,7 @@ packages:
       '@panva/hkdf': 1.1.1
       cookie: 0.5.0
       jose: 4.14.4
-      next: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       oauth: 0.9.15
       openid-client: 5.4.2
       preact: 10.13.2
@@ -17813,7 +17889,7 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /next-intl@2.22.3(next@14.0.1)(react@18.2.0):
+  /next-intl@2.22.3(next@14.0.3)(react@18.2.0):
     resolution: {integrity: sha512-6HNPxWPO7JRKhrMKJJQTsq6AOd3Neu5fsH0EUCYCwkIMqlrud24BkI6zBocWoOgAaqVrNylXtn53xbVTw6hdYg==}
     deprecated: This was intended as 3.0, but CI accidentally published it as 2.22.3. Either stay on 2.22.1 or upgrade to 3.0
     peerDependencies:
@@ -17822,7 +17898,7 @@ packages:
     dependencies:
       '@formatjs/intl-localematcher': 0.2.32
       negotiator: 0.6.3
-      next: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       use-intl: 2.22.3(react@18.2.0)
     dev: false
@@ -17844,19 +17920,19 @@ packages:
       - supports-color
     dev: false
 
-  /next-seo@6.0.0(next@14.0.1)(react-dom@18.2.0)(react@18.2.0):
+  /next-seo@6.0.0(next@14.0.3)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-jKKt1p1z4otMA28AyeoAONixVjdYmgFCWwpEFtu+DwRHQDllVX3RjtyXbuCQiUZEfQ9rFPBpAI90vDeLZlMBdg==}
     peerDependencies:
       next: ^8.1.1-canary.54 || >=9.0.0
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      next: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /next-sitemap@4.0.7(@next/env@14.0.1)(next@14.0.1):
+  /next-sitemap@4.0.7(@next/env@14.0.1)(next@14.0.3):
     resolution: {integrity: sha512-S2g5IwJeO0+ecmFq981fb+Mw9YWmntOuN/qTCxclSkUibOJ8qKIOye0vn6NEJ1S4tKhbY+MTYKgJpNdFZYxLoA==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -17867,23 +17943,23 @@ packages:
       '@corex/deepmerge': 4.0.43
       '@next/env': 14.0.1
       minimist: 1.2.8
-      next: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
     dev: true
 
-  /next-themes@0.2.1(next@14.0.1)(react-dom@18.2.0)(react@18.2.0):
+  /next-themes@0.2.1(next@14.0.3)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==}
     peerDependencies:
       next: '*'
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /next@14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-s4YaLpE4b0gmb3ggtmpmV+wt+lPRuGtANzojMQ2+gmBpgX9w5fTbjsy6dXByBuENsdCX5pukZH/GxdFgO62+pA==}
+  /next@14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-AbYdRNfImBr3XGtvnwOxq8ekVCwbFTv/UJoLwmaX89nk9i051AEY4/HAWzU0YpaTDw8IofUpmuIlvzWF13jxIw==}
     engines: {node: '>=18.17.0'}
     hasBin: true
     peerDependencies:
@@ -17897,7 +17973,7 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 14.0.1
+      '@next/env': 14.0.3
       '@swc/helpers': 0.5.2
       busboy: 1.6.0
       caniuse-lite: 1.0.30001509
@@ -17907,20 +17983,20 @@ packages:
       styled-jsx: 5.1.1(@babel/core@7.22.5)(react@18.2.0)
       watchpack: 2.4.0
     optionalDependencies:
-      '@next/swc-darwin-arm64': 14.0.1
-      '@next/swc-darwin-x64': 14.0.1
-      '@next/swc-linux-arm64-gnu': 14.0.1
-      '@next/swc-linux-arm64-musl': 14.0.1
-      '@next/swc-linux-x64-gnu': 14.0.1
-      '@next/swc-linux-x64-musl': 14.0.1
-      '@next/swc-win32-arm64-msvc': 14.0.1
-      '@next/swc-win32-ia32-msvc': 14.0.1
-      '@next/swc-win32-x64-msvc': 14.0.1
+      '@next/swc-darwin-arm64': 14.0.3
+      '@next/swc-darwin-x64': 14.0.3
+      '@next/swc-linux-arm64-gnu': 14.0.3
+      '@next/swc-linux-arm64-musl': 14.0.3
+      '@next/swc-linux-x64-gnu': 14.0.3
+      '@next/swc-linux-x64-musl': 14.0.3
+      '@next/swc-win32-arm64-msvc': 14.0.3
+      '@next/swc-win32-ia32-msvc': 14.0.3
+      '@next/swc-win32-x64-msvc': 14.0.3
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  /nextra-theme-docs@2.13.2(next@14.0.1)(nextra@2.13.2)(react-dom@18.2.0)(react@18.2.0):
+  /nextra-theme-docs@2.13.2(next@14.0.3)(nextra@2.13.2)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-yE4umXaImp1/kf/sFciPj2+EFrNSwd9Db26hi98sIIiujzGf3+9eUgAz45vF9CwBw50FSXxm1QGRcY+slQ4xQQ==}
     peerDependencies:
       next: '>=9.5.3'
@@ -17937,17 +18013,17 @@ packages:
       git-url-parse: 13.1.0
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
-      next: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
-      next-seo: 6.0.0(next@14.0.1)(react-dom@18.2.0)(react@18.2.0)
-      next-themes: 0.2.1(next@14.0.1)(react-dom@18.2.0)(react@18.2.0)
-      nextra: 2.13.2(next@14.0.1)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+      next-seo: 6.0.0(next@14.0.3)(react-dom@18.2.0)(react@18.2.0)
+      next-themes: 0.2.1(next@14.0.3)(react-dom@18.2.0)(react@18.2.0)
+      nextra: 2.13.2(next@14.0.3)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.0.10
       zod: 3.22.4
     dev: false
 
-  /nextra@2.13.2(next@14.0.1)(react-dom@18.2.0)(react@18.2.0):
+  /nextra@2.13.2(next@14.0.3)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-pIgOSXNUqTz1laxV4ChFZOU7lzJAoDHHaBPj8L09PuxrLKqU1BU/iZtXAG6bQeKCx8EPdBsoXxEuENnL9QGnGA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -17967,7 +18043,7 @@ packages:
       gray-matter: 4.0.3
       katex: 0.16.9
       lodash.get: 4.4.2
-      next: 14.0.1(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.3(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       next-mdx-remote: 4.4.1(react-dom@18.2.0)(react@18.2.0)
       p-limit: 3.1.0
       react: 18.2.0
@@ -19416,7 +19492,6 @@ packages:
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.2
-    dev: false
 
   /postcss-import@15.1.0(postcss@8.4.31):
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -19437,7 +19512,6 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.24
-    dev: false
 
   /postcss-js@4.0.1(postcss@8.4.31):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
@@ -19463,7 +19537,6 @@ packages:
       lilconfig: 2.1.0
       postcss: 8.4.24
       yaml: 2.2.2
-    dev: false
 
   /postcss-load-config@4.0.1(postcss@8.4.31):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
@@ -19640,7 +19713,6 @@ packages:
     dependencies:
       postcss: 8.4.24
       postcss-selector-parser: 6.0.12
-    dev: false
 
   /postcss-nested@6.0.1(postcss@8.4.31):
     resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
@@ -19832,7 +19904,6 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: false
 
   /postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -22444,7 +22515,6 @@ packages:
       sucrase: 3.32.0
     transitivePeerDependencies:
       - ts-node
-    dev: false
 
   /tailwindcss@3.3.3:
     resolution: {integrity: sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==}


### PR DESCRIPTION
Fixes #250 



https://github.com/amannn/next-intl/assets/4038316/94281efc-5963-46ae-a782-8d2a3f058f1f



Turbo seemingly also supports HMR for JSON files (if the path is static)—this comes in quite handy!