### PR TITLE
fix: Allow to call `getRequestConfig` in outer module closure in a Client Component module graph

### DIFF
--- a/packages/next-intl/src/server/react-client/index.tsx
+++ b/packages/next-intl/src/server/react-client/index.tsx
@@ -1,3 +1,14 @@
+import type {
+  getRequestConfig as getRequestConfig_type,
+  getFormatter as getFormatter_type,
+  getNow as getNow_type,
+  getTimeZone as getTimeZone_type,
+  getTranslations as getTranslations_type,
+  getMessages as getMessages_type,
+  getLocale as getLocale_type,
+  unstable_setRequestLocale as unstable_setRequestLocale_type
+} from '../react-server';
+
 /**
  * Allows to import `next-intl/server` in non-RSC environments.
  *
@@ -12,14 +23,27 @@ function notSupported(message: string) {
   };
 }
 
-export const getRequestConfig = notSupported('getRequestConfig');
-export const getFormatter = notSupported('getFormatter');
-export const getNow = notSupported('getNow');
-export const getTimeZone = notSupported('getTimeZone');
-export const getTranslations = notSupported('getTranslations');
-export const getMessages = notSupported('getMessages');
-export const getLocale = notSupported('getLocale');
+export function getRequestConfig(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  ...args: Parameters<typeof getRequestConfig_type>
+): ReturnType<typeof getRequestConfig_type> {
+  return notSupported('getRequestConfig');
+}
+export const getFormatter = notSupported(
+  'getFormatter'
+) as typeof getFormatter_type;
+export const getNow = notSupported('getNow') as typeof getNow_type;
+export const getTimeZone = notSupported(
+  'getTimeZone'
+) as typeof getTimeZone_type;
+export const getTranslations = notSupported(
+  'getTranslations'
+) as typeof getTranslations_type;
+export const getMessages = notSupported(
+  'getMessages'
+) as typeof getMessages_type;
+export const getLocale = notSupported('getLocale') as typeof getLocale_type;
 
 export const unstable_setRequestLocale = notSupported(
   'unstable_setRequestLocale'
-);
+) as typeof unstable_setRequestLocale_type;

--- a/packages/next-intl/test/server/react-client/index.test.tsx
+++ b/packages/next-intl/test/server/react-client/index.test.tsx
@@ -1,0 +1,21 @@
+import {describe, expect, it} from 'vitest';
+import {getRequestConfig} from '../../../src/server.react-client';
+
+describe('getRequestConfig', () => {
+  it('can be called in the outer module closure', () => {
+    expect(
+      getRequestConfig(({locale}) => ({
+        messages: {hello: 'Hello ' + locale}
+      }))
+    );
+  });
+
+  it('can not call the returned function', () => {
+    const getConfig = getRequestConfig(({locale}) => ({
+      messages: {hello: 'Hello ' + locale}
+    }));
+    expect(() => getConfig({locale: 'en'})).toThrow(
+      '`getRequestConfig` is not supported in Client Components.'
+    );
+  });
+});


### PR DESCRIPTION
Fixes #685 

This is fixed for compatibility, since we've silently supported this pattern previously. However, it's still not recommended to call `getRequestConfig` in a Client Component module graph as the function can't do anything useful there. Instead, you can extract shared config like `locales` to a file like [`src/navigation.ts`](https://next-intl-docs.vercel.app/docs/routing/navigation) or any other module that is then imported into Client and Server Components.