### PR TITLE
docs: add missing `notFound` import

### DIFF
--- a/docs/pages/docs/environments/error-files.mdx
+++ b/docs/pages/docs/environments/error-files.mdx
@@ -78,6 +78,7 @@ export default function RootLayout({children}) {
 For the 404 page to render, we need to call the `notFound` function in [`i18n.ts`](/docs/usage/configuration#i18nts) when we detect an incoming `locale` param that isn't a valid locale.
 
 ```tsx filename="i18n.ts"
+import {notFound} from 'next/navigation';
 import {getRequestConfig} from 'next-intl/server';
 
 // Can be imported from a shared config

--- a/docs/pages/docs/environments/error-files.mdx
+++ b/docs/pages/docs/environments/error-files.mdx
@@ -121,6 +121,7 @@ Since the `error` file must be defined as a Client Component, you have to use [`
 
 ```tsx filename="app/[locale]/layout.tsx"
 import pick from 'lodash/pick';
+import {NextIntlClientProvider, useMessages} from "next-intl";
 
 export default async function LocaleLayout({children}) {
   // ...

--- a/docs/pages/docs/getting-started/app-router.mdx
+++ b/docs/pages/docs/getting-started/app-router.mdx
@@ -64,6 +64,7 @@ module.exports = withNextIntl({
 `next-intl` creates a configuration once per request. Here you can provide messages and other options depending on the locale of the user.
 
 ```tsx filename="src/i18n.ts"
+import {notFound} from "next/navigation";
 import {getRequestConfig} from 'next-intl/server';
 
 // Can be imported from a shared config

--- a/docs/pages/docs/usage/configuration.mdx
+++ b/docs/pages/docs/usage/configuration.mdx
@@ -15,6 +15,7 @@ Depending on if you handle [internationalization in Client- or Server Components
 `i18n.ts` can be used to provide configuration for **Server Components**.
 
 ```tsx filename="i18n.ts"
+import {notFound} from "next/navigation";
 import {getRequestConfig} from 'next-intl/server';
 
 // Can be imported from a shared config
@@ -38,7 +39,6 @@ The configuration object is created once for each request by internally using Re
 
 ```tsx filename="app/[locale]/layout.tsx" /NextIntlClientProvider/
 import {NextIntlClientProvider, useMessages} from 'next-intl';
-import {notFound} from 'next/navigation';
 
 export default function LocaleLayout({children, params: {locale}}) {
   const messages = useMessages();
@@ -77,7 +77,7 @@ The most crucial aspect of internationalization is providing labels based on the
 
 <Tabs items={['i18n.ts', 'Provider']}>
 <Tab>
-  
+
 ```tsx filename="i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 
@@ -176,7 +176,7 @@ export default getRequestConfig(async ({locale}) => {
 
   return {
     // The time zone can either be statically defined, read from the
-    // user profile if you store such a setting, or based on dynamic 
+    // user profile if you store such a setting, or based on dynamic
     // request information like the locale or headers.
     timeZone: 'Europe/Vienna'
   };
@@ -215,7 +215,7 @@ If you prefer to override the default, you can provide an explicit value for `no
 
 <Tabs items={['i18n.ts', 'Provider']}>
 <Tab>
-  
+
 ```tsx filename="i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 
@@ -223,7 +223,7 @@ export default getRequestConfig(async ({locale}) => {
   // ...
 
   return {
-    // This is the default, a single date instance will be used 
+    // This is the default, a single date instance will be used
     // by all Server Components to ensure consistency
     now: new Date()
   };
@@ -257,7 +257,7 @@ To achieve consistent date, time, number and list formatting, you can define a s
 
 <Tabs items={['i18n.ts', 'Provider']}>
 <Tab>
-  
+
 ```tsx filename="i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 
@@ -362,7 +362,7 @@ To achieve consistent usage of translation values and reduce redundancy, you can
 
 <Tabs items={['i18n.ts', 'Provider']}>
 <Tab>
-  
+
 ```tsx filename="i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 
@@ -405,7 +405,7 @@ This behavior can be customized with the `onError` and `getMessageFallback` conf
 
 <Tabs items={['i18n.ts', 'Provider']}>
 <Tab>
-  
+
 ```tsx filename="i18n.ts"
 import {getRequestConfig} from 'next-intl/server';
 import {IntlErrorCode} from 'next-intl';


### PR DESCRIPTION
this adds a missing import for `notFound` to the recently updated `i18n.ts` examples in the docs.