### PR TITLE
feat: Invoke `notFound()` when no locale was attached to the request and update docs to suggest validating the locale in `i18n.ts`

### DIFF
--- a/docs/pages/docs/environments/error-files.mdx
+++ b/docs/pages/docs/environments/error-files.mdx
@@ -45,23 +45,23 @@ After this change, all requests that are matched within the `[locale]` segment w
 
 ### Catching non-localized requests
 
-When the user requests a route that is not matched by [the `next-intl` middleware](/docs/routing/middleware), there's no locale associated with the request (depending on your `matcher` config, e.g. `/unknown.txt` might not be matched).
+When the user requests a route that is not matched by [the `next-intl` middleware](/docs/routing/middleware), there's no locale associated with the request (depending on your [`matcher` config](/docs/routing/middleware#matcher-config), e.g. `/unknown.txt` might not be matched).
 
 You can add a root `not-found` page to handle these cases too.
 
 ```tsx filename="app/not-found.tsx"
 'use client';
 
-import {redirect, usePathname} from 'next/navigation';
-
-// Can be imported from a shared config
-const defaultLocale = 'en';
+import Error from 'next/error';
 
 export default function NotFound() {
-  const pathname = usePathname();
-
-  // Add a locale prefix to show a localized not found page
-  redirect(`/${defaultLocale}${pathname}`);
+  return (
+    <html lang="en">
+      <body>
+        <Error statusCode={404} />
+      </body>
+    </html>
+  );
 }
 ```
 
@@ -75,25 +75,25 @@ export default function RootLayout({children}) {
 }
 ```
 
-For the 404 page to render, we need to call the `notFound` function within `[locale]/layout.tsx` when we detect an incoming `locale` param that isn't a valid locale.
+For the 404 page to render, we need to call the `notFound` function in [`i18n.ts`](/docs/usage/configuration#i18nts) when we detect an incoming `locale` param that isn't a valid locale.
 
-```tsx filename="app/[locale]/layout.tsx"
-import {useLocale} from 'next-intl';
-import {notFound} from 'next/navigation';
+```tsx filename="i18n.ts"
+import {getRequestConfig} from 'next-intl/server';
 
+// Can be imported from a shared config
 const locales = ['en', 'de'];
 
-export default function LocaleLayout({children, params}) {
+export default getRequestConfig(async ({locale}) => {
   // Validate that the incoming `locale` parameter is valid
   if (!locales.includes(locale as any)) notFound();
 
-  return (
-    <html lang={locale}>
-      <body>{children}</body>
-    </html>
-  );
-}
+  return {
+    // ...
+  };
+});
 ```
+
+Note that `next-intl` will also call the `notFound` function internally when it tries to resolve a locale for component usage, but can not find one attached to the request (either from the middleware, or manually via [`unstable_setRequestLocale`](https://next-intl-docs.vercel.app/docs/getting-started/app-router#static-rendering)).
 
 ## `error.js`
 
@@ -159,7 +159,7 @@ export default function Error({error, reset}) {
 }
 ```
 
-Note that `error.tsx` is loaded as soon as the app starts. If your app is performance-senstive and you want to avoid loading translation functionality from `next-intl` as part of the initial bundle, you can export a lazy reference from your `error` file:
+Note that `error.tsx` is loaded right after your app has initialized. If your app is performance-senstive and you want to avoid loading translation functionality from `next-intl` as part of the initial bundle, you can export a lazy reference from your `error` file:
 
 ```tsx filename="app/[locale]/error.tsx"
 'use client';

--- a/docs/pages/docs/environments/server-client-components.mdx
+++ b/docs/pages/docs/environments/server-client-components.mdx
@@ -26,7 +26,6 @@ Moving internationalization to the server side unlocks new levels of performance
 2. Library code for internationalization doesn't need to be loaded on the client side
 3. No need to split your messages, e.g. based on routes or components
 4. No runtime cost on the client side
-5. No need to handle environment differences like different time zones on the server and client
 
 ## Using internationalization in Server Components
 

--- a/docs/pages/docs/getting-started/app-router.mdx
+++ b/docs/pages/docs/getting-started/app-router.mdx
@@ -66,9 +66,17 @@ module.exports = withNextIntl({
 ```tsx filename="src/i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 
-export default getRequestConfig(async ({locale}) => ({
-  messages: (await import(`../messages/${locale}.json`)).default
-}));
+// Can be imported from a shared config
+const locales = ['en', 'de'];
+
+export default getRequestConfig(async ({locale}) => {
+  // Validate that the incoming `locale` parameter is valid
+  if (!locales.includes(locale as any)) notFound();
+
+  return {
+    messages: (await import(`../messages/${locale}.json`)).default
+  };
+});
 ```
 
 <details>
@@ -117,15 +125,7 @@ export const config = {
 The `locale` that was matched by the middleware is available via the `locale` param and can be used to configure the document language.
 
 ```tsx filename="app/[locale]/layout.tsx"
-import {notFound} from 'next/navigation';
-
-// Can be imported from a shared config
-const locales = ['en', 'de'];
-
 export default function LocaleLayout({children, params: {locale}}) {
-  // Validate that the incoming `locale` parameter is valid
-  if (!locales.includes(locale as any)) notFound();
-
   return (
     <html lang={locale}>
       <body>{children}</body>
@@ -190,6 +190,7 @@ By using APIs like `useTranslations` from `next-intl` in Server Components, your
 Since we use a dynamic route segment for the `[locale]` param, we need to provide all possible values via [`generateStaticParams`](https://nextjs.org/docs/app/api-reference/functions/generate-static-params) to Next.js, so the routes can be rendered at build time.
 
 ```tsx filename="app/[locale]/layout.tsx"
+// Can be imported from a shared config
 const locales = ['en', 'de'];
 
 export function generateStaticParams() {
@@ -199,20 +200,12 @@ export function generateStaticParams() {
 
 ### Add `unstable_setRequestLocale` to all layouts and pages
 
-`next-intl` provides a temporary API that can be used to distribute the locale that is received via `params` in a layout or page for usage in all Server Components that are rendered as part of the request.
+`next-intl` provides a temporary API that can be used to distribute the locale that is received via `params` in layouts and pages for usage in all Server Components that are rendered as part of the request.
 
 ```tsx filename="app/[locale]/layout.tsx"
 import {unstable_setRequestLocale} from 'next-intl/server';
 
-const locales = ['en', 'de'];
-
-export default async function LocaleLayout({
-  children,
-  params: {locale}
-}) {
-  // Validate that the incoming `locale` parameter is valid
-  if (!locales.includes(locale as any)) notFound();
-
+export default async function LocaleLayout({children, params: {locale}}) {
   unstable_setRequestLocale(locale);
 
   return (
@@ -223,11 +216,8 @@ export default async function LocaleLayout({
 
 ```tsx filename="app/[locale]/page.tsx"
 import {unstable_setRequestLocale} from 'next-intl/server';
-import {locales} from '..';
 
-export default function IndexPage({
-  params: {locale}
-}) {
+export default function IndexPage({params: {locale}}) {
   unstable_setRequestLocale(locale);
 
   // Once the request locale is set, you
@@ -242,7 +232,7 @@ export default function IndexPage({
 
 **Keep in mind that:**
 
-1. `unstable_setRequestLocale` needs to be called after the `locale` is validated, but before you call any hooks from `next-intl`. Otherwise, you'll get an error when trying to prerender the page.
+1. The locale that you pass to `unstable_setRequestLocale` should be validated (either immediately after receiving it via `params` or in [`i18n.ts`](/docs/usage/configuration#i18nts)). Otherwise, you'll get an error when trying to prerender the page.
 
 2. You need to call this function in every page and every layout that you intend to enable static rendering for since Next.js can render layouts and pages independently.
 
@@ -275,7 +265,7 @@ Due to this, `next-intl` uses its middleware to attach an `x-next-intl-locale` h
 
 However, the usage of `headers` opts the route into dynamic rendering.
 
-By using `unstable_setRequestLocale`, you can provide the locale that is received in layouts and pages via `params` to `next-intl`. By doing this, all APIs from `next-intl` can now read from this value instead of the header, enabling static rendering.
+By using `unstable_setRequestLocale`, you can provide the locale that is received in layouts and pages via `params` to `next-intl`. All APIs from `next-intl` can now read from this value instead of the header, enabling static rendering.
 
 </details>
 

--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -632,3 +632,5 @@ To recover from this error, please make sure that:
 3. Your [middleware matcher](#matcher-config) matches all routes of your application, including dynamic segments with potentially unexpected characters like dots (e.g. `/users/jane.doe`).
 4. If you're using [`localePrefix: 'as-needed'`](#locale-prefix-as-needed), the `locale` segment effectively acts like a catch-all for all unknown routes. You should make sure that `params.locale` is [validated](/docs/getting-started/app-router#applocalelayouttsx) before it's used by any APIs from `next-intl`.
 5. To implement static rendering properly, make sure to [provide a static locale](/docs/getting-started/app-router#static-rendering) to `next-intl`.
+
+Note that `next-intl` will print this warning only during development and will invoke the `notFound()` function to abort the render.

--- a/docs/pages/docs/usage/configuration.mdx
+++ b/docs/pages/docs/usage/configuration.mdx
@@ -11,15 +11,23 @@ Configuration properties that you use across your Next.js app can be set globall
 Depending on if you handle [internationalization in Client- or Server Components](/docs/environments/server-client-components), the configuration from `i18n.ts` or `NextIntlClientProvider` will be applied respectively.
 
 ### `i18n.ts`
-  
+
 `i18n.ts` can be used to provide configuration for **Server Components**.
 
 ```tsx filename="i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 
-export default getRequestConfig(async ({locale}) => ({
-  messages: (await import(`../messages/${locale}.json`)).default
-}));
+// Can be imported from a shared config
+const locales = ['en', 'de'];
+
+export default getRequestConfig(async ({locale}) => {
+  // Validate that the incoming `locale` parameter is valid
+  if (!locales.includes(locale as any)) notFound();
+
+  return {
+    messages: (await import(`../messages/${locale}.json`)).default
+  };
+});
 ```
 
 The configuration object is created once for each request by internally using React's [`cache`](https://nextjs.org/docs/app/building-your-application/data-fetching/caching#react-cache). The first component to use internationalization will call the function defined with `getRequestConfig`.
@@ -29,16 +37,11 @@ The configuration object is created once for each request by internally using Re
 `NextIntlClientProvider` can be used to provide configuration for **Client Components**.
 
 ```tsx filename="app/[locale]/layout.tsx" /NextIntlClientProvider/
-import {NextIntlClientProvider} from 'next-intl';
+import {NextIntlClientProvider, useMessages} from 'next-intl';
 import {notFound} from 'next/navigation';
 
-export default async function LocaleLayout({children, params: {locale}}) {
-  let messages;
-  try {
-    messages = (await import(`../../messages/${locale}.json`)).default;
-  } catch (error) {
-    notFound();
-  }
+export default function LocaleLayout({children, params: {locale}}) {
+  const messages = useMessages();
 
   return (
     <html lang={locale}>
@@ -52,8 +55,12 @@ export default async function LocaleLayout({children, params: {locale}}) {
 }
 ```
 
+`NextIntlClientProvider` inherits the props `locale`, `now` and `timeZone` when the component is rendered from a Server Component. Other configuration like `messages` and `formats` can be provided as necessary.
+
 <Callout>
-  `NextIntlClientProvider` inherits the props `locale`, `now` and `timeZone` when the component is rendered from a Server Component. Other configuration like `messages` and `formats` can be provided as necessary.
+  Before passing all messages to the client side, learn more about the options
+  you have to [use internationalization in Client
+  Components](/docs/environments/server-client-components).
 </Callout>
 
 ## Messages
@@ -74,9 +81,13 @@ The most crucial aspect of internationalization is providing labels based on the
 ```tsx filename="i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 
-export default getRequestConfig(async ({locale}) => ({
-  messages: (await import(`../messages/${locale}.json`)).default
-}));
+export default getRequestConfig(async ({locale}) => {
+  // ...
+
+  return {
+    messages: (await import(`../messages/${locale}.json`)).default
+  };
+});
 ```
 
 </Tab>
@@ -156,17 +167,20 @@ Specifying a time zone affects the rendering of dates and times. By default, the
 
 <Tabs items={['i18n.ts', 'Provider']}>
 <Tab>
-  
+
 ```tsx filename="i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 
-export default getRequestConfig(async ({locale}) => ({
-  // The time zone can either be statically defined, read from the
-  // user profile if you store such a setting, or based on dynamic 
-  // request information like the locale or headers.
-  timeZone: 'Europe/Vienna',
+export default getRequestConfig(async ({locale}) => {
   // ...
-}));
+
+  return {
+    // The time zone can either be statically defined, read from the
+    // user profile if you store such a setting, or based on dynamic 
+    // request information like the locale or headers.
+    timeZone: 'Europe/Vienna'
+  };
+});
 ```
 
 </Tab>
@@ -187,7 +201,10 @@ const timeZone = 'Europe/Vienna';
 The available time zone names can be looked up in [the tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 <Callout>
-The time zone in Client Components is automatically inherited from the server side if you wrap the relevant components in a `NextIntlClientProvider` that is rendered by a Server Component. For all other cases, you can specify the value explicitly.
+  The time zone in Client Components is automatically inherited from the server
+  side if you wrap the relevant components in a `NextIntlClientProvider` that is
+  rendered by a Server Component. For all other cases, you can specify the value
+  explicitly.
 </Callout>
 
 ## Now value [#now]
@@ -202,12 +219,15 @@ If you prefer to override the default, you can provide an explicit value for `no
 ```tsx filename="i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 
-export default getRequestConfig(async ({locale}) => ({
-  // This is the default, a single date instance will be used 
-  // by all Server Components to ensure consistency
-  now: new Date(), 
+export default getRequestConfig(async ({locale}) => {
   // ...
-}));
+
+  return {
+    // This is the default, a single date instance will be used 
+    // by all Server Components to ensure consistency
+    now: new Date()
+  };
+});
 ```
 
 </Tab>
@@ -216,7 +236,7 @@ export default getRequestConfig(async ({locale}) => ({
 ```tsx
 const now = new Date('2020-11-20T10:36:01.516Z');
 
-<NextIntlClientProvider now={now}>...</NextIntlClientProvider>
+<NextIntlClientProvider now={now}>...</NextIntlClientProvider>;
 ```
 
 </Tab>
@@ -224,16 +244,11 @@ const now = new Date('2020-11-20T10:36:01.516Z');
 
 **Tip:** For consistent results in end-to-end tests, it can be helpful to mock this value to a constant value, e.g. based on an environment parameter.
 
-<Callout type="warning">
-  **Important:** When you cache the rendered markup (e.g. when using [static
-  rendering](https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic-rendering#static-rendering-default)),
-  the formatted value will become stale. Therefore either regenerate these pages
-  regularly or use the `updateInterval` option of
-  [`useNow`](/docs/usage/dates-times#usenow) on the client side.
-</Callout>
-
 <Callout>
-Similarly to the `timeZone`, the `now` value in Client Components is automatically inherited from the server side if you wrap the relevant components in a `NextIntlClientProvider` that is rendered by a Server Component.
+  Similarly to the `timeZone`, the `now` value in Client Components is
+  automatically inherited from the server side if you wrap the relevant
+  components in a `NextIntlClientProvider` that is rendered by a Server
+  Component.
 </Callout>
 
 ## Formats
@@ -246,29 +261,32 @@ To achieve consistent date, time, number and list formatting, you can define a s
 ```tsx filename="i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 
-export default getRequestConfig(async ({locale}) => ({
-  formats: {
-    dateTime: {
-      short: {
-        day: 'numeric',
-        month: 'short',
-        year: 'numeric'
-      }
-    },
-    number: {
-      precise: {
-        maximumFractionDigits: 5
-      }
-    },
-    list: {
-      enumeration: {
-        style: 'long',
-        type: 'conjunction'
+export default getRequestConfig(async ({locale}) => {
+  // ...
+
+  return {
+    formats: {
+      dateTime: {
+        short: {
+          day: 'numeric',
+          month: 'short',
+          year: 'numeric'
+        }
+      },
+      number: {
+        precise: {
+          maximumFractionDigits: 5
+        }
+      },
+      list: {
+        enumeration: {
+          style: 'long',
+          type: 'conjunction'
+        }
       }
     }
-  },
-  // ...
-}));
+  };
+});
 ```
 
 </Tab>
@@ -348,13 +366,16 @@ To achieve consistent usage of translation values and reduce redundancy, you can
 ```tsx filename="i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 
-export default getRequestConfig(async ({locale}) => ({
-  defaultTranslationValues: {
-    important: (chunks) => <b>{chunks}</b>,
-    value: 123
-  }
+export default getRequestConfig(async ({locale}) => {
   // ...
-}));
+
+  return {
+    defaultTranslationValues: {
+      important: (chunks) => <b>{chunks}</b>,
+      value: 123
+    }
+  };
+});
 ```
 
 </Tab>
@@ -389,28 +410,31 @@ This behavior can be customized with the `onError` and `getMessageFallback` conf
 import {getRequestConfig} from 'next-intl/server';
 import {IntlErrorCode} from 'next-intl';
 
-export default getRequestConfig(async ({locale}) => ({
-  onError(error) {
-    if (error.code === IntlErrorCode.MISSING_MESSAGE) {
-      // Missing translations are expected and should only log an error
-      console.error(error);
-    } else {
-      // Other errors indicate a bug in the app and should be reported
-      reportToErrorTracking(error);
-    }
-  },
-  getMessageFallback({namespace, key, error}) {
-    const path = [namespace, key].filter((part) => part != null).join('.');
-
-    if (error.code === IntlErrorCode.MISSING_MESSAGE) {
-      return path + ' is not yet translated';
-    } else {
-      return 'Dear developer, please fix this message: ' + path;
-    }
-  },
+export default getRequestConfig(async ({locale}) => {
   // ...
-}));
-```
+
+  return {
+    onError(error) {
+      if (error.code === IntlErrorCode.MISSING_MESSAGE) {
+        // Missing translations are expected and should only log an error
+        console.error(error);
+      } else {
+        // Other errors indicate a bug in the app and should be reported
+        reportToErrorTracking(error);
+      }
+    },
+    getMessageFallback({namespace, key, error}) {
+      const path = [namespace, key].filter((part) => part != null).join('.');
+
+      if (error.code === IntlErrorCode.MISSING_MESSAGE) {
+        return path + ' is not yet translated';
+      } else {
+        return 'Dear developer, please fix this message: ' + path;
+      }
+    }
+  };
+});
+````
 
 </Tab>
 <Tab>

--- a/examples/example-app-router-playground/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/layout.tsx
@@ -1,5 +1,4 @@
 import {Metadata} from 'next';
-import {notFound} from 'next/navigation';
 import {
   getFormatter,
   getNow,
@@ -8,7 +7,6 @@ import {
 } from 'next-intl/server';
 import {ReactNode} from 'react';
 import Navigation from '../../components/Navigation';
-import {locales} from '../../navigation';
 
 type Props = {
   children: ReactNode;
@@ -35,9 +33,6 @@ export async function generateMetadata({
 }
 
 export default function LocaleLayout({children, params: {locale}}: Props) {
-  // Validate that the incoming `locale` parameter is valid
-  if (!locales.includes(locale as any)) notFound();
-
   return (
     <html lang={locale}>
       <body>

--- a/examples/example-app-router-playground/src/app/not-found.tsx
+++ b/examples/example-app-router-playground/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import Error from 'next/error';
+
+export default function NotFound() {
+  return (
+    <html lang="en">
+      <body>
+        <Error statusCode={404} />
+      </body>
+    </html>
+  );
+}

--- a/examples/example-app-router-playground/src/i18n.tsx
+++ b/examples/example-app-router-playground/src/i18n.tsx
@@ -1,7 +1,12 @@
 import {headers} from 'next/headers';
+import {notFound} from 'next/navigation';
 import {getRequestConfig} from 'next-intl/server';
+import {locales} from './navigation';
 
 export default getRequestConfig(async ({locale}) => {
+  // Validate that the incoming `locale` parameter is valid
+  if (!locales.includes(locale as any)) notFound();
+
   const now = headers().get('x-now');
   const timeZone = headers().get('x-time-zone') ?? 'Europe/Vienna';
   const messages = (await import(`../messages/${locale}.json`)).default;

--- a/examples/example-app-router-playground/src/middleware.ts
+++ b/examples/example-app-router-playground/src/middleware.ts
@@ -1,8 +1,8 @@
 import createMiddleware from 'next-intl/middleware';
-import {locales, pathnames, localePrefix} from './navigation';
+import {locales, pathnames, localePrefix, defaultLocale} from './navigation';
 
 export default createMiddleware({
-  defaultLocale: 'en',
+  defaultLocale,
   localePrefix,
   pathnames,
   locales

--- a/examples/example-app-router-playground/src/navigation.tsx
+++ b/examples/example-app-router-playground/src/navigation.tsx
@@ -3,6 +3,8 @@ import {
   Pathnames
 } from 'next-intl/navigation';
 
+export const defaultLocale = 'en';
+
 export const locales = ['en', 'de', 'es'] as const;
 
 export const localePrefix = 'as-needed';

--- a/examples/example-app-router-playground/tests/main.spec.ts
+++ b/examples/example-app-router-playground/tests/main.spec.ts
@@ -39,6 +39,13 @@ it('handles unknown locales', async ({page}) => {
   ).toBeVisible();
 });
 
+it('handles pathnames that are not matched by the middleware', async ({
+  page
+}) => {
+  const response = await page.goto('/unknown.txt');
+  expect(response?.status()).toBe(404);
+});
+
 it('redirects to a matched locale at the root for non-default locales', async ({
   browser
 }) => {

--- a/examples/example-app-router/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router/src/app/[locale]/layout.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import {Inter} from 'next/font/google';
-import {notFound} from 'next/navigation';
 import {getTranslations, unstable_setRequestLocale} from 'next-intl/server';
 import {ReactNode} from 'react';
 import Navigation from 'components/Navigation';
@@ -31,9 +30,6 @@ export default async function LocaleLayout({
   children,
   params: {locale}
 }: Props) {
-  // Validate that the incoming `locale` parameter is valid
-  if (!locales.includes(locale as any)) notFound();
-
   // Enable static rendering
   unstable_setRequestLocale(locale);
 

--- a/examples/example-app-router/src/app/[locale]/page.tsx
+++ b/examples/example-app-router/src/app/[locale]/page.tsx
@@ -1,18 +1,12 @@
-import {notFound} from 'next/navigation';
 import {useTranslations} from 'next-intl';
 import {unstable_setRequestLocale} from 'next-intl/server';
 import PageLayout from 'components/PageLayout';
-import {locales} from '../../config';
 
 type Props = {
   params: {locale: string};
 };
 
 export default function IndexPage({params: {locale}}: Props) {
-  // Validate that the incoming `locale` parameter is valid
-  const isValidLocale = locales.some((cur) => cur === locale);
-  if (!isValidLocale) notFound();
-
   // Enable static rendering
   unstable_setRequestLocale(locale);
 

--- a/examples/example-app-router/src/i18n.ts
+++ b/examples/example-app-router/src/i18n.ts
@@ -1,10 +1,17 @@
+import {notFound} from 'next/navigation';
 import {getRequestConfig} from 'next-intl/server';
+import {locales} from 'config';
 
-export default getRequestConfig(async ({locale}) => ({
-  messages: (
-    await (locale === 'en'
-      ? // When using Turbopack, this will enable HMR for `en`
-        import('../messages/en.json')
-      : import(`../messages/${locale}.json`))
-  ).default
-}));
+export default getRequestConfig(async ({locale}) => {
+  // Validate that the incoming `locale` parameter is valid
+  if (!locales.includes(locale as any)) notFound();
+
+  return {
+    messages: (
+      await (locale === 'en'
+        ? // When using Turbopack, this will enable HMR for `en`
+          import('../messages/en.json')
+        : import(`../messages/${locale}.json`))
+    ).default
+  };
+});

--- a/packages/next-intl/src/server/react-server/RequestLocale.tsx
+++ b/packages/next-intl/src/server/react-server/RequestLocale.tsx
@@ -1,4 +1,5 @@
 import {headers} from 'next/headers';
+import {notFound} from 'next/navigation';
 import {cache} from 'react';
 import {HEADER_LOCALE_NAME} from '../../shared/constants';
 
@@ -22,9 +23,12 @@ function getLocaleFromHeaderImpl() {
   }
 
   if (!locale) {
-    throw new Error(
-      `Unable to find \`next-intl\` locale because the middleware didn't run on this request. See https://next-intl-docs.vercel.app/docs/routing/middleware#unable-to-find-locale`
-    );
+    if (process.env.NODE_ENV === 'development') {
+      console.error(
+        `Unable to find \`next-intl\` locale because the middleware didn't run on this request. See https://next-intl-docs.vercel.app/docs/routing/middleware#unable-to-find-locale. The \`notFound()\` function will be called as a result.`
+      );
+    }
+    notFound();
   }
 
   return locale;


### PR DESCRIPTION
Users are currently struggling with errors that are caused by these two scenarios:
1. An invalid locale was passed to `next-intl` APIs (e.g. https://github.com/amannn/next-intl/issues/736)
2. No locale was passed to `next-intl` APIs (e.g. https://github.com/amannn/next-intl/issues/716)

**Handling invalid locales**

Users run into this error because the locale wasn't sufficiently validated. This is in practice quite hard because we currently educate in the docs that this should happen in [the root layout](https://next-intl-docs.vercel.app/docs/getting-started/app-router#applocalelayouttsx), but due to the parallel rendering capabilities of Next.js, potentially a page or `generateMetadata` runs first.

Therefore moving this validation to a more central place seems necessary. Due to this, the docs will now suggest validating the locale in `i18n.tsx`. By doing this, we can catch erroneous locale arguments in a single place before e.g. importing JSON files.

The only edge case is if an app uses no APIs of `next-intl` in Server Components at all and therefore `i18n.ts` doesn't run. This should be a very rare case though as even `NextIntlClientProvider` will call `i18n.ts`.

**Handling missing locales**

This warning is probably one of the most annoying errors that users currently run into:

```
Unable to find next-intl locale because the middleware didn't run on this request.
```

The various causes of this error are outlined in [the docs](https://next-intl-docs.vercel.app/docs/routing/middleware#unable-to-find-locale).

Some of these cases should simply be 404s (e.g. when your middleware matcher doesn't match `/unknown.txt`), while others require a fix in the matcher (e.g. considering `/users/jane.doe` when using `localePrefix: 'as-necessary'`).

My assumption is that many of these errors are false positives that are caused by the `[locale]` segment acting as a catch-all. As a result, a 500 error is encountered instead of 404s. Due to this, this PR will downgrade the previous error to a dev-only warning and will invoke the `notFound()` function. This should help in the majority of cases.

I think this change is a good idea because if you're using `unstable_setRequestLocale` and you have a misconfigured middleware matcher, you can provide any kind of string to `next-intl` (also `unknown.txt`) and not run into this error. Therefore it only affects users with dynamic rendering. Validating the locale in `i18n.ts` is the solution to either case (see above). Also in case something like [`routeParams`](https://github.com/amannn/next-intl/issues/663) gets added to Next.js, the current warning will be gone entirely—therefore tackling it from a different direction is likely a good idea.

The false negatives of this should hopefully be rather small as we consistently point out that you need to adapt your middleware matcher when switching the `localePrefix` to anything other than `always`. Dev-only warnings should help to get further information for these requests.

---

Closes https://github.com/amannn/next-intl/issues/736
Closes https://github.com/amannn/next-intl/issues/716
Closes https://github.com/amannn/next-intl/discussions/446

