### PR TITLE
fix: Improve performance when calling hooks like `useTranslations` in Server Components by making sure we only suspend when i18n config is loaded initially and never for subsequent calls

### DIFF
--- a/docs/pages/docs/environments/server-client-components.mdx
+++ b/docs/pages/docs/environments/server-client-components.mdx
@@ -117,6 +117,8 @@ If you implement components that qualify as shared components, it can be benefic
 
 However, there's no need to dogmatically use non-async functions exclusively for handling internationalization—use what fits your app best.
 
+In regard to performance, async functions and hooks can be used very much interchangeably. The configuration from [`i18n.ts`](/docs/usage/configuration#i18nts) is only loaded once upon first usage and both implementations use request-based caching internally where relevant. The only minor difference is that async functions have the benefit that rendering can be resumed right after an async function has been invoked. In contrast, in case a hook call triggers the initialization in `i18n.ts`, the component will suspend until the config is resolved and will re-render subsequently, possibly re-executing component logic prior to the hook call. However, once config has been resolved as part of a request, hooks will execute synchronously without suspending, resulting in less overhead in comparison to async functions since rendering can be resumed without having to wait for the microtask queue to flush (see [resuming a suspended component by replaying its execution](https://github.com/acdlite/rfcs/blob/first-class-promises/text/0000-first-class-support-for-promises.md#resuming-a-suspended-component-by-replaying-its-execution) in the corresponding React RFC).
+
 </details>
 
 ## Using internationalization in Client Components

--- a/packages/next-intl/__mocks__/react.tsx
+++ b/packages/next-intl/__mocks__/react.tsx
@@ -1,0 +1,49 @@
+// @ts-expect-error -- React uses CJS
+export * from 'react';
+
+export {default} from 'react';
+
+export function use(promise: Promise<unknown> & {value?: unknown}) {
+  if (!(promise instanceof Promise)) {
+    throw new Error('Expected a promise, got ' + typeof promise);
+  }
+
+  if (promise.value) {
+    return promise.value;
+  } else {
+    throw promise.then((value) => {
+      promise.value = value;
+      return promise;
+    });
+  }
+}
+
+const cached = {} as Record<string, unknown>;
+
+export function cache(fn: (...args: Array<unknown>) => unknown) {
+  if (!fn.name) {
+    throw new Error('Expected a named function for easier debugging');
+  }
+
+  function cachedFn(...args: Array<unknown>) {
+    const key = `${fn.name}(${args
+      .map((arg) => JSON.stringify(arg))
+      .join(', ')})`;
+
+    if (cached[key]) {
+      return cached[key];
+    } else {
+      const result = fn(...args);
+      cached[key] = result;
+      return result;
+    }
+  }
+
+  return cachedFn;
+}
+
+cache.reset = () => {
+  Object.keys(cached).forEach((key) => {
+    delete cached[key];
+  });
+};

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -114,7 +114,7 @@
     },
     {
       "path": "dist/production/index.react-server.js",
-      "limit": "13.6 KB"
+      "limit": "14.15 KB"
     },
     {
       "path": "dist/production/navigation.react-client.js",
@@ -130,7 +130,7 @@
     },
     {
       "path": "dist/production/server.react-server.js",
-      "limit": "12.8 KB"
+      "limit": "12.82 KB"
     },
     {
       "path": "dist/production/middleware.js",

--- a/packages/next-intl/src/react-server/getTranslator.tsx
+++ b/packages/next-intl/src/react-server/getTranslator.tsx
@@ -10,20 +10,22 @@ import {
   createTranslator,
   MarkupTranslationValues
 } from 'use-intl/core';
-import getConfig from '../server/react-server/getConfig';
 
-const getMessageFormatCache = cache(() => new Map());
+function getMessageFormatCacheImpl() {
+  return new Map();
+}
+const getMessageFormatCache = cache(getMessageFormatCacheImpl);
 
-async function getTranslatorImpl<
+function getTranslatorImpl<
   NestedKey extends NamespaceKeys<
     IntlMessages,
     NestedKeyOf<IntlMessages>
   > = never
 >(
-  locale: string,
+  config: Parameters<typeof createTranslator>[0],
   namespace?: NestedKey
 ): // Explicitly defining the return type is necessary as TypeScript would get it wrong
-Promise<{
+{
   // Default invocation
   <
     TargetKey extends MessageKeys<
@@ -101,13 +103,11 @@ Promise<{
   >(
     key: TargetKey
   ): any;
-}> {
-  const config = await getConfig(locale);
+} {
   return createTranslator({
     ...config,
     messageFormatCache: getMessageFormatCache(),
-    namespace,
-    messages: config.messages
+    namespace
   });
 }
 

--- a/packages/next-intl/src/react-server/useConfig.tsx
+++ b/packages/next-intl/src/react-server/useConfig.tsx
@@ -1,9 +1,8 @@
 import {use} from 'react';
+import getConfig from '../server/react-server/getConfig';
+import useLocale from './useLocale';
 
-export default function useHook<Value>(
-  hookName: string,
-  promise: Promise<Value>
-) {
+function useHook<Value>(hookName: string, promise: Promise<Value>) {
   try {
     return use(promise);
   } catch (error: any) {
@@ -19,4 +18,11 @@ export default function useHook<Value>(
       throw error;
     }
   }
+}
+
+export default function useConfig(
+  hookName: string
+): Awaited<ReturnType<typeof getConfig>> {
+  const locale = useLocale();
+  return useHook(hookName, getConfig(locale));
 }

--- a/packages/next-intl/src/react-server/useFormatter.tsx
+++ b/packages/next-intl/src/react-server/useFormatter.tsx
@@ -1,5 +1,6 @@
 import {cache} from 'react';
-import {createFormatter, type useFormatter as useFormatterType} from 'use-intl';
+import {type useFormatter as useFormatterType} from 'use-intl';
+import {createFormatter} from 'use-intl/core';
 import useConfig from './useConfig';
 
 const createFormatterCached = cache(createFormatter);

--- a/packages/next-intl/src/react-server/useFormatter.tsx
+++ b/packages/next-intl/src/react-server/useFormatter.tsx
@@ -1,12 +1,13 @@
-import type {useFormatter as useFormatterType} from 'use-intl';
-import getFormatter from '../server/react-server/getFormatter';
-import useHook from './useHook';
-import useLocale from './useLocale';
+import {cache} from 'react';
+import {createFormatter, type useFormatter as useFormatterType} from 'use-intl';
+import useConfig from './useConfig';
+
+const createFormatterCached = cache(createFormatter);
 
 export default function useFormatter(
   // eslint-disable-next-line no-empty-pattern
   ...[]: Parameters<typeof useFormatterType>
 ): ReturnType<typeof useFormatterType> {
-  const locale = useLocale();
-  return useHook('useFormatter', getFormatter({locale}));
+  const config = useConfig('useFormatter');
+  return createFormatterCached(config);
 }

--- a/packages/next-intl/src/react-server/useMessages.tsx
+++ b/packages/next-intl/src/react-server/useMessages.tsx
@@ -1,12 +1,11 @@
 import type {useMessages as useMessagesType} from 'use-intl';
-import getMessages from '../server/react-server/getMessages';
-import useHook from './useHook';
-import useLocale from './useLocale';
+import {getMessagesFromConfig} from '../server/react-server/getMessages';
+import useConfig from './useConfig';
 
 export default function useMessages(
   // eslint-disable-next-line no-empty-pattern
   ...[]: Parameters<typeof useMessagesType>
 ): ReturnType<typeof useMessagesType> {
-  const locale = useLocale();
-  return useHook('useMessages', getMessages({locale}));
+  const config = useConfig('useMessages');
+  return getMessagesFromConfig(config);
 }

--- a/packages/next-intl/src/react-server/useNow.tsx
+++ b/packages/next-intl/src/react-server/useNow.tsx
@@ -1,7 +1,5 @@
 import type {useNow as useNowType} from 'use-intl';
-import getNow from '../server/react-server/getNow';
-import useHook from './useHook';
-import useLocale from './useLocale';
+import useConfig from './useConfig';
 
 export default function useNow(
   ...[options]: Parameters<typeof useNowType>
@@ -12,6 +10,6 @@ export default function useNow(
     );
   }
 
-  const locale = useLocale();
-  return useHook('useNow', getNow({locale}));
+  const config = useConfig('useNow');
+  return config.now;
 }

--- a/packages/next-intl/src/react-server/useTimeZone.tsx
+++ b/packages/next-intl/src/react-server/useTimeZone.tsx
@@ -1,12 +1,10 @@
 import type {useTimeZone as useTimeZoneType} from 'use-intl';
-import getTimeZone from '../server/react-server/getTimeZone';
-import useHook from './useHook';
-import useLocale from './useLocale';
+import useConfig from './useConfig';
 
 export default function useTimeZone(
   // eslint-disable-next-line no-empty-pattern
   ...[]: Parameters<typeof useTimeZoneType>
 ): ReturnType<typeof useTimeZoneType> {
-  const locale = useLocale();
-  return useHook('useTimeZone', getTimeZone({locale}));
+  const config = useConfig('useTimeZone');
+  return config.timeZone;
 }

--- a/packages/next-intl/src/react-server/useTranslations.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.tsx
@@ -1,5 +1,6 @@
 import type {useTranslations as useTranslationsType} from 'use-intl';
-import getBaseTranslator from './getBaseTranslator';
+import getConfig from '../server/react-server/getConfig';
+import getBaseTranslator from './getTranslator';
 import useHook from './useHook';
 import useLocale from './useLocale';
 
@@ -7,11 +8,6 @@ export default function useTranslations(
   ...[namespace]: Parameters<typeof useTranslationsType>
 ): ReturnType<typeof useTranslationsType> {
   const locale = useLocale();
-
-  const result = useHook(
-    'useTranslations',
-    getBaseTranslator(locale, namespace)
-  );
-
-  return result;
+  const config = useHook('useTranslations', getConfig(locale));
+  return getBaseTranslator(config, namespace);
 }

--- a/packages/next-intl/src/react-server/useTranslations.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.tsx
@@ -1,13 +1,10 @@
 import type {useTranslations as useTranslationsType} from 'use-intl';
-import getConfig from '../server/react-server/getConfig';
 import getBaseTranslator from './getTranslator';
-import useHook from './useHook';
-import useLocale from './useLocale';
+import useConfig from './useConfig';
 
 export default function useTranslations(
   ...[namespace]: Parameters<typeof useTranslationsType>
 ): ReturnType<typeof useTranslationsType> {
-  const locale = useLocale();
-  const config = useHook('useTranslations', getConfig(locale));
+  const config = useConfig('useTranslations');
   return getBaseTranslator(config, namespace);
 }

--- a/packages/next-intl/src/server/react-server/RequestLocale.tsx
+++ b/packages/next-intl/src/server/react-server/RequestLocale.tsx
@@ -2,7 +2,7 @@ import {headers} from 'next/headers';
 import {cache} from 'react';
 import {HEADER_LOCALE_NAME} from '../../shared/constants';
 
-const getLocaleFromHeader = cache(() => {
+function getLocaleFromHeaderImpl() {
   let locale;
 
   try {
@@ -28,13 +28,15 @@ const getLocaleFromHeader = cache(() => {
   }
 
   return locale;
-});
+}
+const getLocaleFromHeader = cache(getLocaleFromHeaderImpl);
 
 // Workaround until `createServerContext` is available
-const getCache = cache(() => {
+function getCacheImpl() {
   const value: {locale?: string} = {locale: undefined};
   return value;
-});
+}
+const getCache = cache(getCacheImpl);
 
 export function setRequestLocale(locale: string) {
   getCache().locale = locale;

--- a/packages/next-intl/src/server/react-server/getConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getConfig.tsx
@@ -3,46 +3,45 @@ import {initializeConfig, IntlConfig} from 'use-intl/core';
 import createRequestConfig from './createRequestConfig';
 
 // Make sure `now` is consistent across the request in case none was configured
-const getDefaultNow = cache(() => new Date());
+function getDefaultNowImpl() {
+  return new Date();
+}
+const getDefaultNow = cache(getDefaultNowImpl);
 
 // This is automatically inherited by `NextIntlClientProvider` if
 // the component is rendered from a Server Component
-const getDefaultTimeZone = cache(
-  () => Intl.DateTimeFormat().resolvedOptions().timeZone
-);
+function getDefaultTimeZoneImpl() {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+const getDefaultTimeZone = cache(getDefaultTimeZoneImpl);
 
-const receiveRuntimeConfig = cache(
-  async (locale: string, getConfig?: typeof createRequestConfig) => {
-    let result = getConfig?.({locale});
-    if (result instanceof Promise) {
-      result = await result;
-    }
-    return {
-      ...result,
-      now: result?.now || getDefaultNow(),
-      timeZone: result?.timeZone || getDefaultTimeZone()
-    };
+async function receiveRuntimeConfigImpl(
+  locale: string,
+  getConfig?: typeof createRequestConfig
+) {
+  let result = getConfig?.({locale});
+  if (result instanceof Promise) {
+    result = await result;
   }
-);
+  return {
+    ...result,
+    now: result?.now || getDefaultNow(),
+    timeZone: result?.timeZone || getDefaultTimeZone()
+  };
+}
+const receiveRuntimeConfig = cache(receiveRuntimeConfigImpl);
 
-const getConfig = cache(
-  async (
-    locale: string
-  ): Promise<
-    IntlConfig & {
-      getMessageFallback: NonNullable<IntlConfig['getMessageFallback']>;
-      now: NonNullable<IntlConfig['now']>;
-      onError: NonNullable<IntlConfig['onError']>;
-      timeZone: NonNullable<IntlConfig['timeZone']>;
-    }
-  > => {
-    const runtimeConfig = await receiveRuntimeConfig(
-      locale,
-      createRequestConfig
-    );
-    const opts = {...runtimeConfig, locale};
-    return initializeConfig(opts);
+async function getConfigImpl(locale: string): Promise<
+  IntlConfig & {
+    getMessageFallback: NonNullable<IntlConfig['getMessageFallback']>;
+    now: NonNullable<IntlConfig['now']>;
+    onError: NonNullable<IntlConfig['onError']>;
+    timeZone: NonNullable<IntlConfig['timeZone']>;
   }
-);
-
+> {
+  const runtimeConfig = await receiveRuntimeConfig(locale, createRequestConfig);
+  const opts = {...runtimeConfig, locale};
+  return initializeConfig(opts);
+}
+const getConfig = cache(getConfigImpl);
 export default getConfig;

--- a/packages/next-intl/src/server/react-server/getFormatter.tsx
+++ b/packages/next-intl/src/server/react-server/getFormatter.tsx
@@ -3,10 +3,11 @@ import {createFormatter} from 'use-intl/core';
 import getConfig from './getConfig';
 import resolveLocaleArg from './resolveLocaleArg';
 
-const getFormatterImpl = cache(async (locale: string) => {
+async function getFormatterCachedImpl(locale: string) {
   const config = await getConfig(locale);
   return createFormatter(config);
-});
+}
+const getFormatterCached = cache(getFormatterCachedImpl);
 
 /**
  * Returns a formatter based on the given locale.
@@ -18,5 +19,5 @@ export default async function getFormatter(opts?: {
   locale?: string;
 }): Promise<ReturnType<typeof createFormatter>> {
   const locale = await resolveLocaleArg(opts);
-  return getFormatterImpl(locale);
+  return getFormatterCached(locale);
 }

--- a/packages/next-intl/src/server/react-server/getMessages.tsx
+++ b/packages/next-intl/src/server/react-server/getMessages.tsx
@@ -3,16 +3,20 @@ import type {AbstractIntlMessages} from 'use-intl';
 import getConfig from './getConfig';
 import resolveLocaleArg from './resolveLocaleArg';
 
-async function getMessagesCachedImpl(locale: string) {
-  const config = await getConfig(locale);
-
+export function getMessagesFromConfig(
+  config: Awaited<ReturnType<typeof getConfig>>
+): AbstractIntlMessages {
   if (!config.messages) {
     throw new Error(
       'No messages found. Have you configured them correctly? See https://next-intl-docs.vercel.app/docs/configuration#messages'
     );
   }
-
   return config.messages;
+}
+
+async function getMessagesCachedImpl(locale: string) {
+  const config = await getConfig(locale);
+  return getMessagesFromConfig(config);
 }
 const getMessagesCached = cache(getMessagesCachedImpl);
 

--- a/packages/next-intl/src/server/react-server/getMessages.tsx
+++ b/packages/next-intl/src/server/react-server/getMessages.tsx
@@ -3,7 +3,7 @@ import type {AbstractIntlMessages} from 'use-intl';
 import getConfig from './getConfig';
 import resolveLocaleArg from './resolveLocaleArg';
 
-const getMessagesImpl = cache(async (locale: string) => {
+async function getMessagesCachedImpl(locale: string) {
   const config = await getConfig(locale);
 
   if (!config.messages) {
@@ -13,11 +13,12 @@ const getMessagesImpl = cache(async (locale: string) => {
   }
 
   return config.messages;
-});
+}
+const getMessagesCached = cache(getMessagesCachedImpl);
 
 export default async function getMessages(opts?: {
   locale?: string;
 }): Promise<AbstractIntlMessages> {
   const locale = await resolveLocaleArg(opts);
-  return getMessagesImpl(locale);
+  return getMessagesCached(locale);
 }

--- a/packages/next-intl/src/server/react-server/getNow.tsx
+++ b/packages/next-intl/src/server/react-server/getNow.tsx
@@ -2,12 +2,13 @@ import {cache} from 'react';
 import getConfig from './getConfig';
 import resolveLocaleArg from './resolveLocaleArg';
 
-const getNowImpl = cache(async (locale: string) => {
+async function getNowCachedImpl(locale: string) {
   const config = await getConfig(locale);
   return config.now;
-});
+}
+const getNowCached = cache(getNowCachedImpl);
 
 export default async function getNow(opts?: {locale?: string}): Promise<Date> {
   const locale = await resolveLocaleArg(opts);
-  return getNowImpl(locale);
+  return getNowCached(locale);
 }

--- a/packages/next-intl/src/server/react-server/getTimeZone.tsx
+++ b/packages/next-intl/src/server/react-server/getTimeZone.tsx
@@ -2,14 +2,15 @@ import {cache} from 'react';
 import getConfig from './getConfig';
 import resolveLocaleArg from './resolveLocaleArg';
 
-const getTimeZoneImpl = cache(async (locale: string) => {
+async function getTimeZoneCachedImpl(locale: string) {
   const config = await getConfig(locale);
   return config.timeZone;
-});
+}
+const getTimeZoneCached = cache(getTimeZoneCachedImpl);
 
 export default async function getTimeZone(opts?: {
   locale?: string;
 }): Promise<string> {
   const locale = await resolveLocaleArg(opts);
-  return getTimeZoneImpl(locale);
+  return getTimeZoneCached(locale);
 }

--- a/packages/next-intl/test/navigation/createLocalizedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/test/navigation/createLocalizedPathnamesNavigation.test.tsx
@@ -29,12 +29,7 @@ vi.mock('next-intl/config', () => ({
       locale: 'en'
     })
 }));
-vi.mock('react', async (importOriginal) => ({
-  ...((await importOriginal()) as typeof import('react')),
-  cache(fn: (...args: Array<unknown>) => unknown) {
-    return (...args: Array<unknown>) => fn(...args);
-  }
-}));
+vi.mock('react');
 // Avoids handling an async component (not supported by renderToString)
 vi.mock('../../src/navigation/react-server/ServerLink', () => ({
   default({locale, ...rest}: any) {

--- a/packages/next-intl/test/navigation/createSharedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/test/navigation/createSharedPathnamesNavigation.test.tsx
@@ -28,12 +28,7 @@ vi.mock('next-intl/config', () => ({
       locale: 'en'
     })
 }));
-vi.mock('react', async (importOriginal) => ({
-  ...((await importOriginal()) as typeof import('react')),
-  cache(fn: (...args: Array<unknown>) => unknown) {
-    return (...args: Array<unknown>) => fn(...args);
-  }
-}));
+vi.mock('react');
 // Avoids handling an async component (not supported by renderToString)
 vi.mock('../../src/navigation/react-server/ServerLink', () => ({
   default({locale, ...rest}: any) {

--- a/packages/next-intl/test/react-server/index.test.tsx
+++ b/packages/next-intl/test/react-server/index.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {describe, expect, vi, it} from 'vitest';
+import {
+  useFormatter,
+  useLocale,
+  useMessages,
+  useNow,
+  useTranslations
+} from '../../src/react-server';
+import {renderToStream} from './utils';
+
+vi.mock('react');
+
+vi.mock('../../src/server/react-server/createRequestConfig', () => ({
+  default: async () => ({
+    messages: {
+      Component: {
+        title: 'Title'
+      }
+    }
+  })
+}));
+
+vi.mock('../../src/server/react-server/RequestLocale', () => ({
+  getRequestLocale: vi.fn(() => 'en')
+}));
+
+describe('performance', () => {
+  it('suspends only once when using a mixture of hooks', async () => {
+    let renderCount = 0;
+
+    function Component({quit}: {quit?: boolean}) {
+      renderCount++;
+
+      const t = useTranslations('Component');
+      const format = useFormatter();
+      const locale = useLocale();
+      const messages = useMessages();
+      const now = useNow();
+
+      return (
+        <>
+          {now.toISOString()}
+          {JSON.stringify(messages)}
+          {locale}
+          {format.number(1000)}
+          {t('title')}
+          {!quit && <Component quit />}
+        </>
+      );
+    }
+
+    await renderToStream(<Component />);
+
+    // Render 1: Suspends when `useTranslations` is encountered
+    // Render 2: Synchronously renders through
+    // Render 3: Recursive call that renders synchronously as well
+    expect(renderCount).toBe(3);
+  });
+});

--- a/packages/next-intl/test/react-server/useTranslations.test.tsx
+++ b/packages/next-intl/test/react-server/useTranslations.test.tsx
@@ -1,0 +1,253 @@
+import React, {Suspense, cache} from 'react';
+import {ReactDOMServerReadableStream} from 'react-dom/server';
+// @ts-expect-error -- Not available in types
+import {renderToReadableStream as _renderToReadableStream} from 'react-dom/server.browser';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+import {createTranslator, useTranslations} from '../../src/react-server';
+
+global.ReadableStream =
+  require('web-streams-polyfill/ponyfill/es6').ReadableStream;
+global.TextEncoder = require('util').TextEncoder;
+
+const renderToReadableStream: typeof import('react-dom/server').renderToReadableStream =
+  _renderToReadableStream;
+
+vi.mock('../../src/server/react-server/createRequestConfig', () => ({
+  default: async () => ({
+    messages: {
+      A: {
+        title: 'A'
+      },
+      B: {
+        title: 'B'
+      },
+      C: {
+        title: 'C'
+      }
+    }
+  })
+}));
+
+vi.mock('../../src/server/react-server/RequestLocale', () => ({
+  getRequestLocale: vi.fn(() => 'en')
+}));
+
+vi.mock('react');
+
+vi.mock('use-intl/core', async (importActual) => {
+  const actual: any = await importActual();
+  const {createTranslator: actualCreateTranslator} = actual;
+  return {
+    ...actual,
+    createTranslator: vi.fn(actualCreateTranslator)
+  };
+});
+
+async function readStream(stream: ReactDOMServerReadableStream) {
+  const reader = stream.getReader();
+  let result = '';
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const {done, value} = await reader.read();
+    if (done) break;
+    result += Buffer.from(value).toString('utf8');
+  }
+  return result;
+}
+
+describe('performance', () => {
+  let attemptedRenders: Record<string, number>;
+  let finishedRenders: Record<string, number>;
+
+  beforeEach(() => {
+    attemptedRenders = {};
+    finishedRenders = {};
+    (cache as any).reset();
+  });
+
+  function attempt(componentName: string) {
+    attemptedRenders[componentName] ??= 0;
+    attemptedRenders[componentName]++;
+  }
+
+  function finish(componentName: string) {
+    finishedRenders[componentName] ??= 0;
+    finishedRenders[componentName]++;
+  }
+
+  it('suspends only once when rendering the same component twice (i.e. multiple `useTranslations` calls with the same namespace)', async () => {
+    function A({quit}: {quit?: boolean}) {
+      attempt('A');
+      const t = useTranslations('A');
+      finish('A');
+      return (
+        <>
+          {t('title')}
+          {!quit && <A quit />}
+        </>
+      );
+    }
+
+    await readStream(
+      await renderToReadableStream(
+        <Suspense>
+          <A />
+        </Suspense>
+      )
+    );
+
+    expect({attemptedRenders, finishedRenders}).toMatchInlineSnapshot(`
+      {
+        "attemptedRenders": {
+          "A": 3,
+        },
+        "finishedRenders": {
+          "A": 2,
+        },
+      }
+    `);
+  });
+
+  it('suspends only once when rendering different components (i.e. multiple `useTranslations` calls with a different namespace)', async () => {
+    function A() {
+      attempt('A');
+      const t = useTranslations('A');
+      finish('A');
+      return (
+        <>
+          {t('title')}
+          <B />
+        </>
+      );
+    }
+
+    function B() {
+      attempt('B');
+      const t = useTranslations('B');
+      finish('B');
+      return t('title');
+    }
+
+    await readStream(
+      await renderToReadableStream(
+        <Suspense>
+          <A />
+        </Suspense>
+      )
+    );
+
+    expect({attemptedRenders, finishedRenders}).toMatchInlineSnapshot(`
+      {
+        "attemptedRenders": {
+          "A": 2,
+          "B": 1,
+        },
+        "finishedRenders": {
+          "A": 1,
+          "B": 1,
+        },
+      }
+    `);
+  });
+
+  it('resolves the config only once for a complex tree', async () => {
+    function A() {
+      attempt('A');
+      const t = useTranslations('A');
+      finish('A');
+      return t('title');
+    }
+
+    function B() {
+      attempt('B');
+      const t = useTranslations('B');
+      finish('B');
+      return t('title');
+    }
+
+    function C() {
+      attempt('C');
+      const t = useTranslations();
+      finish('C');
+      return t('C.title');
+    }
+
+    function E() {
+      attempt('E');
+      finish('E');
+      return <A />;
+    }
+
+    function D() {
+      attempt('D');
+      finish('D');
+      return (
+        <>
+          <A />
+          <B />
+          <C />
+          <E />
+        </>
+      );
+    }
+
+    await readStream(
+      await renderToReadableStream(
+        <Suspense>
+          <A />
+          <B />
+          <C />
+          <D />
+        </Suspense>
+      )
+    );
+
+    expect({attemptedRenders, finishedRenders}).toMatchInlineSnapshot(`
+      {
+        "attemptedRenders": {
+          "A": 6,
+          "B": 4,
+          "C": 4,
+          "D": 1,
+          "E": 1,
+        },
+        "finishedRenders": {
+          "A": 3,
+          "B": 2,
+          "C": 2,
+          "D": 1,
+          "E": 1,
+        },
+      }
+    `);
+  });
+
+  it('instantiates a single translator per namespace', async () => {
+    vi.mocked(createTranslator).mockImplementation(() => (() => 'Test') as any);
+
+    function Component() {
+      useTranslations('CreateTranslatorInstancesTest-1');
+      useTranslations('CreateTranslatorInstancesTest-1');
+      useTranslations('CreateTranslatorInstancesTest-2');
+      return null;
+    }
+    await readStream(
+      await renderToReadableStream(
+        <>
+          <Component />
+        </>
+      )
+    );
+
+    function getCalls(namespace: string) {
+      return vi
+        .mocked(createTranslator)
+        .mock.calls.filter(
+          ([{namespace: _namespace}]) => _namespace === namespace
+        );
+    }
+
+    expect(getCalls('CreateTranslatorInstancesTest-1').length).toEqual(1);
+    expect(getCalls('CreateTranslatorInstancesTest-2').length).toEqual(1);
+  });
+});

--- a/packages/next-intl/test/react-server/utils.tsx
+++ b/packages/next-intl/test/react-server/utils.tsx
@@ -1,0 +1,25 @@
+import React, {ReactNode, Suspense} from 'react';
+import {ReactDOMServerReadableStream} from 'react-dom/server';
+// @ts-expect-error -- Not available in types
+import {renderToReadableStream as _renderToReadableStream} from 'react-dom/server.browser';
+
+const renderToReadableStream: typeof import('react-dom/server').renderToReadableStream =
+  _renderToReadableStream;
+
+async function readStream(stream: ReactDOMServerReadableStream) {
+  const reader = stream.getReader();
+  let result = '';
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const {done, value} = await reader.read();
+    if (done) break;
+    result += Buffer.from(value).toString('utf8');
+  }
+  return result;
+}
+
+export async function renderToStream(children: ReactNode) {
+  return readStream(
+    await renderToReadableStream(<Suspense>{children}</Suspense>)
+  );
+}

--- a/packages/next-intl/test/server/react-server/index.test.tsx
+++ b/packages/next-intl/test/server/react-server/index.test.tsx
@@ -40,15 +40,7 @@ vi.mock('next/headers', () => ({
   })
 }));
 
-vi.mock('react', async (importOriginal) => {
-  const React = (await importOriginal()) as typeof import('react');
-  return {
-    ...React,
-    cache(fn: (...args: Array<unknown>) => unknown) {
-      return (...args: Array<unknown>) => fn(...args);
-    }
-  };
-});
+vi.mock('react');
 
 describe('getTranslations', () => {
   it('works with an implicit locale', async () => {

--- a/packages/next-intl/tsconfig.json
+++ b/packages/next-intl/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "eslint-config-molindo/tsconfig.json",
-  "include": ["src", "test", "types", "next-env.d.ts"],
+  "include": ["src", "test", "__mocks__", "types", "next-env.d.ts"],
   "compilerOptions": {
     "moduleDetection": "force",
     "isolatedModules": true,

--- a/packages/use-intl/src/core/createTranslator.tsx
+++ b/packages/use-intl/src/core/createTranslator.tsx
@@ -33,7 +33,7 @@ export default function createTranslator<
   onError = defaultOnError,
   ...rest
 }: Omit<IntlConfig<IntlMessages>, 'defaultTranslationValues' | 'messages'> & {
-  messages: IntlConfig<IntlMessages>['messages'];
+  messages?: IntlConfig<IntlMessages>['messages'];
   namespace?: NestedKey;
   /** @private */
   messageFormatCache?: MessageFormatCache;


### PR DESCRIPTION
Fixes https://github.com/amannn/next-intl/issues/734 by making sure we suspend only once when loading configuration.

See also https://github.com/acdlite/rfcs/blob/first-class-promises/text/0000-first-class-support-for-promises.md#resuming-a-suspended-component-by-replaying-its-execution
