### PR TITLE
feat: Add redirects for case mismatches in locale prefixes (e.g. `/EN` → `/en`)

### DIFF
--- a/examples/example-app-router-playground/tests/main.spec.ts
+++ b/examples/example-app-router-playground/tests/main.spec.ts
@@ -57,7 +57,7 @@ it('redirects to a matched locale at the root for non-default locales', async ({
   page.getByRole('heading', {name: 'Start'});
 });
 
-it('redirects to a matched locale for invalid cased locales', async ({
+it('redirects to a matched locale for an invalid cased non-default locale', async ({
   browser
   }) => {
   const context = await browser.newContext({locale: 'de'});
@@ -66,6 +66,39 @@ it('redirects to a matched locale for invalid cased locales', async ({
   await page.goto('/DE');
   await expect(page).toHaveURL('/de');
   page.getByRole('heading', {name: 'Start'});
+});
+
+it('redirects to a matched locale for an invalid cased non-default locale in a nested path', async ({
+  browser
+  }) => {
+  const context = await browser.newContext({locale: 'de'});
+  const page = await context.newPage();
+
+  await page.goto('/DE/verschachtelt');
+  await expect(page).toHaveURL('/de/verschachtelt');
+  page.getByRole('heading', {name: 'Verschachtelt'});
+});
+
+it('redirects to a matched locale for an invalid cased default locale', async ({
+  browser
+  }) => {
+  const context = await browser.newContext({locale: 'en'});
+  const page = await context.newPage();
+
+  await page.goto('/EN');
+  await expect(page).toHaveURL('/');
+  page.getByRole('heading', {name: 'Home'});
+});
+
+it('redirects to a matched locale for an invalid cased default locale in a nested path', async ({
+  browser
+  }) => {
+  const context = await browser.newContext({locale: 'en'});
+  const page = await context.newPage();
+
+  await page.goto('/EN/nested');
+  await expect(page).toHaveURL('/nested');
+  page.getByRole('heading', {name: 'Nested'});
 });
 
 it('redirects a prefixed pathname for the default locale to the unprefixed version', async ({

--- a/examples/example-app-router-playground/tests/main.spec.ts
+++ b/examples/example-app-router-playground/tests/main.spec.ts
@@ -64,7 +64,7 @@ it('redirects to a matched locale for invalid cased locales', async ({
   const page = await context.newPage();
 
   await page.goto('/DE');
-  await expect(page).toHaveURL('/DE');
+  await expect(page).toHaveURL('/de');
   page.getByRole('heading', {name: 'Start'});
 });
 

--- a/examples/example-app-router-playground/tests/main.spec.ts
+++ b/examples/example-app-router-playground/tests/main.spec.ts
@@ -57,6 +57,17 @@ it('redirects to a matched locale at the root for non-default locales', async ({
   page.getByRole('heading', {name: 'Start'});
 });
 
+it('redirects to a matched locale for invalid cased locales', async ({
+  browser
+  }) => {
+  const context = await browser.newContext({locale: 'de'});
+  const page = await context.newPage();
+
+  await page.goto('/DE');
+  await expect(page).toHaveURL('/DE');
+  page.getByRole('heading', {name: 'Start'});
+});
+
 it('redirects a prefixed pathname for the default locale to the unprefixed version', async ({
   request
 }) => {

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -138,7 +138,7 @@
     },
     {
       "path": "dist/production/middleware.js",
-      "limit": "5.84 KB"
+      "limit": "5.855 KB"
     }
   ]
 }

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -138,7 +138,7 @@
     },
     {
       "path": "dist/production/middleware.js",
-      "limit": "5.81 KB"
+      "limit": "5.84 KB"
     }
   ]
 }

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -16,7 +16,7 @@ import {
   getInternalTemplate,
   formatTemplatePathname,
   getBestMatchingDomain,
-  getKnownLocaleFromPathname,
+  getPathnameLocale,
   getNormalizedPathname,
   getPathWithSearch,
   isLocaleSupportedOnDomain,
@@ -134,7 +134,7 @@ export default function createMiddleware<Locales extends AllLocales>(
       configWithDefaults.locales
     );
 
-    const pathLocale = getKnownLocaleFromPathname(
+    const pathLocale = getPathnameLocale(
       request.nextUrl.pathname,
       configWithDefaults.locales
     );

--- a/packages/next-intl/src/middleware/resolveLocale.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.tsx
@@ -68,7 +68,7 @@ function resolveLocaleFromPrefix<Locales extends AllLocales>(
 
   // Prio 1: Use route prefix
   if (pathname) {
-    const pathLocale = getLocaleFromPathname(pathname);
+    const pathLocale = getLocaleFromPathname(pathname, locales);
     if (locales.includes(pathLocale)) {
       locale = pathLocale;
     }

--- a/packages/next-intl/src/middleware/resolveLocale.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.tsx
@@ -8,7 +8,8 @@ import {
   MiddlewareConfigWithDefaults
 } from './NextIntlMiddlewareConfig';
 import {
-  getLocaleFromPathname,
+  findCaseInsensitiveLocale,
+  getFirstPathnameSegment,
   getHost,
   isLocaleSupportedOnDomain
 } from './utils';
@@ -68,9 +69,13 @@ function resolveLocaleFromPrefix<Locales extends AllLocales>(
 
   // Prio 1: Use route prefix
   if (pathname) {
-    const pathLocale = getLocaleFromPathname(pathname);
-    if (locales.includes(pathLocale)) {
-      locale = pathLocale;
+    const pathLocaleCandidate = getFirstPathnameSegment(pathname);
+    const matchedLocale = findCaseInsensitiveLocale(
+      pathLocaleCandidate,
+      locales
+    );
+    if (matchedLocale) {
+      locale = matchedLocale;
     }
   }
 

--- a/packages/next-intl/src/middleware/resolveLocale.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.tsx
@@ -68,7 +68,7 @@ function resolveLocaleFromPrefix<Locales extends AllLocales>(
 
   // Prio 1: Use route prefix
   if (pathname) {
-    const pathLocale = getLocaleFromPathname(pathname, locales);
+    const pathLocale = getLocaleFromPathname(pathname);
     if (locales.includes(pathLocale)) {
       locale = pathLocale;
     }

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -10,14 +10,15 @@ export function getLocaleFromPathname<Locales extends AllLocales>(
   locales: Locales
 ) {
   // Get the potential locale from the pathname
-  const potentialLocale = pathname.split('/')[1];
+  const potentialLocale = pathname.split('/')[1].toLowerCase();
 
-  // Try to get a validated version of the potential locale in a case-insensitive manner
-  return (
-    locales.find(
-      (locale) => locale.toLowerCase() === potentialLocale.toLowerCase()
-    ) ?? ''
+  // Try to get a validated version of the potential locale with case-insensitive matching
+  const matchedLocale = locales.find(
+    (locale) => locale.toLowerCase() === potentialLocale
   );
+
+  // Return matched locale or default to an empty string if not found
+  return matchedLocale ?? '';
 }
 
 export function getInternalTemplate<

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -5,8 +5,19 @@ import {
   MiddlewareConfigWithDefaults
 } from './NextIntlMiddlewareConfig';
 
-export function getLocaleFromPathname(pathname: string) {
-  return pathname.split('/')[1];
+export function getLocaleFromPathname<Locales extends AllLocales>(
+  pathname: string,
+  locales: Locales
+) {
+  // Get the potential locale from the pathname
+  const potentialLocale = pathname.split('/')[1];
+
+  // Try to get a validated version of the potential locale in a case-insensitive manner
+  return (
+    locales.find(
+      (locale) => locale.toLowerCase() === potentialLocale.toLowerCase()
+    ) ?? ''
+  );
 }
 
 export function getInternalTemplate<
@@ -71,7 +82,9 @@ export function getNormalizedPathname<Locales extends AllLocales>(
     pathname += '/';
   }
 
-  const match = pathname.match(`^/(${locales.join('|')})/(.*)`);
+  const match = pathname.match(
+    new RegExp(`^/(${locales.join('|')})/(.*)`, 'i')
+  );
   let result = match ? '/' + match[2] : pathname;
 
   if (result !== '/') {
@@ -85,7 +98,7 @@ export function getKnownLocaleFromPathname<Locales extends AllLocales>(
   pathname: string,
   locales: Locales
 ): Locales[number] | undefined {
-  const pathLocaleCandidate = getLocaleFromPathname(pathname);
+  const pathLocaleCandidate = getLocaleFromPathname(pathname, locales);
   const pathLocale = locales.includes(pathLocaleCandidate)
     ? pathLocaleCandidate
     : undefined;

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -88,7 +88,9 @@ export function getKnownLocaleFromPathname<Locales extends AllLocales>(
   locales: Locales
 ): Locales[number] | undefined {
   const pathLocaleCandidate = getLocaleFromPathname(pathname);
-  const pathLocale = locales.includes(pathLocaleCandidate)
+  const pathLocale = locales.find(
+    (locale) => locale.toLowerCase() === pathLocaleCandidate.toLowerCase()
+  )
     ? pathLocaleCandidate
     : undefined;
   return pathLocale;

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -5,7 +5,7 @@ import {
   MiddlewareConfigWithDefaults
 } from './NextIntlMiddlewareConfig';
 
-export function getLocaleFromPathname(pathname: string) {
+export function getFirstPathnameSegment(pathname: string) {
   return pathname.split('/')[1];
 }
 
@@ -83,14 +83,21 @@ export function getNormalizedPathname<Locales extends AllLocales>(
   return result;
 }
 
-export function getKnownLocaleFromPathname<Locales extends AllLocales>(
+export function findCaseInsensitiveLocale<Locales extends AllLocales>(
+  candidate: string,
+  locales: Locales
+) {
+  return locales.find(
+    (locale) => locale.toLowerCase() === candidate.toLowerCase()
+  );
+}
+
+export function getPathnameLocale<Locales extends AllLocales>(
   pathname: string,
   locales: Locales
 ): Locales[number] | undefined {
-  const pathLocaleCandidate = getLocaleFromPathname(pathname);
-  const pathLocale = locales.find(
-    (locale) => locale.toLowerCase() === pathLocaleCandidate.toLowerCase()
-  )
+  const pathLocaleCandidate = getFirstPathnameSegment(pathname);
+  const pathLocale = findCaseInsensitiveLocale(pathLocaleCandidate, locales)
     ? pathLocaleCandidate
     : undefined;
   return pathLocale;

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -5,20 +5,8 @@ import {
   MiddlewareConfigWithDefaults
 } from './NextIntlMiddlewareConfig';
 
-export function getLocaleFromPathname<Locales extends AllLocales>(
-  pathname: string,
-  locales: Locales
-) {
-  // Get the potential locale from the pathname
-  const potentialLocale = pathname.split('/')[1].toLowerCase();
-
-  // Try to get a validated version of the potential locale with case-insensitive matching
-  const matchedLocale = locales.find(
-    (locale) => locale.toLowerCase() === potentialLocale
-  );
-
-  // Return matched locale or default to an empty string if not found
-  return matchedLocale ?? '';
+export function getLocaleFromPathname(pathname: string) {
+  return pathname.split('/')[1];
 }
 
 export function getInternalTemplate<
@@ -99,7 +87,7 @@ export function getKnownLocaleFromPathname<Locales extends AllLocales>(
   pathname: string,
   locales: Locales
 ): Locales[number] | undefined {
-  const pathLocaleCandidate = getLocaleFromPathname(pathname, locales);
+  const pathLocaleCandidate = getLocaleFromPathname(pathname);
   const pathLocale = locales.includes(pathLocaleCandidate)
     ? pathLocaleCandidate
     : undefined;

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -538,7 +538,7 @@ describe('prefix-based routing', () => {
       });
 
       it('redirects uppercase locale requests to case-sensitive defaults at the root', () => {
-        middlewareWithPathnames(createMockRequest('/EN', 'en'));
+        middlewareWithPathnames(createMockRequest('/EN', 'de'));
         expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
         expect(MockedNextResponse.next).not.toHaveBeenCalled();
         expect(MockedNextResponse.redirect).toHaveBeenCalled();
@@ -548,7 +548,7 @@ describe('prefix-based routing', () => {
       });
 
       it('redirects uppercase locale requests to case-sensitive defaults for nested paths', () => {
-        middlewareWithPathnames(createMockRequest('/EN/about', 'en'));
+        middlewareWithPathnames(createMockRequest('/EN/about', 'de'));
         expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
         expect(MockedNextResponse.next).not.toHaveBeenCalled();
         expect(MockedNextResponse.redirect).toHaveBeenCalled();

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -539,20 +539,20 @@ describe('prefix-based routing', () => {
 
       it('redirects an invalid, upper-cased request for a localized route to the case-sensitive format', () => {
         middlewareWithPathnames(createMockRequest('/DE-AT', 'de-AT'));
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
         expect(MockedNextResponse.next).not.toHaveBeenCalled();
-        expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+        expect(MockedNextResponse.redirect).toHaveBeenCalled();
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
           'http://localhost:3000/de-AT'
         );
       });
 
       it('redirects an invalid, lower-cased request for a localized route to the case-sensitive format', () => {
         middlewareWithPathnames(createMockRequest('/de-at', 'de-AT'));
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
         expect(MockedNextResponse.next).not.toHaveBeenCalled();
-        expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+        expect(MockedNextResponse.redirect).toHaveBeenCalled();
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
           'http://localhost:3000/de-AT'
         );
       });

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -537,7 +537,7 @@ describe('prefix-based routing', () => {
         );
       });
 
-      it('redirects an invalid, upper cased request for a localized route to the correct casing', () => {
+      it('redirects an invalid, upper-cased request for a localized route to the case-sensitive format', () => {
         middlewareWithPathnames(createMockRequest('/DE-AT', 'de-AT'));
         expect(MockedNextResponse.rewrite).toHaveBeenCalled();
         expect(MockedNextResponse.next).not.toHaveBeenCalled();
@@ -547,7 +547,7 @@ describe('prefix-based routing', () => {
         );
       });
 
-      it('redirects an invalid, lower cased request for a localized route to the correct casing', () => {
+      it('redirects an invalid, lower-cased request for a localized route to the case-sensitive format', () => {
         middlewareWithPathnames(createMockRequest('/de-at', 'de-AT'));
         expect(MockedNextResponse.rewrite).toHaveBeenCalled();
         expect(MockedNextResponse.next).not.toHaveBeenCalled();

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -537,23 +537,63 @@ describe('prefix-based routing', () => {
         );
       });
 
-      it('redirects an invalid, upper-cased request for a localized route to the case-sensitive format', () => {
+      it('redirects uppercase locale requests to case-sensitive defaults at the root', () => {
+        middlewareWithPathnames(createMockRequest('/EN', 'en'));
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).toHaveBeenCalled();
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://localhost:3000/en/'
+        );
+      });
+
+      it('redirects uppercase locale requests to case-sensitive defaults for nested paths', () => {
+        middlewareWithPathnames(createMockRequest('/EN/about', 'en'));
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).toHaveBeenCalled();
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://localhost:3000/en/about'
+        );
+      });
+
+      it('redirects uppercase locale requests for non-default locales at the root', () => {
         middlewareWithPathnames(createMockRequest('/DE-AT', 'de-AT'));
         expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
         expect(MockedNextResponse.next).not.toHaveBeenCalled();
         expect(MockedNextResponse.redirect).toHaveBeenCalled();
         expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
-          'http://localhost:3000/de-AT'
+          'http://localhost:3000/de-AT/'
         );
       });
 
-      it('redirects an invalid, lower-cased request for a localized route to the case-sensitive format', () => {
+      it('redirects uppercase locale requests for non-default locales and nested paths', () => {
+        middlewareWithPathnames(createMockRequest('/DE-AT/ueber', 'de-AT'));
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).toHaveBeenCalled();
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://localhost:3000/de-AT/ueber'
+        );
+      });
+
+      it('redirects lowercase locale requests for non-default locales to case-sensitive format at the root', () => {
         middlewareWithPathnames(createMockRequest('/de-at', 'de-AT'));
         expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
         expect(MockedNextResponse.next).not.toHaveBeenCalled();
         expect(MockedNextResponse.redirect).toHaveBeenCalled();
         expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
-          'http://localhost:3000/de-AT'
+          'http://localhost:3000/de-AT/'
+        );
+      });
+
+      it('redirects lowercase locale requests for non-default locales to case-sensitive format for nested paths', () => {
+        middlewareWithPathnames(createMockRequest('/de-at/ueber', 'de-AT'));
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).toHaveBeenCalled();
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://localhost:3000/de-AT/ueber'
         );
       });
 
@@ -976,7 +1016,7 @@ describe('prefix-based routing', () => {
   describe('localePrefix: never', () => {
     const middleware = createIntlMiddleware({
       defaultLocale: 'en',
-      locales: ['en', 'de'],
+      locales: ['en', 'de', 'de-AT'],
       localePrefix: 'never'
     });
 
@@ -1069,6 +1109,36 @@ describe('prefix-based routing', () => {
       middleware(createMockRequest('/en/list'));
       expect(MockedNextResponse.next).not.toHaveBeenCalled();
       expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/list'
+      );
+    });
+
+    it('redirects requests with uppercase default locale in a nested path', () => {
+      middleware(createMockRequest('/EN/list'));
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect).toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/list'
+      );
+    });
+
+    it('redirects requests with uppercase non-default locale in a nested path', () => {
+      middleware(createMockRequest('/DE-AT/list'));
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect).toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/list'
+      );
+    });
+
+    it('redirects requests with lowercase non-default locale in a nested path', () => {
+      middleware(createMockRequest('/de-at/list'));
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect).toHaveBeenCalled();
       expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
         'http://localhost:3000/list'
       );


### PR DESCRIPTION
I noticed the same in one of my projects and thought I could look into it 🙂 . This PR should implement a case-insensitive matching mechanism for the given locales. This means that the package should treat a request with an invalid case locale, such as `de-at` or `DE`, as valid and map it correctly to `de-AT` and `de` respectively; it should also rewrite the URL to reflect the correct case, for example by rewriting `de-at` to `de-AT`.

I have done a little bit research on this topic and I think case-insensitive matching for locales makes sense to enhance the UX and avoid people mixing up uppercase and lowercase when typing in locale codes. Also, it seems to be a common practice on a lot of popular websites. Maybe it would still make sense to be able to control the behavior via a property in the middleware. What do you think about this?

Also, in the Playwright test I added, I noticed that the matcher `toHaveURL` still expects `/DE` as the URL. In my browser, however, the redirect works as expected from `/DE` to `/de`. Just let me know if I have overlooked something in the implementation, or if I can improve something 🙂.

### Prerequisites

- [x] Use a meaningful title for the pull request
- [x] Test the changes you've made by adding or editing tests

### Content
- Added tests to the `middleware` that verify the `pathLocale` is converted correctly in a case-insensitive manner
- Changed `getNormalizedPathname` to handle the locale in a case-insensitive manner
- Changed `getLocaleFromPathname` to get a validated version of the locale with case-insensitive matching

#### Tests
- Added tests to verify the redirect for invalid cased locales works as intended
- Added a playwright test to the `example-app-router-playground` to make sure the redirect works

Closes https://github.com/amannn/next-intl/issues/775