### PR TITLE
fix: Adjustment to the pathname generation when localePrefix is 'as-needed'

### DIFF
--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -87,8 +87,9 @@ export default function createMiddleware<Locales extends AllLocales>(
             if (
               bestMatchingDomain.defaultLocale === locale &&
               configWithDefaults.localePrefix === 'as-needed'
-            ) {              
-              urlObj.pathname = urlObj.pathname.replace(new RegExp(`\\/${locale}\\b`), '');
+            ) {
+              const regex = new RegExp(`\\/${locale}\\b`);
+              urlObj.pathname = urlObj.pathname.replace(regex, '');
             }
           }
         }

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -87,8 +87,8 @@ export default function createMiddleware<Locales extends AllLocales>(
             if (
               bestMatchingDomain.defaultLocale === locale &&
               configWithDefaults.localePrefix === 'as-needed'
-            ) {
-              urlObj.pathname = urlObj.pathname.replace(`/${locale}`, '');
+            ) {              
+              urlObj.pathname = urlObj.pathname.replace(new RegExp(`\\/${locale}\\b`), '');
             }
           }
         }

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -86,7 +86,8 @@ export default function createMiddleware<Locales extends AllLocales>(
 
             if (
               bestMatchingDomain.defaultLocale === locale &&
-              configWithDefaults.localePrefix === 'as-needed'
+              configWithDefaults.localePrefix === 'as-needed' &&
+              urlObj.pathname.startsWith(`/${locale}`)
             ) {
               const regex = new RegExp(`\\/${locale}\\b`);
               urlObj.pathname = urlObj.pathname.replace(regex, '');

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -96,7 +96,7 @@ export function getKnownLocaleFromPathname<Locales extends AllLocales>(
 }
 
 export function getBasePath(pathname: string, pathLocale: string) {
-  let result = pathname.replace(`/${pathLocale}`, '');
+  let result = pathname.replace(new RegExp(`\\/${pathLocale}\\b`), '');
   if (!result.startsWith('/')) {
     result = `/${result}`;
   }

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -96,7 +96,10 @@ export function getKnownLocaleFromPathname<Locales extends AllLocales>(
 }
 
 export function getBasePath(pathname: string, pathLocale: string) {
-  let result = pathname.replace(new RegExp(`\\/${pathLocale}\\b`), '');
+  let result = pathname;
+  if (pathname.startsWith(`/${pathLocale}`)) {
+    result = pathname.replace(new RegExp(`\\/${pathLocale}\\b`), '');
+  }
   if (!result.startsWith('/')) {
     result = `/${result}`;
   }


### PR DESCRIPTION
Right now in my current project if a url has `/${locale}` string in the url it's erased in several places. 
E.g. if the url is `https://domain.com/en/projects/energy` and the default locale is 'en' -> we end up with `https://domain.com/projectsergy`.
The above behaviour happens only when localePrefix is set to `as-needed`

This patch makes sure we are only replacing it if the pathname starts with `/${locale}` and using a word regex for safety.