### PR TITLE
fix: Apply correct port when redirecting to another domain and the app doesn't run behind a proxy

### DIFF
--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -116,10 +116,15 @@ export default function createMiddleware<Locales extends AllLocales>(
       }
 
       if (redirectDomain) {
-        urlObj.protocol =
-          request.headers.get('x-forwarded-proto') ?? request.nextUrl.protocol;
-        urlObj.port = '';
         urlObj.host = redirectDomain;
+
+        if (request.headers.get('x-forwarded-host')) {
+          urlObj.protocol =
+            request.headers.get('x-forwarded-proto') ??
+            request.nextUrl.protocol;
+
+          urlObj.port = request.headers.get('x-forwarded-port') ?? '';
+        }
       }
 
       if (request.nextUrl.basePath) {

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -2451,15 +2451,13 @@ describe('domain-based routing', () => {
       );
     });
 
-    it('uses the correct port and protocol', () => { 
-      middleware( 
-        createMockRequest('/', 'fr', 'http://ca.example.com:3000') 
-      ); 
-      expect(MockedNextResponse.next).not.toHaveBeenCalled(); 
-      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled(); 
-      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe( 
-        'http://ca.example.com:3000/fr' 
-      ); 
+    it('uses the correct port and protocol', () => {
+      middleware(createMockRequest('/', 'fr', 'http://ca.example.com:3000'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://ca.example.com:3000/fr'
+      );
     });
 
     it('uses the correct port and protocol when behind a proxy', () => {

--- a/packages/next-intl/test/middleware/middleware.test.tsx
+++ b/packages/next-intl/test/middleware/middleware.test.tsx
@@ -2451,7 +2451,18 @@ describe('domain-based routing', () => {
       );
     });
 
-    it('uses the correct port and protocol when being called from an internal address', () => {
+    it('uses the correct port and protocol', () => { 
+      middleware( 
+        createMockRequest('/', 'fr', 'http://ca.example.com:3000') 
+      ); 
+      expect(MockedNextResponse.next).not.toHaveBeenCalled(); 
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled(); 
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe( 
+        'http://ca.example.com:3000/fr' 
+      ); 
+    });
+
+    it('uses the correct port and protocol when behind a proxy', () => {
       middleware(
         createMockRequest('/', 'fr', 'http://192.168.0.1:3000', undefined, {
           'x-forwarded-host': 'ca.example.com',
@@ -2462,6 +2473,19 @@ describe('domain-based routing', () => {
       expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
         'https://ca.example.com/fr'
+      );
+
+      middleware(
+        createMockRequest('/', 'fr', 'http://192.168.0.1:3000', undefined, {
+          'x-forwarded-host': 'ca.example.com',
+          'x-forwarded-port': '4200',
+          'x-forwarded-proto': 'https'
+        })
+      );
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[1][0].toString()).toBe(
+        'https://ca.example.com:4200/fr'
       );
     });
 


### PR DESCRIPTION
Fixes #658

----

# Contribution feedback

@amannn to preserve your desired formatting, this project would benefit from an [EditorConfig](https://editorconfig.org/) or tool such as [Prettier](https://prettier.io/)