### PR TITLE
feat: Support formatting of React elements via `format.list(…)`.

### DIFF
--- a/docs/pages/docs/usage/lists.mdx
+++ b/docs/pages/docs/usage/lists.mdx
@@ -39,18 +39,9 @@ See the [arrays of messages guide](/docs/usage/messages#arrays-of-messages).
 
 </details>
 
-## Accepted values
+## Formatting of React elements [#react-elements]
 
-While [`Intl.ListFormat#format`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/format) only accepts `string` values, `format.list` accepts a broader range of values that can be formatted:
-
-- `string`
-- `number`
-- `boolean`
-- `ReactNode`
-- `null`
-- `undefined`
-
-Note that if you pass elements that are a non-primitive `ReactNode`, the formatter will return a `ReactNode` too.
+Apart from string values, you can also pass React elements to the formatting function:
 
 ```tsx
 import {useFormatter} from 'next-intl';
@@ -64,7 +55,6 @@ function Component() {
     {id: 3, name: 'Charlie'}
   ];
 
-  // Returns a `ReactNode`
   return format.list(
     users.map((user) => (
       <a key={user.id} href={`/user/${user.id}`}>
@@ -74,3 +64,5 @@ function Component() {
   );
 }
 ```
+
+Note that `format.list` will return an `Iterable<ReactElement>` in this case.

--- a/docs/pages/docs/usage/lists.mdx
+++ b/docs/pages/docs/usage/lists.mdx
@@ -61,18 +61,18 @@ function Component() {
     </a>
   ));
 
-  return <div>{format.list(items)}</div>;
+  return <p>{format.list(items)}</p>;
 }
 ```
 
 **Result:**
 
 ```html
-<div>
-  <a href="/user/1">Alice</a>,
+<p>
+  <a href="/user/1">Alice</a>, 
   <a href="/user/2">Bob</a>, and
   <a href="/user/3">Charlie</a>
-</div>
+</p>
 ```
 
 Note that `format.list` will return an `Iterable<ReactElement>` in this case.

--- a/docs/pages/docs/usage/lists.mdx
+++ b/docs/pages/docs/usage/lists.mdx
@@ -41,7 +41,7 @@ See the [arrays of messages guide](/docs/usage/messages#arrays-of-messages).
 
 ## Formatting of React elements [#react-elements]
 
-Apart from string values, you can also pass React elements to the formatting function:
+Apart from string values, you can also pass arrays of React elements to the formatting function:
 
 ```tsx
 import {useFormatter} from 'next-intl';
@@ -55,14 +55,24 @@ function Component() {
     {id: 3, name: 'Charlie'}
   ];
 
-  return format.list(
-    users.map((user) => (
-      <a key={user.id} href={`/user/${user.id}`}>
-        {user.name}
-      </a>
-    ))
-  );
+  const items = users.map((user) => (
+    <a key={user.id} href={`/user/${user.id}`}>
+      {user.name}
+    </a>
+  ));
+
+  return <div>{format.list(items)}</div>;
 }
+```
+
+**Result:**
+
+```html
+<div>
+  <a href="/user/1">Alice</a>,
+  <a href="/user/2">Bob</a>, and
+  <a href="/user/3">Charlie</a>
+</div>
 ```
 
 Note that `format.list` will return an `Iterable<ReactElement>` in this case.

--- a/docs/pages/docs/usage/lists.mdx
+++ b/docs/pages/docs/usage/lists.mdx
@@ -30,10 +30,7 @@ See [the MDN docs about `ListFormat`](https://developer.mozilla.org/en-US/docs/W
 
 Note that lists can can currently only be formatted via `useFormatter`, there's no equivalent inline syntax for messages at this point.
 
-<Callout>
-  To reuse list formats for multiple components, you can configure [global
-  formats](/docs/usage/configuration#formats).
-</Callout>
+To reuse list formats for multiple components, you can configure [global formats](/docs/usage/configuration#formats).
 
 <details>
 <summary>How can I render an array of messages?</summary>
@@ -41,3 +38,39 @@ Note that lists can can currently only be formatted via `useFormatter`, there's 
 See the [arrays of messages guide](/docs/usage/messages#arrays-of-messages).
 
 </details>
+
+## Accepted values
+
+While [`Intl.ListFormat#format`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/format) only accepts `string` values, `format.list` accepts a broader range of values that can be formatted:
+
+- `string`
+- `number`
+- `boolean`
+- `ReactNode`
+- `null`
+- `undefined`
+
+Note that if you pass elements that are a non-primitive `ReactNode`, the formatter will return a `ReactNode` too.
+
+```tsx
+import {useFormatter} from 'next-intl';
+
+function Component() {
+  const format = useFormatter();
+
+  const users = [
+    {id: 1, name: 'Alice'},
+    {id: 2, name: 'Bob'},
+    {id: 3, name: 'Charlie'}
+  ];
+
+  // Returns a `ReactNode`
+  return format.list(
+    users.map((user) => (
+      <a key={user.id} href={`/user/${user.id}`}>
+        {user.name}
+      </a>
+    ))
+  );
+}
+```

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -114,11 +114,11 @@
   "size-limit": [
     {
       "path": "dist/production/index.react-client.js",
-      "limit": "12.865 KB"
+      "limit": "12.99 KB"
     },
     {
       "path": "dist/production/index.react-server.js",
-      "limit": "14.15 KB"
+      "limit": "13.75 KB"
     },
     {
       "path": "dist/production/navigation.react-client.js",
@@ -134,7 +134,7 @@
     },
     {
       "path": "dist/production/server.react-server.js",
-      "limit": "12.82 KB"
+      "limit": "12.945 KB"
     },
     {
       "path": "dist/production/middleware.js",

--- a/packages/use-intl/package.json
+++ b/packages/use-intl/package.json
@@ -90,7 +90,7 @@
   "size-limit": [
     {
       "path": "dist/production/index.js",
-      "limit": "12.4 kB"
+      "limit": "12.51 kB"
     }
   ]
 }

--- a/packages/use-intl/package.json
+++ b/packages/use-intl/package.json
@@ -90,7 +90,7 @@
   "size-limit": [
     {
       "path": "dist/production/index.js",
-      "limit": "12.51 kB"
+      "limit": "12.5 kB"
     }
   ]
 }

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -7,7 +7,7 @@ import RelativeTimeFormatOptions from './RelativeTimeFormatOptions';
 import TimeZone from './TimeZone';
 import {defaultOnError} from './defaults';
 
-type SimpleReactNodes = string | number | boolean | null | undefined;
+type PrimitiveReactNodes = string | number | boolean | null | undefined;
 
 const SECOND = 1;
 const MINUTE = SECOND * 60;
@@ -243,7 +243,7 @@ export default function createFormatter({
   function list<Value extends ReactNode>(
     value: Iterable<Value>,
     formatOrOptions?: string | Intl.ListFormatOptions
-  ): Value extends SimpleReactNodes ? string : ReactNode {
+  ): Value extends PrimitiveReactNodes ? string : ReactNode {
     const serializedValue: Array<string> = [];
     let hasRichValues: boolean | undefined;
     const richValues: Record<string, Value> = {};
@@ -266,7 +266,7 @@ export default function createFormatter({
 
     return getFormattedValue<
       Intl.ListFormatOptions,
-      Value extends SimpleReactNodes ? string : ReactNode
+      Value extends PrimitiveReactNodes ? string : ReactNode
     >(
       formatOrOptions,
       formats?.list,

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -1,4 +1,4 @@
-import {ReactNode} from 'react';
+import {ReactElement} from 'react';
 import DateTimeFormatOptions from './DateTimeFormatOptions';
 import Formats from './Formats';
 import IntlError, {IntlErrorCode} from './IntlError';
@@ -6,8 +6,6 @@ import NumberFormatOptions from './NumberFormatOptions';
 import RelativeTimeFormatOptions from './RelativeTimeFormatOptions';
 import TimeZone from './TimeZone';
 import {defaultOnError} from './defaults';
-
-type PrimitiveReactNodes = string | number | boolean | null | undefined;
 
 const SECOND = 1;
 const MINUTE = SECOND * 60;
@@ -240,20 +238,18 @@ export default function createFormatter({
     }
   }
 
-  function list<Value extends ReactNode>(
+  type FormattableListValue = string | ReactElement | Iterable<ReactElement>;
+  function list<Value extends FormattableListValue>(
     value: Iterable<Value>,
     formatOrOptions?: string | Intl.ListFormatOptions
-  ): Value extends PrimitiveReactNodes ? string : ReactNode {
+  ): Value extends string ? string : Iterable<ReactElement> {
     const serializedValue: Array<string> = [];
     let hasRichValues: boolean | undefined;
     const richValues: Record<string, Value> = {};
 
     let index = 0;
     for (const item of value) {
-      if (
-        item && // `null` is an `object` too
-        typeof item === 'object'
-      ) {
+      if (typeof item === 'object') {
         const id = String(index);
         richValues[id] = item;
         serializedValue.push(id);
@@ -266,7 +262,7 @@ export default function createFormatter({
 
     return getFormattedValue<
       Intl.ListFormatOptions,
-      Value extends PrimitiveReactNodes ? string : ReactNode
+      Value extends string ? string : Iterable<ReactElement>
     >(
       formatOrOptions,
       formats?.list,

--- a/packages/use-intl/test/react/useFormatter.test.tsx
+++ b/packages/use-intl/test/react/useFormatter.test.tsx
@@ -1,6 +1,6 @@
 import {render, screen} from '@testing-library/react';
 import {parseISO} from 'date-fns';
-import React, {ComponentProps, ReactNode} from 'react';
+import React, {ComponentProps, ReactNode, ReactElement} from 'react';
 import {it, expect, describe, vi} from 'vitest';
 import {
   DateTimeFormatOptions,
@@ -551,12 +551,12 @@ describe('list', () => {
         [<span key="one">One</span>, <span key="two">Two</span>]
       ]);
 
-      function expectReactNode(v: ReactNode) {
+      function expectIterableReactElement(v: Iterable<ReactElement>) {
         return v;
       }
 
       expect(Array.isArray(result)).toBe(true);
-      return expectReactNode(result);
+      return expectIterableReactElement(result);
     }
 
     const {container} = render(

--- a/packages/use-intl/test/react/useFormatter.test.tsx
+++ b/packages/use-intl/test/react/useFormatter.test.tsx
@@ -513,6 +513,65 @@ describe('list', () => {
     screen.getByText('apple, banana, and orange');
   });
 
+  it('returns a string for non-JSX elements', () => {
+    function Component() {
+      const format = useFormatter();
+      const value = ['apple', 23, true, null, undefined];
+      const result = format.list(value);
+      expect(typeof result).toBe('string');
+
+      function expectString(v: string) {
+        return v;
+      }
+
+      return expectString(result);
+    }
+
+    render(
+      <MockProvider>
+        <Component />
+      </MockProvider>
+    );
+
+    screen.getByText('apple, 23, true, null, and undefined');
+  });
+
+  it('formats a list of rich elements', () => {
+    const users = [
+      {id: 1, name: 'Alice'},
+      {id: 2, name: 'Bob'},
+      {id: 3, name: 'Charlie'}
+    ];
+
+    function Component() {
+      const format = useFormatter();
+      const result = format.list(
+        users.map((user) => (
+          <a key={user.id} href={`/user/${user.id}`}>
+            {user.name}
+          </a>
+        ))
+      );
+
+      function expectReactNode(v: ReactNode) {
+        return v;
+      }
+
+      expect(Array.isArray(result)).toBe(true);
+      return expectReactNode(result);
+    }
+
+    const {container} = render(
+      <MockProvider>
+        <Component />
+      </MockProvider>
+    );
+
+    expect(container.innerHTML).toEqual(
+      '<a href="/user/1">Alice</a>, <a href="/user/2">Bob</a>, and <a href="/user/3">Charlie</a>'
+    );
+  });
+
   it('accepts a set', () => {
     renderList(new Set(['apple', 'banana', 'orange']));
     screen.getByText('apple, banana, and orange');

--- a/packages/use-intl/test/react/useFormatter.test.tsx
+++ b/packages/use-intl/test/react/useFormatter.test.tsx
@@ -541,15 +541,13 @@ describe('list', () => {
     function Component() {
       const format = useFormatter();
 
-      const result = format.list([
-        ...users.map((user) => (
+      const result = format.list(
+        users.map((user) => (
           <a key={user.id} href={`/user/${user.id}`}>
             {user.name}
           </a>
-        )),
-        // An `Iterable<ReactElement>` as a single element
-        [<span key="one">One</span>, <span key="two">Two</span>]
-      ]);
+        ))
+      );
 
       function expectIterableReactElement(v: Iterable<ReactElement>) {
         return v;
@@ -566,7 +564,7 @@ describe('list', () => {
     );
 
     expect(container.innerHTML).toEqual(
-      '<a href="/user/1">Alice</a>, <a href="/user/2">Bob</a>, <a href="/user/3">Charlie</a>, and <span>One</span><span>Two</span>'
+      '<a href="/user/1">Alice</a>, <a href="/user/2">Bob</a>, and <a href="/user/3">Charlie</a>'
     );
   });
 

--- a/packages/use-intl/test/react/useFormatter.test.tsx
+++ b/packages/use-intl/test/react/useFormatter.test.tsx
@@ -509,14 +509,9 @@ describe('list', () => {
   }
 
   it('formats a list', () => {
-    renderList(['apple', 'banana', 'orange']);
-    screen.getByText('apple, banana, and orange');
-  });
-
-  it('returns a string for non-JSX elements', () => {
     function Component() {
       const format = useFormatter();
-      const value = ['apple', 23, true, null, undefined];
+      const value = ['apple', 'banana', 'orange'];
       const result = format.list(value);
       expect(typeof result).toBe('string');
 
@@ -533,7 +528,7 @@ describe('list', () => {
       </MockProvider>
     );
 
-    screen.getByText('apple, 23, true, null, and undefined');
+    screen.getByText('apple, banana, and orange');
   });
 
   it('formats a list of rich elements', () => {
@@ -545,13 +540,16 @@ describe('list', () => {
 
     function Component() {
       const format = useFormatter();
-      const result = format.list(
-        users.map((user) => (
+
+      const result = format.list([
+        ...users.map((user) => (
           <a key={user.id} href={`/user/${user.id}`}>
             {user.name}
           </a>
-        ))
-      );
+        )),
+        // An `Iterable<ReactElement>` as a single element
+        [<span key="one">One</span>, <span key="two">Two</span>]
+      ]);
 
       function expectReactNode(v: ReactNode) {
         return v;
@@ -568,7 +566,7 @@ describe('list', () => {
     );
 
     expect(container.innerHTML).toEqual(
-      '<a href="/user/1">Alice</a>, <a href="/user/2">Bob</a>, and <a href="/user/3">Charlie</a>'
+      '<a href="/user/1">Alice</a>, <a href="/user/2">Bob</a>, <a href="/user/3">Charlie</a>, and <span>One</span><span>Two</span>'
     );
   });
 


### PR DESCRIPTION
```tsx
import {useFormatter} from 'next-intl';

function Component() {
  const format = useFormatter();

  const users = [
    {id: 1, name: 'Alice'},
    {id: 2, name: 'Bob'},
    {id: 3, name: 'Charlie'}
  ];

  // Returns a `ReactNode`
  return format.list(
    users.map((user) => (
      <a key={user.id} href={`/user/${user.id}`}>
        {user.name}
      </a>
    ))
  );
}
```

As discussed in https://github.com/amannn/next-intl/discussions/840