### PR TITLE
fix: Use .default for message imports in pages router example

### DIFF
--- a/examples/example-pages-router-advanced/src/pages/404.tsx
+++ b/examples/example-pages-router-advanced/src/pages/404.tsx
@@ -14,7 +14,7 @@ export async function getStaticProps({locale}: GetStaticPropsContext) {
   return {
     props: {
       messages: pick(
-        await import(`../../messages/${locale}.json`),
+        (await import(`../../messages/${locale}.json`)).default,
         NotFound.messages
       )
     }

--- a/examples/example-pages-router-advanced/src/pages/about.tsx
+++ b/examples/example-pages-router-advanced/src/pages/about.tsx
@@ -26,7 +26,7 @@ export async function getServerSideProps({locale}: GetServerSidePropsContext) {
   return {
     props: {
       messages: pick(
-        await import(`../../messages/${locale}.json`),
+        (await import(`../../messages/${locale}.json`)).default,
         About.messages
       ),
       // Note that when `now` is passed to the app, you need to make sure the

--- a/examples/example-pages-router-advanced/src/pages/api/hello.tsx
+++ b/examples/example-pages-router-advanced/src/pages/api/hello.tsx
@@ -15,7 +15,7 @@ export default async function handler(
   const locale = resolveLocale(req);
 
   // Fetch messages based on the locale.
-  const messages = await import(`../../../messages/${locale}.json`);
+  const messages = (await import(`../../../messages/${locale}.json`)).default;
 
   // This creates the same function that is returned by `useTranslations`.
   // Since there's no provider, you can pass all the properties you'd

--- a/examples/example-pages-router-advanced/src/pages/index.tsx
+++ b/examples/example-pages-router-advanced/src/pages/index.tsx
@@ -40,7 +40,7 @@ export async function getStaticProps({locale}: GetStaticPropsContext) {
   return {
     props: {
       messages: pick(
-        await import(`../../messages/${locale}.json`),
+        (await import(`../../messages/${locale}.json`)).default,
         Index.messages
       )
     }


### PR DESCRIPTION
Hello and thanks for a great plugin! 
This is a small PR to help save someone 20 min of debugging. It adds `.default` to awaited imports of messages in the Advanced Pages Router example. This approach is used in every other example as far as I could tell.
