### PR TITLE
fix: update vscode-integration

### DIFF
--- a/docs/pages/docs/workflows/vscode-integration.mdx
+++ b/docs/pages/docs/workflows/vscode-integration.mdx
@@ -29,19 +29,19 @@ These extensions are known to support `next-intl`:
 "i18n-ally.keystyle": "nested"
 ```
 
-## Inlang IDE extension [#inlang]
+## inlang IDE extension [#inlang]
 
 **Features:**
 
 - Message extraction
 - Inline annotations
 - Inline message editing
-- [Message linting](https://inlang.com/m/r7kp499g/app-inlang-ideextension#message-linting)
-- Integration with other parts of the Inlang ecosystem like [the Fink editor](https://inlang.com/m/tdozzpar/app-inlang-editor)
+- [Message linting](https://inlang.com/m/r7kp499g/app-inlang-ideextension#message-linting?ref=next-intl)
+- Integration with other parts of the inlang ecosystem like [the Fink editor](https://inlang.com/m/tdozzpar/app-inlang-editor?ref=next-intl) or [the inlang CLI](https://inlang.com/m/2qj2w8pu/app-inlang-cli?ref=next-intl)
 
 **Setup:**
 
-1. Install [the Inlang IDE extension](https://marketplace.visualstudio.com/items?itemName=inlang.vs-code-extension)
+1. Install [the inlang IDE extension](https://marketplace.visualstudio.com/items?itemName=inlang.vs-code-extension)
 2. Configure the extension in your project via `project.inlang/settings.json`:
 
 ```json filename="project.inlang/settings.json"
@@ -58,4 +58,4 @@ These extensions are known to support `next-intl`:
 }
 ```
 
-Learn more in the Inlang docs: [Setting up next-intl with the IDE extension](https://inlang.com/g/hhfueysj/guide-nilsjacobsen-nextIntlIdeExtension)
+Learn more in the inlang docs: [Setting up next-intl with the IDE extension](https://inlang.com/g/hhfueysj/guide-nilsjacobsen-nextIntlIdeExtension?ref=next-intl)


### PR DESCRIPTION
### What I changed

- Changed `Inlang` to `inlang` according to brand guideline
- Added `?ref=next-intl` to the links that point to inlang.com
- Added inlang CLI as an ecosystem example