### PR TITLE
docs: Update Clerk integration example to Clerk Core 2

### DIFF
--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -593,10 +593,14 @@ Note that if you use a [`localePrefix`](#locale-prefix) other than `always`, you
 
 ### Example: Integrating with Clerk
 
-[`@clerk/nextjs`](https://clerk.com/docs/references/nextjs/overview) provides a middleware that can be integrated with `next-intl` by using the [`beforeAuth` hook](https://clerk.com/docs/references/nextjs/auth-middleware#using-before-auth-to-execute-middleware-before-authentication). By doing this, the middleware from `next-intl` will run first, potentially redirect or rewrite incoming requests, followed by the middleware from `@clerk/next` acting on the response.
+[`@clerk/nextjs`](https://clerk.com/docs/references/nextjs/overview) provides a middleware that can be [combined](https://clerk.com/docs/references/nextjs/clerk-middleware#combine-middleware) with other middlewares like the one provided by `next-intl`. By combining them, the middleware from `@clerk/next` will first ensure protected routes are handled appropriately. Subsequently, the middleware from `next-intl` will run, potentially redirecting or rewriting incoming requests.
 
 ```tsx filename="middleware.ts"
-import {authMiddleware} from '@clerk/nextjs';
+import {
+  clerkMiddleware,
+  createRouteMatcher,
+  redirectToSignIn,
+} from '@clerk/nextjs/server';
 import createMiddleware from 'next-intl/middleware';
 
 const intlMiddleware = createMiddleware({
@@ -604,18 +608,21 @@ const intlMiddleware = createMiddleware({
   defaultLocale: 'en'
 });
 
-export default authMiddleware({
-  beforeAuth(request) {
-    return intlMiddleware(request);
-  },
+const isProtectedRoute = createRouteMatcher([
+  'dashboard/(.*)',
+]);
 
-  // Ensure that locale-specific sign in pages are public
-  publicRoutes: ['/:locale', '/:locale/sign-in']
+export default clerkMiddleware((auth, req) => {
+  if (isProtectedRoute(req)) auth().protect();
+
+  return intlMiddleware(req);
 });
 
 export const config = {
-  // Match only internationalized pathnames
-  matcher: ['/', '/(de|en)/:path*']
+  /**
+   * Match all paths except of internal /_next/ routes, static files and api paths
+   */
+  matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api)(.*)'],
 };
 ```
 

--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -599,7 +599,6 @@ Note that if you use a [`localePrefix`](#locale-prefix) other than `always`, you
 import {
   clerkMiddleware,
   createRouteMatcher,
-  redirectToSignIn,
 } from '@clerk/nextjs/server';
 import createMiddleware from 'next-intl/middleware';
 

--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -608,7 +608,7 @@ const intlMiddleware = createMiddleware({
 });
 
 const isProtectedRoute = createRouteMatcher([
-  'dashboard/(.*)',
+  '/:locale/dashboard(.*)',
 ]);
 
 export default clerkMiddleware((auth, req) => {
@@ -618,10 +618,8 @@ export default clerkMiddleware((auth, req) => {
 });
 
 export const config = {
-  /**
-   * Match all paths except of internal /_next/ routes, static files and api paths
-   */
-  matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api)(.*)'],
+  // Match only internationalized pathnames
+  matcher: ['/', '/(de|en)/:path*'],
 };
 ```
 

--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -596,10 +596,7 @@ Note that if you use a [`localePrefix`](#locale-prefix) other than `always`, you
 [`@clerk/nextjs`](https://clerk.com/docs/references/nextjs/overview) provides a middleware that can be [combined](https://clerk.com/docs/references/nextjs/clerk-middleware#combine-middleware) with other middlewares like the one provided by `next-intl`. By combining them, the middleware from `@clerk/next` will first ensure protected routes are handled appropriately. Subsequently, the middleware from `next-intl` will run, potentially redirecting or rewriting incoming requests.
 
 ```tsx filename="middleware.ts"
-import {
-  clerkMiddleware,
-  createRouteMatcher,
-} from '@clerk/nextjs/server';
+import {clerkMiddleware, createRouteMatcher} from '@clerk/nextjs/server';
 import createMiddleware from 'next-intl/middleware';
 
 const intlMiddleware = createMiddleware({
@@ -608,7 +605,7 @@ const intlMiddleware = createMiddleware({
 });
 
 const isProtectedRoute = createRouteMatcher([
-  '/:locale/dashboard(.*)',
+  '/:locale/dashboard(.*)'
 ]);
 
 export default clerkMiddleware((auth, req) => {
@@ -619,7 +616,7 @@ export default clerkMiddleware((auth, req) => {
 
 export const config = {
   // Match only internationalized pathnames
-  matcher: ['/', '/(de|en)/:path*'],
+  matcher: ['/', '/(de|en)/:path*']
 };
 ```
 


### PR DESCRIPTION
Clerk recently release [Clerk Core 2](https://clerk.com/docs/upgrade-guides/core-2/overview) wich changes the procedure of integrating with next-intl. This PR updates the docs to reflect these changes.