### PR TITLE
feat: Support symbols in localized pathnames that require URL encoding

### DIFF
--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -412,6 +412,8 @@ In this case, the localized slug can either be provided by the backend or genera
 
 A good practice is to include the ID in the URL, allowing you to retrieve the article based on this information from the backend. The ID can be further used to implement [self-healing URLs](https://mikebifulco.com/posts/self-healing-urls-nextjs-seo), where a redirect is added if the `articleSlug` doesn't match.
 
+If you localize the values for dynamic segments, you might want to turn off [alternate links](#alternate-links) and provide your own implementation that considers localized values for dynamic segments.
+
 </details>
 
 ### Matcher config

--- a/examples/example-app-router-playground/messages/ja.json
+++ b/examples/example-app-router-playground/messages/ja.json
@@ -1,0 +1,12 @@
+{
+  "Index": {
+    "title": "Home (ja)",
+    "description": "This is the home page (ja).",
+    "rich": "This is a <important>rich</important> text (ja).",
+    "globalDefaults": "<highlight>{globalString}</highlight> (ja)"
+  },
+  "Nested": {
+    "title": "ネステッド",
+    "description": "これはネストされたページです。"
+  }
+}

--- a/examples/example-app-router-playground/src/i18n.tsx
+++ b/examples/example-app-router-playground/src/i18n.tsx
@@ -1,6 +1,7 @@
 import {headers} from 'next/headers';
 import {notFound} from 'next/navigation';
 import {getRequestConfig} from 'next-intl/server';
+import defaultMessages from '../messages/en.json';
 import {locales} from './navigation';
 
 export default getRequestConfig(async ({locale}) => {
@@ -9,7 +10,8 @@ export default getRequestConfig(async ({locale}) => {
 
   const now = headers().get('x-now');
   const timeZone = headers().get('x-time-zone') ?? 'Europe/Vienna';
-  const messages = (await import(`../messages/${locale}.json`)).default;
+  const localeMessages = (await import(`../messages/${locale}.json`)).default;
+  const messages = {...defaultMessages, ...localeMessages};
 
   return {
     now: now ? new Date(now) : undefined,

--- a/examples/example-app-router-playground/src/navigation.tsx
+++ b/examples/example-app-router-playground/src/navigation.tsx
@@ -5,7 +5,7 @@ import {
 
 export const defaultLocale = 'en';
 
-export const locales = ['en', 'de', 'es'] as const;
+export const locales = ['en', 'de', 'es', 'ja'] as const;
 
 export const localePrefix =
   process.env.NEXT_PUBLIC_LOCALE_PREFIX === 'never' ? 'never' : 'as-needed';
@@ -17,13 +17,15 @@ export const pathnames = {
   '/nested': {
     en: '/nested',
     de: '/verschachtelt',
-    es: '/anidada'
+    es: '/anidada',
+    ja: '/ネスト'
   },
   '/redirect': '/redirect',
   '/news/[articleId]': {
     en: '/news/[articleId]',
     de: '/neuigkeiten/[articleId]',
-    es: '/noticias/[articleId]'
+    es: '/noticias/[articleId]',
+    ja: '/ニュース/[articleId]'
   }
 } satisfies Pathnames<typeof locales>;
 

--- a/examples/example-app-router-playground/tests/main.spec.ts
+++ b/examples/example-app-router-playground/tests/main.spec.ts
@@ -61,7 +61,7 @@ it('redirects to a matched locale at the root for non-default locales', async ({
 
 it('redirects to a matched locale for an invalid cased non-default locale', async ({
   browser
-  }) => {
+}) => {
   const context = await browser.newContext({locale: 'de'});
   const page = await context.newPage();
 
@@ -72,7 +72,7 @@ it('redirects to a matched locale for an invalid cased non-default locale', asyn
 
 it('redirects to a matched locale for an invalid cased non-default locale in a nested path', async ({
   browser
-  }) => {
+}) => {
   const context = await browser.newContext({locale: 'de'});
   const page = await context.newPage();
 
@@ -83,7 +83,7 @@ it('redirects to a matched locale for an invalid cased non-default locale in a n
 
 it('redirects to a matched locale for an invalid cased default locale', async ({
   browser
-  }) => {
+}) => {
   const context = await browser.newContext({locale: 'en'});
   const page = await context.newPage();
 
@@ -94,7 +94,7 @@ it('redirects to a matched locale for an invalid cased default locale', async ({
 
 it('redirects to a matched locale for an invalid cased default locale in a nested path', async ({
   browser
-  }) => {
+}) => {
   const context = await browser.newContext({locale: 'en'});
   const page = await context.newPage();
 
@@ -684,17 +684,13 @@ describe('handling of foreign characters', () => {
     await page.goto('/ja/ネスト');
     await expect(page).toHaveURL('/ja/ネスト');
     page.getByRole('heading', {name: 'ネステッド'});
-    await expect(page.getByTestId('UnlocalizedPathname')).toHaveText(
-      '/%E3%83%8D%E3%82%B9%E3%83%88'
-    );
+    await expect(page.getByTestId('UnlocalizedPathname')).toHaveText('/nested');
   });
 
   it('handles decoded localized pathnames', async ({page}) => {
     await page.goto('/ja/%E3%83%8D%E3%82%B9%E3%83%88');
     await expect(page).toHaveURL('/ja/ネスト');
     page.getByRole('heading', {name: 'ネステッド'});
-    await expect(page.getByTestId('UnlocalizedPathname')).toHaveText(
-      '/%E3%83%8D%E3%82%B9%E3%83%88'
-    );
+    await expect(page.getByTestId('UnlocalizedPathname')).toHaveText('/nested');
   });
 });

--- a/examples/example-app-router-playground/tests/main.spec.ts
+++ b/examples/example-app-router-playground/tests/main.spec.ts
@@ -421,6 +421,9 @@ it('can use `usePathname` to get internal pathnames', async ({page}) => {
 
   await page.goto('/en/nested');
   await expect(page.getByTestId('UnlocalizedPathname')).toHaveText('/nested');
+
+  await page.goto('/ja//ネスト');
+  await expect(page.getByTestId('UnlocalizedPathname')).toHaveText('/nested');
 });
 
 it('returns the correct value from `usePathname` in the initial render', async ({

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -138,7 +138,7 @@
     },
     {
       "path": "dist/production/middleware.js",
-      "limit": "5.9 KB"
+      "limit": "5.95 KB"
     }
   ]
 }

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -44,11 +44,14 @@ export default function createMiddleware<Locales extends AllLocales>(
   const configWithDefaults = receiveConfig(config);
 
   return function middleware(request: NextRequest) {
+    // Resolve potential foreign symbols (e.g. /ja/%E7%B4%84 → /ja/約))
+    const nextPathname = decodeURI(request.nextUrl.pathname);
+
     const {domain, locale} = resolveLocale(
       configWithDefaults,
       request.headers,
       request.cookies,
-      request.nextUrl.pathname
+      nextPathname
     );
 
     const hasOutdatedCookie =
@@ -130,12 +133,12 @@ export default function createMiddleware<Locales extends AllLocales>(
     }
 
     const normalizedPathname = getNormalizedPathname(
-      request.nextUrl.pathname,
+      nextPathname,
       configWithDefaults.locales
     );
 
     const pathLocale = getPathnameLocale(
-      request.nextUrl.pathname,
+      nextPathname,
       configWithDefaults.locales
     );
     const hasLocalePrefix = pathLocale != null;
@@ -143,7 +146,7 @@ export default function createMiddleware<Locales extends AllLocales>(
     let response;
     let internalTemplateName: string | undefined;
 
-    let pathname = request.nextUrl.pathname;
+    let pathname = nextPathname;
     if (configWithDefaults.pathnames) {
       let resolvedTemplateLocale: Locales[number] | undefined;
       [resolvedTemplateLocale, internalTemplateName] = getInternalTemplate(

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -161,7 +161,11 @@ export function getRoute<Locales extends AllLocales>({
   pathname: string;
   pathnames: Pathnames<Locales>;
 }) {
-  const unlocalizedPathname = unlocalizePathname(pathname, locale);
+  const unlocalizedPathname = unlocalizePathname(
+    // Potentially handle foreign symbols
+    decodeURI(pathname),
+    locale
+  );
 
   let template = Object.entries(pathnames).find(([, routePath]) => {
     const routePathname =

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -363,41 +363,47 @@ describe('prefix-based routing', () => {
     describe('localized pathnames', () => {
       const middlewareWithPathnames = createIntlMiddleware({
         defaultLocale: 'en',
-        locales: ['en', 'de', 'de-AT'],
+        locales: ['en', 'de', 'de-AT', 'ja'],
         localePrefix: 'as-needed',
         pathnames: {
           '/': '/',
           '/about': {
             en: '/about',
             de: '/ueber',
-            'de-AT': '/ueber'
+            'de-AT': '/ueber',
+            ja: '/約'
           },
           '/users': {
             en: '/users',
             de: '/benutzer',
-            'de-AT': '/benutzer'
+            'de-AT': '/benutzer',
+            ja: '/ユーザー'
           },
           '/users/[userId]': {
             en: '/users/[userId]',
             de: '/benutzer/[userId]',
-            'de-AT': '/benutzer/[userId]'
+            'de-AT': '/benutzer/[userId]',
+            ja: '/ユーザー/[userId]'
           },
           '/news/[articleSlug]-[articleId]': {
             en: '/news/[articleSlug]-[articleId]',
             de: '/neuigkeiten/[articleSlug]-[articleId]',
-            'de-AT': '/neuigkeiten/[articleSlug]-[articleId]'
+            'de-AT': '/neuigkeiten/[articleSlug]-[articleId]',
+            ja: '/ニュース/[articleSlug]-[articleId]'
           },
           '/products/[...slug]': {
             en: '/products/[...slug]',
             de: '/produkte/[...slug]',
-            'de-AT': '/produkte/[...slug]'
+            'de-AT': '/produkte/[...slug]',
+            ja: '/製品/[...slug]'
           },
           '/categories/[[...slug]]': {
             en: '/categories/[[...slug]]',
             de: '/kategorien/[[...slug]]',
-            'de-AT': '/kategorien/[[...slug]]'
+            'de-AT': '/kategorien/[[...slug]]',
+            ja: '/カテゴリー/[[...slug]]'
           }
-        } satisfies Pathnames<ReadonlyArray<'en' | 'de' | 'de-AT'>>
+        } satisfies Pathnames<ReadonlyArray<'en' | 'de' | 'de-AT' | 'ja'>>
       });
 
       it('serves requests for the default locale at the root', () => {
@@ -490,6 +496,45 @@ describe('prefix-based routing', () => {
         );
         expect(MockedNextResponse.rewrite.mock.calls[5][0].toString()).toBe(
           'http://localhost:3000/de/categories/frauen/t-shirts'
+        );
+      });
+
+      it('serves requests for a non-default locale at nested paths', () => {
+        middlewareWithPathnames(createMockRequest('/ja/約', 'ja'));
+        middlewareWithPathnames(createMockRequest('/ja/ユーザー', 'ja'));
+        middlewareWithPathnames(createMockRequest('/ja/ユーザー/1', 'ja'));
+        middlewareWithPathnames(
+          createMockRequest('/ja/ニュース/happy-newyear-g5b116754', 'ja')
+        );
+        middlewareWithPathnames(
+          createMockRequest('/ja/製品/アパレル/ティーシャツ', 'ja')
+        );
+        middlewareWithPathnames(
+          createMockRequest('/ja/カテゴリー/女性/ティーシャツ', 'ja')
+        );
+
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(6);
+        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+          'http://localhost:3000/ja/about'
+        );
+        expect(MockedNextResponse.rewrite.mock.calls[1][0].toString()).toBe(
+          'http://localhost:3000/ja/users'
+        );
+        expect(MockedNextResponse.rewrite.mock.calls[2][0].toString()).toBe(
+          'http://localhost:3000/ja/users/1'
+        );
+        expect(MockedNextResponse.rewrite.mock.calls[3][0].toString()).toBe(
+          'http://localhost:3000/ja/news/happy-newyear-g5b116754'
+        );
+
+        // Dynamic segments are expected to be encoded
+        expect(MockedNextResponse.rewrite.mock.calls[4][0].toString()).toBe(
+          'http://localhost:3000/ja/products/%E3%82%A2%E3%83%91%E3%83%AC%E3%83%AB/%E3%83%86%E3%82%A3%E3%83%BC%E3%82%B7%E3%83%A3%E3%83%84'
+        );
+        expect(MockedNextResponse.rewrite.mock.calls[5][0].toString()).toBe(
+          'http://localhost:3000/ja/categories/%E5%A5%B3%E6%80%A7/%E3%83%86%E3%82%A3%E3%83%BC%E3%82%B7%E3%83%A3%E3%83%84'
         );
       });
 
@@ -608,36 +653,42 @@ describe('prefix-based routing', () => {
           '<http://localhost:3000/>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/de>; rel="alternate"; hreflang="de"',
           '<http://localhost:3000/de-AT>; rel="alternate"; hreflang="de-AT"',
+          '<http://localhost:3000/ja>; rel="alternate"; hreflang="ja"',
           '<http://localhost:3000/>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(getLinks(createMockRequest('/de', 'de'))).toEqual([
           '<http://localhost:3000/>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/de>; rel="alternate"; hreflang="de"',
           '<http://localhost:3000/de-AT>; rel="alternate"; hreflang="de-AT"',
+          '<http://localhost:3000/ja>; rel="alternate"; hreflang="ja"',
           '<http://localhost:3000/>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(getLinks(createMockRequest('/about', 'en'))).toEqual([
           '<http://localhost:3000/about>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/de/ueber>; rel="alternate"; hreflang="de"',
           '<http://localhost:3000/de-AT/ueber>; rel="alternate"; hreflang="de-AT"',
+          '<http://localhost:3000/ja/%E7%B4%84>; rel="alternate"; hreflang="ja"',
           '<http://localhost:3000/about>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(getLinks(createMockRequest('/de/ueber', 'de'))).toEqual([
           '<http://localhost:3000/about>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/de/ueber>; rel="alternate"; hreflang="de"',
           '<http://localhost:3000/de-AT/ueber>; rel="alternate"; hreflang="de-AT"',
+          '<http://localhost:3000/ja/%E7%B4%84>; rel="alternate"; hreflang="ja"',
           '<http://localhost:3000/about>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(getLinks(createMockRequest('/users/1', 'en'))).toEqual([
           '<http://localhost:3000/users/1>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/de/benutzer/1>; rel="alternate"; hreflang="de"',
           '<http://localhost:3000/de-AT/benutzer/1>; rel="alternate"; hreflang="de-AT"',
+          '<http://localhost:3000/ja/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC/1>; rel="alternate"; hreflang="ja"',
           '<http://localhost:3000/users/1>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(getLinks(createMockRequest('/de/benutzer/1', 'de'))).toEqual([
           '<http://localhost:3000/users/1>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/de/benutzer/1>; rel="alternate"; hreflang="de"',
           '<http://localhost:3000/de-AT/benutzer/1>; rel="alternate"; hreflang="de-AT"',
+          '<http://localhost:3000/ja/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC/1>; rel="alternate"; hreflang="ja"',
           '<http://localhost:3000/users/1>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(
@@ -646,6 +697,7 @@ describe('prefix-based routing', () => {
           '<http://localhost:3000/products/apparel/t-shirts>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/de/produkte/apparel/t-shirts>; rel="alternate"; hreflang="de"',
           '<http://localhost:3000/de-AT/produkte/apparel/t-shirts>; rel="alternate"; hreflang="de-AT"',
+          '<http://localhost:3000/ja/%E8%A3%BD%E5%93%81/apparel/t-shirts>; rel="alternate"; hreflang="ja"',
           '<http://localhost:3000/products/apparel/t-shirts>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(
@@ -654,18 +706,21 @@ describe('prefix-based routing', () => {
           '<http://localhost:3000/products/apparel/t-shirts>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/de/produkte/apparel/t-shirts>; rel="alternate"; hreflang="de"',
           '<http://localhost:3000/de-AT/produkte/apparel/t-shirts>; rel="alternate"; hreflang="de-AT"',
+          '<http://localhost:3000/ja/%E8%A3%BD%E5%93%81/apparel/t-shirts>; rel="alternate"; hreflang="ja"',
           '<http://localhost:3000/products/apparel/t-shirts>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(getLinks(createMockRequest('/unknown', 'en'))).toEqual([
           '<http://localhost:3000/unknown>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/de/unknown>; rel="alternate"; hreflang="de"',
           '<http://localhost:3000/de-AT/unknown>; rel="alternate"; hreflang="de-AT"',
+          '<http://localhost:3000/ja/unknown>; rel="alternate"; hreflang="ja"',
           '<http://localhost:3000/unknown>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(getLinks(createMockRequest('/de/unknown', 'de'))).toEqual([
           '<http://localhost:3000/unknown>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/de/unknown>; rel="alternate"; hreflang="de"',
           '<http://localhost:3000/de-AT/unknown>; rel="alternate"; hreflang="de-AT"',
+          '<http://localhost:3000/ja/unknown>; rel="alternate"; hreflang="ja"',
           '<http://localhost:3000/unknown>; rel="alternate"; hreflang="x-default"'
         ]);
       });

--- a/packages/next-intl/test/navigation/createLocalizedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/test/navigation/createLocalizedPathnamesNavigation.test.tsx
@@ -51,20 +51,23 @@ beforeEach(() => {
   vi.mocked(useParams).mockImplementation(() => ({locale: 'en'}));
 });
 
-const locales = ['en', 'de'] as const;
+const locales = ['en', 'de', 'ja'] as const;
 const pathnames = {
   '/': '/',
   '/about': {
     en: '/about',
-    de: '/ueber-uns'
+    de: '/ueber-uns',
+    ja: '/約'
   },
   '/news/[articleSlug]-[articleId]': {
     en: '/news/[articleSlug]-[articleId]',
-    de: '/neuigkeiten/[articleSlug]-[articleId]'
+    de: '/neuigkeiten/[articleSlug]-[articleId]',
+    ja: '/ニュース/[articleSlug]-[articleId]'
   },
   '/categories/[...parts]': {
     en: '/categories/[...parts]',
-    de: '/kategorien/[...parts]'
+    de: '/kategorien/[...parts]',
+    ja: '/カテゴリ/[...parts]'
   },
   '/catch-all/[[...parts]]': '/catch-all/[[...parts]]'
 } satisfies Pathnames<typeof locales>;
@@ -433,6 +436,18 @@ describe.each([
               }
             })
           ).toBe('/categories/clothing/t-shirts?sort=price');
+        });
+
+        it('handles foreign symbols', () => {
+          expect(
+            getPathname({
+              locale: 'ja',
+              href: {
+                pathname: '/about',
+                query: {foo: 'bar'}
+              }
+            })
+          ).toBe('/約?foo=bar');
         });
       });
     });


### PR DESCRIPTION
Fixes #607

**Prerelease:**

```
next-intl@3.11.0-beta.2
```

**Example:**

```js
export const pathnames = {
  '/': '/',
  '/test': {
    en: '/test',
    ja: '/テスト'
  }
} satisfies Pathnames<typeof locales>
```

Previously, a request to `/ja/テスト` would be a 404 since the pathname wasn't matched correctly. Now, the internal `/test` route is properly used for rendering.

If you've previously used [a workaround to encode pathnames](https://github.com/amannn/next-intl/issues/607#issuecomment-1979747515), please remove it when upgrading to the latest version of `next-intl`.

