### PR TITLE
feat: When using localized pathnames, allow access to internal pathnames only if they match an entry from a particular locale—otherwise redirect

### DIFF
--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -138,7 +138,7 @@
     },
     {
       "path": "dist/production/middleware.js",
-      "limit": "5.855 KB"
+      "limit": "5.9 KB"
     }
   ]
 }

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -183,8 +183,10 @@ export default function createMiddleware<Locales extends AllLocales>(
           );
         }
       } else {
-        const pathnameWithoutLocale =
-          pathname.split(`/${locale}`)[1] ?? pathname;
+        const segments = pathname.split('/');
+        if (segments[1] === locale) segments.splice(1, 1);
+        const pathnameWithoutLocale = segments.join('/');
+
         const internalTemplateName = Object.keys(
           configWithDefaults.pathnames
         ).find((template) => matchesPathname(template, pathnameWithoutLocale));

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -51,8 +51,6 @@ export function getInternalTemplate<
   // if all localized pathnames are different from the internal pathnames).
   for (const internalPathname of Object.keys(pathnames)) {
     if (matchesPathname(internalPathname, pathname)) {
-      // resolve a localized pathname instead?
-
       return [undefined, internalPathname];
     }
   }

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -2286,59 +2286,84 @@ describe('domain-based routing', () => {
         });
       });
 
-      describe('redirects an internal route with localization to its localized pathname', () => {
-        it('redirects an internal route', () => {
-          middlewareWithPathnames(
-            createMockRequest('/internal', 'fr', 'http://ca.example.com')
-          );
-          expect(MockedNextResponse.next).not.toHaveBeenCalled();
-          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
-          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
-          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
-            'http://ca.example.com/fr/external'
-          );
-        });
-        it('redirects a multi-level internal route', () => {
-          middlewareWithPathnames(
-            createMockRequest(
-              '/internal/foo/bar',
-              'fr',
-              'http://ca.example.com'
-            )
-          );
-          expect(MockedNextResponse.next).not.toHaveBeenCalled();
-          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
-          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
-          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
-            'http://ca.example.com/fr/external-fr/foo/bar'
-          );
-        });
-        it('redirects a dynamic internal route', () => {
-          middlewareWithPathnames(
-            createMockRequest('/internal/22', 'fr', 'http://ca.example.com')
-          );
-          expect(MockedNextResponse.next).not.toHaveBeenCalled();
-          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
-          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
-          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
-            'http://ca.example.com/fr/external-fr/22'
-          );
-        });
-        it('redirects a dynamic internal route', () => {
-          middlewareWithPathnames(
-            createMockRequest(
-              '/internal/22/foo/bar',
-              'fr',
-              'http://ca.example.com'
-            )
-          );
-          expect(MockedNextResponse.next).not.toHaveBeenCalled();
-          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
-          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
-          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
-            'http://ca.example.com/fr/external-fr/22/foo/bar'
-          );
-        });
+      it('redirects an internal route for the default locale', () => {
+        middlewareWithPathnames(
+          createMockRequest('/internal', 'en', 'http://ca.example.com')
+        );
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://ca.example.com/external'
+        );
+      });
+
+      it('redirects an internal route for a secondary locale', () => {
+        middlewareWithPathnames(
+          createMockRequest('/internal', 'fr', 'http://ca.example.com')
+        );
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://ca.example.com/fr/external'
+        );
+      });
+
+      it('redirects a multi-level internal route for the default locale', () => {
+        middlewareWithPathnames(
+          createMockRequest('/internal/foo/bar', 'en', 'http://ca.example.com')
+        );
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://ca.example.com/external-en/foo/bar'
+        );
+      });
+
+      it('redirects a dynamic internal route for the default locale', () => {
+        middlewareWithPathnames(
+          createMockRequest('/internal/22', 'en', 'http://ca.example.com')
+        );
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://ca.example.com/external-en/22'
+        );
+      });
+
+      it('redirects a dynamic internal route for the default locale', () => {
+        middlewareWithPathnames(
+          createMockRequest(
+            '/internal/22/foo/bar',
+            'en',
+            'http://ca.example.com'
+          )
+        );
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://ca.example.com/external-en/22/foo/bar'
+        );
+      });
+
+      it('redirects a dynamic internal route for a secondary locale', () => {
+        middlewareWithPathnames(
+          createMockRequest(
+            '/internal/22/foo/bar',
+            'fr',
+            'http://ca.example.com'
+          )
+        );
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://ca.example.com/fr/external-fr/22/foo/bar'
+        );
       });
     });
   });

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -714,7 +714,19 @@ describe('prefix-based routing', () => {
         locales: ['en', 'de'],
         localePrefix: 'as-needed',
         pathnames: {
-          '/internal': '/external'
+          '/internal': '/external',
+          '/internal/foo/bar': {
+            en: '/external/foo/bar',
+            de: '/external/foo/bar'
+          },
+          '/internal/[id]': {
+            en: '/external/[id]',
+            de: '/external/[id]'
+          },
+          '/internal/[...slug]': {
+            en: '/external/[...slug]',
+            de: '/external/[...slug]'
+          },
         } satisfies Pathnames<ReadonlyArray<'en' | 'de'>>
       });
 
@@ -737,6 +749,48 @@ describe('prefix-based routing', () => {
           'http://localhost:3000/external?hello'
         );
       });
+
+      describe('redirects an internal route with localization to its localized pathname but removes the locale prefix while keeping search params', () => {
+        it('redirects an internal route', () => {
+          middlewareWithPathnames(createMockRequest('/en/internal?hello', 'en'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/external?hello'
+          );
+        });
+
+        it('redirects a multi level internal route', () => {
+          middlewareWithPathnames(createMockRequest('/en/internal/foo/bar?hello', 'en'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/external/foo/bar?hello'
+          );
+        });
+
+        it('redirects a dynamic internal route', () => {
+          middlewareWithPathnames(createMockRequest('/en/internal/22?hello', 'en'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/external/22?hello'
+          );
+        });
+
+        it('redirects a multi-level dynamic internal route', () => {
+          middlewareWithPathnames(createMockRequest('/en/internal/22/foo/bar?hello', 'en'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/external/22/foo/bar?hello'
+          );
+        });
+      })
     });
   });
 
@@ -874,7 +928,20 @@ describe('prefix-based routing', () => {
           '/products/[...slug]': {
             en: '/products/[...slug]',
             de: '/produkte/[...slug]'
-          }
+          },
+          '/internal': '/external',
+          '/internal/foo/bar': {
+            en: '/external/foo/bar',
+            de: '/external/foo/bar'
+          },
+          '/internal/[id]': {
+            en: '/external/[id]',
+            de: '/external/[id]'
+          },
+          '/internal/[...slug]': {
+            en: '/external/[...slug]',
+            de: '/external/[...slug]'
+          },
         } satisfies Pathnames<ReadonlyArray<'en' | 'de'>>
       });
 
@@ -1009,6 +1076,48 @@ describe('prefix-based routing', () => {
           '<http://localhost:3000/en/unknown>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/de/unknown>; rel="alternate"; hreflang="de"'
         ]);
+      });
+
+      describe('redirects an internal route with localization to its localized pathname with the requested locale', () => {
+        it('redirects an internal route', () => {
+          middlewareWithPathnames(createMockRequest('/en/internal', 'en'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/en/external'
+          );
+        });
+
+        it('redirects a multi level internal route', () => {
+          middlewareWithPathnames(createMockRequest('/en/internal/foo/bar', 'en'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/en/external/foo/bar'
+          );
+        });
+
+        it('redirects a dynamic internal route', () => {
+          middlewareWithPathnames(createMockRequest('/en/internal/22', 'en'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/en/external/22'
+          );
+        });
+
+        it('redirects a multi-level dynamic internal route', () => {
+          middlewareWithPathnames(createMockRequest('/en/internal/22/foo/bar', 'en'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/en/external/22/foo/bar'
+          );
+        });
       });
     });
   });
@@ -1274,7 +1383,20 @@ describe('prefix-based routing', () => {
           '/products/[...slug]': {
             en: '/products/[...slug]',
             de: '/produkte/[...slug]'
-          }
+          },
+          '/internal': '/external',
+          '/internal/foo/bar': {
+            en: '/external/foo/bar',
+            de: '/external/foo/bar'
+          },
+          '/internal/[id]': {
+            en: '/external/[id]',
+            de: '/external/[id]'
+          },
+          '/internal/[...slug]': {
+            en: '/external/[...slug]',
+            de: '/external/[...slug]'
+          },
         } satisfies Pathnames<ReadonlyArray<'en' | 'de'>>
       });
 
@@ -1368,6 +1490,45 @@ describe('prefix-based routing', () => {
         expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
           'http://localhost:3000/ueber?hello'
         );
+      });
+
+      describe('redirects an internal route with localization to its localized pathname and removes the locale prefix while keeping search params', () => {
+        it('redirects an internal route', () => {
+          middlewareWithPathnames(createMockRequest('/de/internal?hello', 'de'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/external?hello'
+          );
+        });
+        it('redirects a multi level internal route', () => {
+          middlewareWithPathnames(createMockRequest('/de/internal/foo/bar?hello', 'de'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/external/foo/bar?hello'
+          );
+        });
+        it('redirects a dynamic internal route', () => {
+          middlewareWithPathnames(createMockRequest('/de/internal/22?hello', 'de'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/external/22?hello'
+          );
+        });
+        it('redirects a dynamic internal route', () => {
+          middlewareWithPathnames(createMockRequest('/de/internal/22/foo/bar?hello', 'de'));
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/external/22/foo/bar?hello'
+          );
+        });
       });
     });
   });
@@ -1678,7 +1839,20 @@ describe('domain-based routing', () => {
           '/categories/[[...slug]]': {
             en: '/categories/[[...slug]]',
             fr: '/categories/[[...slug]]'
-          }
+          },
+          '/internal': '/external',
+          '/internal/foo/bar': {
+            en: '/external/foo/bar',
+            fr: '/external/foo/bar'
+          },
+          '/internal/[id]': {
+            en: '/external/[id]',
+            fr: '/external/[id]'
+          },
+          '/internal/[...slug]': {
+            en: '/external/[...slug]',
+            fr: '/external/[...slug]'
+          },
         } satisfies Pathnames<ReadonlyArray<'en' | 'fr'>>
       });
 
@@ -2019,6 +2193,53 @@ describe('domain-based routing', () => {
             '<http://ca.example.com/base/fr>; rel="alternate"; hreflang="fr"',
             '<http://fr.example.com/base>; rel="alternate"; hreflang="fr"'
           ]);
+        });
+      });
+
+      describe('redirects an internal route with localization to its localized pathname', () => {
+        it('redirects an internal route', () => {
+          middlewareWithPathnames(
+            createMockRequest('/internal', 'fr', 'http://ca.example.com')
+          );
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://ca.example.com/fr/external'
+          );
+        });
+        it('redirects a multi level internal route', () => {
+          middlewareWithPathnames(
+            createMockRequest('/internal/foo/bar', 'fr', 'http://ca.example.com')
+          );
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://ca.example.com/fr/external/foo/bar'
+          );
+        });
+        it('redirects a dynamic internal route', () => {
+          middlewareWithPathnames(
+            createMockRequest('/internal/22', 'fr', 'http://ca.example.com')
+          );
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://ca.example.com/fr/external/22'
+          );
+        });
+        it('redirects a dynamic internal route', () => {
+          middlewareWithPathnames(
+            createMockRequest('/internal/22/foo/bar', 'fr', 'http://ca.example.com')
+          );
+          expect(MockedNextResponse.next).not.toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+          expect(MockedNextResponse.redirect).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+            'http://ca.example.com/fr/external/22/foo/bar'
+          );
         });
       });
     });

--- a/packages/next-intl/test/middleware/utils.test.tsx
+++ b/packages/next-intl/test/middleware/utils.test.tsx
@@ -131,21 +131,34 @@ describe('getInternalTemplate', () => {
   const pathnames = {
     '/categories/[[...slug]]': {
       en: '/categories/[[...slug]]',
-      de: '/kategorien/[[...slug]]'
+      de: '/kategorien/[[...slug]]',
+      it: '/categorie/[[...slug]]'
+    },
+    '/internal/[id]': {
+      en: '/external-en/[id]',
+      de: '/external/[id]',
+      it: '/external/[id]'
     }
   };
 
   it('works when passing no params to optional catch-all segments', () => {
-    expect(getInternalTemplate(pathnames, '/kategorien')).toEqual([
+    expect(getInternalTemplate(pathnames, '/kategorien', 'en')).toEqual([
       'de',
       '/categories/[[...slug]]'
     ]);
   });
 
   it('works when passing params to optional catch-all segments', () => {
-    expect(getInternalTemplate(pathnames, '/kategorien/neu')).toEqual([
+    expect(getInternalTemplate(pathnames, '/kategorien/neu', 'en')).toEqual([
       'de',
       '/categories/[[...slug]]'
+    ]);
+  });
+
+  it('prefers a template from the current locale', () => {
+    expect(getInternalTemplate(pathnames, '/external/2', 'it')).toEqual([
+      'it',
+      '/internal/[id]'
     ]);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/amannn/next-intl/issues/904

**Example:**

```tsx
createIntlMiddleware({
  locales: ['lv', 'ru'],
  defaultLocale: 'lv',
  pathnames: {
    '/': '/',
    '/about': {
      lv: '/par-mums',
      ru: '/o-nas',
    }
  }
});
```

In this case, the only available app routes are `/lv`, `/ru`, `/lv/par-mums` and `/ru/o-nas`.

If a request for `/lv/about` or `/ru/about` is initiated, a 302 redirect to the localized alternative will now be returned.

If `en: '/about'` is added to `pathnames`, then the internal pathname becomes available—but only for this particular locale.

This PR furthermore includes a minor fix for the case where multiple localized pathnames share the same entry, but there are still variations:

```js
'/about': {
  'en-UK': '/about',
  'en-US': '/about',
  'lv': '/par-mums'
}
```

Previously, `/en-US/about` could incorrectly redirect to `/en-UK/about`. Now, this is fixed.