### PR TITLE
feat: added ability to not include `x-default` alternate link 

### DIFF
--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -241,6 +241,11 @@ export default createMiddleware({
   // ... other config
 
   alternateLinks: false // Defaults to `true`
+  // Alternatively, you can provide more verbose config:
+  // {
+  //   enabled: true,
+  //   includeXDefault: false,
+  // }
 });
 ```
 

--- a/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
+++ b/packages/next-intl/src/middleware/NextIntlMiddlewareConfig.tsx
@@ -23,13 +23,21 @@ export type DomainConfig<Locales extends AllLocales> = Omit<
   locales?: RoutingBaseConfig<Array<Locales[number]>>['locales'];
 };
 
+type AlternateLinksConfig =
+  | {
+      enabled: true;
+      includeXDefault: boolean;
+    }
+  | { enabled: false }
+  | boolean;
+
 type MiddlewareConfig<Locales extends AllLocales> =
   RoutingBaseConfig<Locales> & {
     /** Can be used to change the locale handling per domain. */
     domains?: Array<DomainConfig<Locales>>;
 
     /** Sets the `Link` response header to notify search engines about content in other languages (defaults to `true`). See https://developers.google.com/search/docs/specialty/international/localized-versions#http */
-    alternateLinks?: boolean;
+    alternateLinks?: AlternateLinksConfig;
 
     /** By setting this to `false`, the cookie as well as the `accept-language` header will no longer be used for locale detection. */
     localeDetection?: boolean;
@@ -44,7 +52,7 @@ type MiddlewareConfig<Locales extends AllLocales> =
 
 export type MiddlewareConfigWithDefaults<Locales extends AllLocales> =
   MiddlewareConfig<Locales> & {
-    alternateLinks: boolean;
+    alternateLinks: AlternateLinksConfig;
     localePrefix: LocalePrefix;
     localeDetection: boolean;
   };

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -115,11 +115,18 @@ export default function getAlternateLinksHeaderValue<
 
   // Add x-default entry
   if (!config.domains) {
-    const url = new URL(
-      getLocalizedPathname(normalizedUrl.pathname, config.defaultLocale),
-      normalizedUrl
-    );
-    links.push(getAlternateEntry(url, 'x-default'));
+    const { alternateLinks } = config;
+    if (
+      typeof alternateLinks === 'boolean'
+        ? alternateLinks === true
+        : alternateLinks.enabled === true && alternateLinks.includeXDefault
+    ) {
+      const url = new URL(
+        getLocalizedPathname(normalizedUrl.pathname, config.defaultLocale),
+        normalizedUrl
+      );
+      links.push(getAlternateEntry(url, 'x-default'));
+    }
   } else {
     // For domain-based routing there is no reasonable x-default
   }

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -265,7 +265,10 @@ export default function createMiddleware<Locales extends AllLocales>(
 
     if (
       configWithDefaults.localePrefix !== 'never' &&
-      configWithDefaults.alternateLinks &&
+      (typeof configWithDefaults.alternateLinks === 'boolean'
+        ? configWithDefaults.alternateLinks
+        : configWithDefaults.alternateLinks.enabled
+      ) &&
       configWithDefaults.locales.length > 1
     ) {
       response.headers.set(


### PR DESCRIPTION
# Why

> The reserved x-default value is used when no other language/region matches the user's browser setting.

If you want just redirect to defaultLocale language, you can use this approach: https://next-intl-docs.vercel.app/docs/environments/error-files#catching-non-localized-requests

Or, in my case: https://github.com/amannn/next-intl/discussions/720#discussioncomment-7844488

In my case I don't want to include `x-default` because this page is either 404 HTTP + JS redirect (as in docs approach) or 3xx HTTP redirect (as in my approach)

This is unnecessary work for crawlers and **potentially** damage SEO