### PR TITLE
docs: Rename inlang VSCode extension to Sherlock

### DIFF
--- a/docs/pages/docs/workflows/vscode-integration.mdx
+++ b/docs/pages/docs/workflows/vscode-integration.mdx
@@ -29,7 +29,7 @@ These extensions are known to support `next-intl`:
 "i18n-ally.keystyle": "nested"
 ```
 
-## 🕵️‍♂️ Sherlock [#sherlock]
+## Sherlock [#sherlock]
 
 **Features:**
 

--- a/docs/pages/docs/workflows/vscode-integration.mdx
+++ b/docs/pages/docs/workflows/vscode-integration.mdx
@@ -58,6 +58,4 @@ These extensions are known to support `next-intl`:
 }
 ```
 
-**Guide:**
-
 Learn more in the inlang docs: [Setting up next-intl with the Sherlock extension](https://inlang.com/g/hhfueysj/guide-nilsjacobsen-nextIntlIdeExtension?ref=next-intl)

--- a/docs/pages/docs/workflows/vscode-integration.mdx
+++ b/docs/pages/docs/workflows/vscode-integration.mdx
@@ -7,7 +7,7 @@ To improve the workflow for managing messages right from your code editor, you c
 These extensions are known to support `next-intl`:
 
 1. [i18n Ally](#i18n-ally)
-2. [🕵️‍♂️ Sherlock](#sherlock)
+2. [Sherlock](#sherlock)
 
 ## i18n Ally [#i18n-ally]
 

--- a/docs/pages/docs/workflows/vscode-integration.mdx
+++ b/docs/pages/docs/workflows/vscode-integration.mdx
@@ -7,7 +7,7 @@ To improve the workflow for managing messages right from your code editor, you c
 These extensions are known to support `next-intl`:
 
 1. [i18n Ally](#i18n-ally)
-2. [inlang IDE extension](#inlang)
+2. [🕵️‍♂️ Sherlock](#sherlock)
 
 ## i18n Ally [#i18n-ally]
 
@@ -29,7 +29,7 @@ These extensions are known to support `next-intl`:
 "i18n-ally.keystyle": "nested"
 ```
 
-## inlang IDE extension [#inlang]
+## 🕵️‍♂️ Sherlock [#sherlock]
 
 **Features:**
 
@@ -41,7 +41,7 @@ These extensions are known to support `next-intl`:
 
 **Setup:**
 
-1. Install [the inlang IDE extension](https://marketplace.visualstudio.com/items?itemName=inlang.vs-code-extension)
+1. Install the [🕵️‍♂️ Sherlock VS Code extension](https://marketplace.visualstudio.com/items?itemName=inlang.vs-code-extension)
 2. Configure the extension in your project via `project.inlang/settings.json`:
 
 ```json filename="project.inlang/settings.json"
@@ -58,4 +58,6 @@ These extensions are known to support `next-intl`:
 }
 ```
 
-Learn more in the inlang docs: [Setting up next-intl with the IDE extension](https://inlang.com/g/hhfueysj/guide-nilsjacobsen-nextIntlIdeExtension?ref=next-intl)
+**Guide:**
+
+Learn more in the inlang docs: [Setting up next-intl with the Sherlock extension](https://inlang.com/g/hhfueysj/guide-nilsjacobsen-nextIntlIdeExtension?ref=next-intl)

--- a/docs/pages/docs/workflows/vscode-integration.mdx
+++ b/docs/pages/docs/workflows/vscode-integration.mdx
@@ -41,7 +41,7 @@ These extensions are known to support `next-intl`:
 
 **Setup:**
 
-1. Install the [🕵️‍♂️ Sherlock VS Code extension](https://marketplace.visualstudio.com/items?itemName=inlang.vs-code-extension)
+1. Install the [Sherlock VS Code extension](https://marketplace.visualstudio.com/items?itemName=inlang.vs-code-extension)
 2. Configure the extension in your project via `project.inlang/settings.json`:
 
 ```json filename="project.inlang/settings.json"


### PR DESCRIPTION
Hey, we recently did a redesign/rebranding of the inlang VS Code extension.

It's now called "Sherlock" 🕵️‍♂️.

This PR reflects this change inside the `next-intl` documentation.
Happy to change anything if needed.

– Felix