### PR TITLE
fix: Correctly normalize pathname for redirects and alternate links when `localePrefix: 'as-needed'` is used with the default locale

### DIFF
--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -10,7 +10,6 @@ import resolveLocale from './resolveLocale';
 import {
   getInternalTemplate,
   formatTemplatePathname,
-  getBasePath,
   getBestMatchingDomain,
   getKnownLocaleFromPathname,
   getNormalizedPathname,
@@ -89,8 +88,10 @@ export default function createMiddleware<Locales extends AllLocales>(
               configWithDefaults.localePrefix === 'as-needed' &&
               urlObj.pathname.startsWith(`/${locale}`)
             ) {
-              const regex = new RegExp(`\\/${locale}\\b`);
-              urlObj.pathname = urlObj.pathname.replace(regex, '');
+              urlObj.pathname = getNormalizedPathname(
+                urlObj.pathname,
+                configWithDefaults.locales
+              );
             }
           }
         }
@@ -186,9 +187,9 @@ export default function createMiddleware<Locales extends AllLocales>(
         );
 
         if (hasLocalePrefix) {
-          const basePath = getBasePath(
+          const basePath = getNormalizedPathname(
             getPathWithSearch(normalizedPathname, request.nextUrl.search),
-            pathLocale
+            configWithDefaults.locales
           );
 
           if (configWithDefaults.localePrefix === 'never') {

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -87,8 +87,9 @@ export default function createMiddleware<Locales extends AllLocales>(
             if (
               bestMatchingDomain.defaultLocale === locale &&
               configWithDefaults.localePrefix === 'as-needed'
-            ) {              
-              urlObj.pathname = urlObj.pathname.replace(new RegExp(`\\/${locale}\\b`), '');
+            ) {
+              const regex = new RegExp(`\\/${locale}\\b`);
+              urlObj.pathname = urlObj.pathname.replace(regex, '');
             }
           }
         }

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -87,8 +87,8 @@ export default function createMiddleware<Locales extends AllLocales>(
             if (
               bestMatchingDomain.defaultLocale === locale &&
               configWithDefaults.localePrefix === 'as-needed'
-            ) {
-              urlObj.pathname = urlObj.pathname.replace(`/${locale}`, '');
+            ) {              
+              urlObj.pathname = urlObj.pathname.replace(new RegExp(`\\/${locale}\\b`), '');
             }
           }
         }

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -86,7 +86,8 @@ export default function createMiddleware<Locales extends AllLocales>(
 
             if (
               bestMatchingDomain.defaultLocale === locale &&
-              configWithDefaults.localePrefix === 'as-needed'
+              configWithDefaults.localePrefix === 'as-needed' &&
+              urlObj.pathname.startsWith(`/${locale}`)
             ) {
               const regex = new RegExp(`\\/${locale}\\b`);
               urlObj.pathname = urlObj.pathname.replace(regex, '');

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -73,8 +73,8 @@ export function getNormalizedPathname<Locales extends AllLocales>(
     pathname += '/';
   }
 
-  const match = pathname.match(`^/(${locales.join('|')})(.*)`);
-  let result = match ? match[2] : pathname;
+  const match = pathname.match(`^/(${locales.join('|')})/(.*)`);
+  let result = match ? '/' + match[2] : pathname;
 
   // Remove trailing slash
   if (result.endsWith('/') && result !== '/') {
@@ -93,17 +93,6 @@ export function getKnownLocaleFromPathname<Locales extends AllLocales>(
     ? pathLocaleCandidate
     : undefined;
   return pathLocale;
-}
-
-export function getBasePath(pathname: string, pathLocale: string) {
-  let result = pathname;
-  if (pathname.startsWith(`/${pathLocale}`)) {
-    result = pathname.replace(new RegExp(`\\/${pathLocale}\\b`), '');
-  }
-  if (!result.startsWith('/')) {
-    result = `/${result}`;
-  }
-  return result;
 }
 
 export function getRouteParams(template: string, pathname: string) {

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -96,7 +96,7 @@ export function getKnownLocaleFromPathname<Locales extends AllLocales>(
 }
 
 export function getBasePath(pathname: string, pathLocale: string) {
-  let result = pathname.replace(`/${pathLocale}`, '');
+  let result = pathname.replace(new RegExp(`\\/${pathLocale}\\b`), '');
   if (!result.startsWith('/')) {
     result = `/${result}`;
   }

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -96,7 +96,10 @@ export function getKnownLocaleFromPathname<Locales extends AllLocales>(
 }
 
 export function getBasePath(pathname: string, pathLocale: string) {
-  let result = pathname.replace(new RegExp(`\\/${pathLocale}\\b`), '');
+  let result = pathname;
+  if (pathname.startsWith(`/${pathLocale}`)) {
+    result = pathname.replace(new RegExp(`\\/${pathLocale}\\b`), '');
+  }
   if (!result.startsWith('/')) {
     result = `/${result}`;
   }

--- a/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/test/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -38,6 +38,18 @@ it('works for prefixed routing (as-needed)', () => {
     '<https://example.com/es/about>; rel="alternate"; hreflang="es"',
     '<https://example.com/about>; rel="alternate"; hreflang="x-default"'
   ]);
+
+  expect(
+    getAlternateLinksHeaderValue({
+      config,
+      request: new NextRequest('https://example.com/energy/es'),
+      resolvedLocale: 'en'
+    }).split(', ')
+  ).toEqual([
+    '<https://example.com/energy/es>; rel="alternate"; hreflang="en"',
+    '<https://example.com/es/energy/es>; rel="alternate"; hreflang="es"',
+    '<https://example.com/energy/es>; rel="alternate"; hreflang="x-default"'
+  ]);
 });
 
 it('works for prefixed routing (as-needed) with `pathnames`', () => {

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -179,6 +179,15 @@ describe('prefix-based routing', () => {
       );
     });
 
+    it('keeps route segments intact that start with the same characters as the locale', () => {
+      middleware(createMockRequest('/en/energy/overview/entry'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/energy/overview/entry'
+      );
+    });
+
     it('redirects requests for other locales', () => {
       middleware(createMockRequest('/', 'de'));
       expect(MockedNextResponse.next).not.toHaveBeenCalled();
@@ -932,6 +941,24 @@ describe('prefix-based routing', () => {
       );
       expect(MockedNextResponse.redirect.mock.calls[1][0].toString()).toBe(
         'http://localhost:3000/about?test=1'
+      );
+    });
+
+    it('keeps route segments intact that start with the same characters as the default locale', () => {
+      middleware(createMockRequest('/en/energy/overview/entry'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/energy/overview/entry'
+      );
+    });
+
+    it('keeps route segments intact that start with the same characters as a non-default locale', () => {
+      middleware(createMockRequest('/de/dentist/overview/delete'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/dentist/overview/delete'
       );
     });
 

--- a/packages/next-intl/test/middleware/utils.test.tsx
+++ b/packages/next-intl/test/middleware/utils.test.tsx
@@ -8,6 +8,8 @@ import {
 describe('getNormalizedPathname', () => {
   it('should return the normalized pathname', () => {
     expect(getNormalizedPathname('/en/about', ['en', 'de'])).toBe('/about');
+    expect(getNormalizedPathname('/en/energy', ['en', 'de'])).toBe('/energy');
+    expect(getNormalizedPathname('/energy', ['en'])).toBe('/energy');
     expect(getNormalizedPathname('/de/about', ['en', 'de'])).toBe('/about');
     expect(getNormalizedPathname('/about', ['en', 'de'])).toBe('/about');
     expect(getNormalizedPathname('/', ['en', 'de'])).toBe('/');


### PR DESCRIPTION
When removing the default locale from a path like `/en/energy`, the middleware would erroneously remove the characters `/en` not only from the beginning, but also from the middle when redirecting to the unprefixed version (i.e. `/ergy`).

This PR is based on the fix from https://github.com/amannn/next-intl/pull/692 by @anna-colenso.