### PR TITLE
fix: Correctly detect base path at the app root `/` when using a locale prefix strategy other than `always`. This ensures the locale cookie is set correctly.

### DIFF
--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -122,11 +122,11 @@
     },
     {
       "path": "dist/production/navigation.react-client.js",
-      "limit": "2.94 KB"
+      "limit": "2.96 KB"
     },
     {
       "path": "dist/production/navigation.react-server.js",
-      "limit": "3.03 KB"
+      "limit": "3.06 KB"
     },
     {
       "path": "dist/production/server.react-client.js",

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -180,6 +180,13 @@ export function getRoute<Locales extends AllLocales>({
   return template as keyof Pathnames<Locales>;
 }
 
-export function getBasePath(pathname: string) {
-  return window.location.pathname.replace(pathname, '');
+export function getBasePath(
+  pathname: string,
+  windowPathname = window.location.pathname
+) {
+  if (pathname === '/') {
+    return windowPathname;
+  } else {
+    return windowPathname.replace(pathname, '');
+  }
 }

--- a/packages/next-intl/test/navigation/shared/utils.test.tsx
+++ b/packages/next-intl/test/navigation/shared/utils.test.tsx
@@ -1,6 +1,7 @@
 import {describe, expect, it} from 'vitest';
 import {
   compileLocalizedPathname,
+  getBasePath,
   serializeSearchParams
 } from '../../../src/navigation/shared/utils';
 
@@ -40,5 +41,23 @@ describe('compileLocalizedPathname', () => {
         'Params: {"one":"1"}'
       ].join('\n')
     );
+  });
+});
+
+describe('getBasePath', () => {
+  it('detects a base path when using a locale prefix and the user is at the root', () => {
+    expect(getBasePath('/en', '/base/en')).toBe('/base');
+  });
+
+  it('detects a base path when using a locale prefix and the user is at a nested path', () => {
+    expect(getBasePath('/en/about', '/base/en/about')).toBe('/base');
+  });
+
+  it('detects a base path when using no locale prefix and the user is at the root', () => {
+    expect(getBasePath('/', '/base')).toBe('/base');
+  });
+
+  it('detects a base path when using no locale prefix and the user is at a nested path', () => {
+    expect(getBasePath('/about', '/base/about')).toBe('/base');
   });
 });


### PR DESCRIPTION
Fixes #997