### PR TITLE
docs: Update Supabase auth example to use `@supabase/ssr`

### DIFF
--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -549,29 +549,113 @@ export const config = {
 
 ### Example: Integrating with Supabase Authentication
 
-[`@supabase/auth-helpers-nextjs`](https://supabase.com/docs/guides/auth/auth-helpers/nextjs?language=ts#managing-session-with-middleware) exports `createMiddlewareClient` that accepts a `req` and `res` object. We can pass the incoming `req` and the `res` created with `createIntlMiddleware` to it.
+[`@supabase/ssr`](https://supabase.com/docs/guides/auth/server-side/creating-a-client) exports a `createServerClient` function. First we're going to create a utils function that invokes the `createServerClient` function and returns the `supabase` object.
+
+```ts filename="utils/supabase/middleware.ts"
+import {createServerClient, type CookieOptions} from '@supabase/ssr';
+import {type NextRequest, NextResponse} from 'next/server';
+
+export const createClient = (request: NextRequest) => {
+  // Create an unmodified response
+  let response = NextResponse.next({
+    request: {
+      headers: request.headers
+    }
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return request.cookies.get(name)?.value;
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          // If the cookie is updated, update the cookies for the request and response
+          request.cookies.set({
+            name,
+            value,
+            ...options
+          });
+          response = NextResponse.next({
+            request: {
+              headers: request.headers
+            }
+          });
+          response.cookies.set({
+            name,
+            value,
+            ...options
+          });
+        },
+        remove(name: string, options: CookieOptions) {
+          // If the cookie is removed, update the cookies for the request and response
+          request.cookies.set({
+            name,
+            value: '',
+            ...options
+          });
+          response = NextResponse.next({
+            request: {
+              headers: request.headers
+            }
+          });
+          response.cookies.set({
+            name,
+            value: '',
+            ...options
+          });
+        }
+      }
+    }
+  );
+
+  return {supabase, response};
+};
+```
+
+Next, we're going to set up two required environment variables in a `.env.local` file. The `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are required to create the `supabase` object.
+
+```txt filename=".env.local"
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+```
+
+Finally, we're going to create a middleware file that uses the `createClient` function that we created and merges it with the `next-intl` middleware.
 
 ```tsx filename="middleware.ts"
-import {createMiddlewareClient} from '@supabase/auth-helpers-nextjs';
+import {NextResponse, type NextRequest} from 'next/server';
+import {createClient} from '@/utils/supabase/middleware';
 import createIntlMiddleware from 'next-intl/middleware';
-import type {NextRequest} from 'next/server';
-import type {Database} from '@/lib/database.types';
 
-export default async function middleware(req: NextRequest) {
+const defaultLocale = 'en';
+const locales = ['en', 'de'];
+
+export async function middleware(request: NextRequest) {
   const handleI18nRouting = createIntlMiddleware({
-    locales: ['en', 'de'],
-    defaultLocale: 'en'
+    locales,
+    defaultLocale
   });
-  const res = handleI18nRouting(req);
+  const response = handleI18nRouting(request);
 
-  const supabase = createMiddlewareClient<Database>({req, res});
-  await supabase.auth.getSession();
-
-  return res;
+  try {
+    const {supabase} = createClient(request);
+    await supabase.auth.getSession();
+    return response;
+  } catch (e) {
+    return NextResponse.next({
+      request: {
+        headers: request.headers
+      }
+    });
+  }
 }
 
 export const config = {
-  matcher: ['/', '/(de|en)/:path*']
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|assets|icon|sitemap.xml|robots.txt|auth|api).*)'
+  ]
 };
 ```
 

--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -549,73 +549,43 @@ export const config = {
 
 ### Example: Integrating with Supabase Authentication
 
-This example is mostly merging the next-intl middleware with the Supabase one. For more information on the Supabase middleware, check [this](https://supabase.com/docs/guides/auth/server-side/nextjs?router=app) guide from their website.
+In order to use Supabase Authentication with `next-intl`, you need to combine the Supabase middleware with the one from `next-intl`.
 
-First, we're going to set up two required environment variables in a `.env.local` file. The `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are required to create the `supabase` object.
-
-```txt filename=".env.local"
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-```
-
-[`@supabase/ssr`](https://supabase.com/docs/guides/auth/server-side/creating-a-client) exports a `createServerClient` function. First we're going to create a function that invokes the `createServerClient` function and returns the `supabase` object.
-
-Finally, we're going to create a middleware file that uses the `createClient` function that we created and merges it with the `next-intl` middleware.
+You can do so by following the [setup guide from Supabase](https://supabase.com/docs/guides/auth/server-side/nextjs?router=app) and adapting the middleware as follows:
 
 ```tsx filename="middleware.ts"
 import {type NextRequest} from 'next/server';
 import {createServerClient, type CookieOptions} from '@supabase/ssr';
 import createIntlMiddleware from 'next-intl/middleware';
 
-export async function middleware(request: NextRequest) {
-  const response = createIntlMiddleware({
-    locales: ['en', 'de'],
-    defaultLocale: 'en'
-  })(request);
+const handleI18nRouting = createIntlMiddleware({
+  locales: ['en', 'de'],
+  defaultLocale: 'en'
+});
 
-  const createClient = (request: NextRequest) => {
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          get(name: string) {
-            return request.cookies.get(name)?.value;
-          },
-          set(name: string, value: string, options: CookieOptions) {
-            // If the cookie is updated, update the cookies for the request and response
-            request.cookies.set({
-              name,
-              value,
-              ...options
-            });
-            response.cookies.set({
-              name,
-              value,
-              ...options
-            });
-          },
-          remove(name: string, options: CookieOptions) {
-            // If the cookie is removed, update the cookies for the request and response
-            request.cookies.set({
-              name,
-              value: '',
-              ...options
-            });
-            response.cookies.set({
-              name,
-              value: '',
-              ...options
-            });
-          }
+export async function middleware(request: NextRequest) {
+  const response = handleI18nRouting(request);
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return request.cookies.get(name)?.value;
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          request.cookies.set({name, value, ...options});
+          response.cookies.set({name, value, ...options});
+        },
+        remove(name: string, options: CookieOptions) {
+          request.cookies.set({name, value: '', ...options});
+          response.cookies.set({name, value: '', ...options});
         }
       }
-    );
+    }
+  );
 
-    return supabase;
-  };
-
-  const supabase = createClient(request);
   await supabase.auth.getUser();
   return response;
 }
@@ -624,6 +594,8 @@ export const config = {
   matcher: ['/', '/(de|en)/:path*']
 };
 ```
+
+Note that cookies need to be set simultaneously for the request and the response.
 
 ### Example: Integrating with Auth.js (aka NextAuth.js) [#example-auth-js]
 

--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -549,113 +549,79 @@ export const config = {
 
 ### Example: Integrating with Supabase Authentication
 
-[`@supabase/ssr`](https://supabase.com/docs/guides/auth/server-side/creating-a-client) exports a `createServerClient` function. First we're going to create a utils function that invokes the `createServerClient` function and returns the `supabase` object.
+This example is mostly merging the next-intl middleware with the Supabase one. For more information on the Supabase middleware, check [this](https://supabase.com/docs/guides/auth/server-side/nextjs?router=app) guide from their website.
 
-```ts filename="utils/supabase/middleware.ts"
-import {createServerClient, type CookieOptions} from '@supabase/ssr';
-import {type NextRequest, NextResponse} from 'next/server';
-
-export const createClient = (request: NextRequest) => {
-  // Create an unmodified response
-  let response = NextResponse.next({
-    request: {
-      headers: request.headers
-    }
-  });
-
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return request.cookies.get(name)?.value;
-        },
-        set(name: string, value: string, options: CookieOptions) {
-          // If the cookie is updated, update the cookies for the request and response
-          request.cookies.set({
-            name,
-            value,
-            ...options
-          });
-          response = NextResponse.next({
-            request: {
-              headers: request.headers
-            }
-          });
-          response.cookies.set({
-            name,
-            value,
-            ...options
-          });
-        },
-        remove(name: string, options: CookieOptions) {
-          // If the cookie is removed, update the cookies for the request and response
-          request.cookies.set({
-            name,
-            value: '',
-            ...options
-          });
-          response = NextResponse.next({
-            request: {
-              headers: request.headers
-            }
-          });
-          response.cookies.set({
-            name,
-            value: '',
-            ...options
-          });
-        }
-      }
-    }
-  );
-
-  return {supabase, response};
-};
-```
-
-Next, we're going to set up two required environment variables in a `.env.local` file. The `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are required to create the `supabase` object.
+First, we're going to set up two required environment variables in a `.env.local` file. The `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are required to create the `supabase` object.
 
 ```txt filename=".env.local"
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 ```
 
+[`@supabase/ssr`](https://supabase.com/docs/guides/auth/server-side/creating-a-client) exports a `createServerClient` function. First we're going to create a function that invokes the `createServerClient` function and returns the `supabase` object.
+
 Finally, we're going to create a middleware file that uses the `createClient` function that we created and merges it with the `next-intl` middleware.
 
 ```tsx filename="middleware.ts"
-import {NextResponse, type NextRequest} from 'next/server';
-import {createClient} from '@/utils/supabase/middleware';
+import {type NextRequest} from 'next/server';
+import {createServerClient, type CookieOptions} from '@supabase/ssr';
 import createIntlMiddleware from 'next-intl/middleware';
 
-const defaultLocale = 'en';
-const locales = ['en', 'de'];
-
 export async function middleware(request: NextRequest) {
-  const handleI18nRouting = createIntlMiddleware({
-    locales,
-    defaultLocale
-  });
-  const response = handleI18nRouting(request);
+  const response = createIntlMiddleware({
+    locales: ['en', 'de'],
+    defaultLocale: 'en'
+  })(request);
 
-  try {
-    const {supabase} = createClient(request);
-    await supabase.auth.getSession();
-    return response;
-  } catch (e) {
-    return NextResponse.next({
-      request: {
-        headers: request.headers
+  const createClient = (request: NextRequest) => {
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          get(name: string) {
+            return request.cookies.get(name)?.value;
+          },
+          set(name: string, value: string, options: CookieOptions) {
+            // If the cookie is updated, update the cookies for the request and response
+            request.cookies.set({
+              name,
+              value,
+              ...options
+            });
+            response.cookies.set({
+              name,
+              value,
+              ...options
+            });
+          },
+          remove(name: string, options: CookieOptions) {
+            // If the cookie is removed, update the cookies for the request and response
+            request.cookies.set({
+              name,
+              value: '',
+              ...options
+            });
+            response.cookies.set({
+              name,
+              value: '',
+              ...options
+            });
+          }
+        }
       }
-    });
-  }
+    );
+
+    return supabase;
+  };
+
+  const supabase = createClient(request);
+  await supabase.auth.getUser();
+  return response;
 }
 
 export const config = {
-  matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|assets|icon|sitemap.xml|robots.txt|auth|api).*)'
-  ]
+  matcher: ['/', '/(de|en)/:path*']
 };
 ```
 


### PR DESCRIPTION
created an example for usage with the new supabase ssr package. The middleware I created is working in development as well as in production. The matcher in `middleware.ts` Was adapted based on multiple metadata files that needed to be ignored.

Suggestions on changes are welcome.

<img width="949" alt="image" src="https://github.com/amannn/next-intl/assets/61006057/cd093aa9-c187-42e3-af2b-08dd5c1f1724">

see `https://supabase.com/docs/guides/auth/auth-helpers/nextjs?language=ts` for the recommendation from supabase.
