### PR TITLE
fix: Don't set cookie on response if `localeDetection: false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <hr />
 
-📣 [Support for Next.js 13 and the App Router has arrived →](https://next-intl-docs.vercel.app/docs/next-13)
+📣 [Support for the App Router and Server Components has arrived →](https://next-intl-docs.vercel.app/docs/getting-started/app-router)
 
 <hr />
 

--- a/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
+++ b/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
@@ -33,7 +33,7 @@ type MiddlewareConfig<Locales extends AllLocales> =
     /** Sets the `Link` response header to notify search engines about content in other languages (defaults to `true`). See https://developers.google.com/search/docs/specialty/international/localized-versions#http */
     alternateLinks?: boolean;
 
-    /** By setting this to `false`, the `accept-language` header will no longer be used for locale detection. */
+    /** By setting this to `false`, the cookie as well as the `accept-language` header will no longer be used for locale detection. */
     localeDetection?: boolean;
 
     /** Maps internal pathnames to external ones which can be localized per locale. */

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -47,7 +47,9 @@ export default function createMiddleware<Locales extends AllLocales>(
     );
 
     const hasOutdatedCookie =
+      configWithDefaults.localeDetection &&
       request.cookies.get(COOKIE_LOCALE_NAME)?.value !== locale;
+
     const hasMatchedDefaultLocale = domain
       ? domain.defaultLocale === locale
       : locale === configWithDefaults.defaultLocale;

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -592,6 +592,13 @@ describe('prefix-based routing', () => {
         'http://localhost:3000/en'
       );
     });
+
+    it("doesn't set a cookie", () => {
+      const response = middleware(
+        createMockRequest('/', 'de', 'http://localhost:3000', undefined)
+      );
+      expect(response.cookies.getAll()).toEqual([]);
+    });
   });
 
   describe('localePrefix: always', () => {


### PR DESCRIPTION
Ref #609