### PR TITLE
fix: Apply correct port and protocol during domain-based redirects when called from an internal address (e.g. from a proxy)

### DIFF
--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -122,7 +122,7 @@
     },
     {
       "path": "dist/production/middleware.js",
-      "limit": "5.7 KB"
+      "limit": "5.72 KB"
     }
   ]
 }

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -36,6 +36,7 @@ export default function getAlternateLinksHeaderValue<
   }
   normalizedUrl.protocol =
     request.headers.get('x-forwarded-proto') ?? normalizedUrl.protocol;
+
   normalizedUrl.pathname = getNormalizedPathname(
     normalizedUrl.pathname,
     config.locales

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -70,11 +70,11 @@ export default function createMiddleware<Locales extends AllLocales>(
       return NextResponse.rewrite(new URL(url, request.url), getResponseInit());
     }
 
-    function redirect(url: string, host?: string) {
+    function redirect(url: string, redirectDomain?: string) {
       const urlObj = new URL(url, request.url);
 
       if (domainConfigs.length > 0) {
-        if (!host) {
+        if (!redirectDomain) {
           const bestMatchingDomain = getBestMatchingDomain(
             domain,
             locale,
@@ -82,7 +82,7 @@ export default function createMiddleware<Locales extends AllLocales>(
           );
 
           if (bestMatchingDomain) {
-            host = bestMatchingDomain.domain;
+            redirectDomain = bestMatchingDomain.domain;
 
             if (
               bestMatchingDomain.defaultLocale === locale &&
@@ -94,8 +94,11 @@ export default function createMiddleware<Locales extends AllLocales>(
         }
       }
 
-      if (host) {
-        urlObj.host = host;
+      if (redirectDomain) {
+        urlObj.protocol =
+          request.headers.get('x-forwarded-proto') ?? request.nextUrl.protocol;
+        urlObj.port = '';
+        urlObj.host = redirectDomain;
       }
 
       return NextResponse.redirect(urlObj.toString());

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -1735,7 +1735,11 @@ describe('domain-based routing', () => {
       locales: ['en', 'fr'],
       localePrefix: 'always',
       domains: [
-        {defaultLocale: 'en', domain: 'example.com', locales: ['en']},
+        {
+          defaultLocale: 'en',
+          domain: 'example.com',
+          locales: ['en']
+        },
         {
           defaultLocale: 'en',
           domain: 'ca.example.com',
@@ -1750,6 +1754,20 @@ describe('domain-based routing', () => {
       expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
         'http://example.com/en'
+      );
+    });
+
+    it('uses the correct port and protocol when being called from an internal address', () => {
+      middleware(
+        createMockRequest('/', 'fr', 'http://192.168.0.1:3000', undefined, {
+          'x-forwarded-host': 'ca.example.com',
+          'x-forwarded-proto': 'https'
+        })
+      );
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'https://ca.example.com/fr'
       );
     });
 


### PR DESCRIPTION
Fixes #658
