### PR TITLE
docs: Fix typo

### DIFF
--- a/docs/pages/docs/environments/metadata-route-handlers.mdx
+++ b/docs/pages/docs/environments/metadata-route-handlers.mdx
@@ -29,7 +29,7 @@ export async function generateMetadata({params: {locale}}) {
 
 <Callout>
   By passing an explicit `locale` to the awaitable functions from `next-intl`,
-  you can make the metadata handler eligable for [static
+  you can make the metadata handler eligible for [static
   rendering](/docs/getting-started/app-router#static-rendering).
 </Callout>
 


### PR DESCRIPTION
Just a small typo fix. Thanks for the amazing lib!