### PR TITLE
docs: Getting started with all messages on the client side

### DIFF
--- a/docs/pages/docs/environments/server-client-components.mdx
+++ b/docs/pages/docs/environments/server-client-components.mdx
@@ -23,7 +23,7 @@ Moving internationalization to the server side unlocks new levels of performance
 
 **Benefits of server-side internationalization:**
 
-1. Your messages never leave the server and don't need to be serialized for the client side
+1. Your messages never leave the server and don't need to be passed to the client side
 2. Library code for internationalization doesn't need to be loaded on the client side
 3. No need to split your messages, e.g. based on routes or components
 4. No runtime cost on the client side
@@ -123,7 +123,9 @@ In regard to performance, async functions and hooks can be used very much interc
 
 ## Using internationalization in Client Components
 
-Depending on your situation, you may need to handle internationalization in Client Components as well. There are several options for using translations or other functionality from `next-intl` in Client Components, listed here in order of recommendation.
+Depending on your situation, you may need to handle internationalization in Client Components as well. While providing all messages to the client side is typically the easiest way to [get started](/docs/getting-started/app-router#layout) and a reasonable approach for emerging apps, you can be more selective about which messages are passed to the client side to reduce the bundle size of your app.
+
+There are several options for using translations from `next-intl` in Client Components, listed here in order of enabling the best performance:
 
 ### Option 1: Passing translations to Client Components
 
@@ -221,15 +223,15 @@ To keep internationalization on the server side, it can be helpful to structure 
 ```tsx filename="app/register/page.tsx"
 import {useTranslations} from 'next-intl';
 
-// A Client Component, so that it can use `useFormState` to
-// potentially display errors received after submission.
+// A Client Component, so that `useFormState` can be used
+// to potentially display errors received after submission.
 import RegisterForm from './RegisterForm';
 
-// A Client Component, so that it can use `useFormStatus`
+// A Client Component, so that `useFormStatus` can be used
 // to disable the input field during submission.
 import FormField from './FormField';
 
-// A Client Component, so that it can use `useFormStatus`
+// A Client Component, so that `useFormStatus` can be used
 // to disable the submit button during submission.
 import FormSubmitButton from './FormSubmitButton';
 
@@ -284,7 +286,7 @@ In particular, page and search params are often a great option because they offe
 
 ### Option 3: Providing individual messages
 
-To reduce bundle size, `next-intl` doesn't automatically provide [messages](/docs/usage/configuration#messages) or [formats](/docs/usage/configuration#formats) to Client Components.
+To reduce bundle size, `next-intl` doesn't automatically provide [messages](/docs/usage/configuration#messages) to Client Components.
 
 If you need to incorporate dynamic state into components that can not be moved to the server side, you can wrap these components with `NextIntlClientProvider` and provide the relevant messages.
 
@@ -310,14 +312,12 @@ export default function Counter() {
 }
 ```
 
-In case you prefer to make all messages available to the client side, you can [configure `NextIntlClientProvider` in the root layout](#option-4-providing-all-messages) instead.
-
 <Details id="messages-client-namespaces">
 <summary>How can I know the messages I need to provide to the client side?</summary>
 
 Currently, the messages you select for being passed to the client side need to be picked based on knowledge about the implementation of the wrapped components.
 
-An automatic, compiler-driven approach is being evaluated in [`next-intl#2`](https://github.com/amannn/next-intl/issues/1).
+An automatic, compiler-driven approach is being evaluated in [`next-intl#1`](https://github.com/amannn/next-intl/issues/1).
 
 </Details>
 
@@ -346,11 +346,6 @@ export default function LocaleLayout({children, params: {locale}}) {
   );
 }
 ```
-
-<Callout type="warning">
-  Note that this is a tradeoff in regard to performance (see the bullet points
-  at the top of this page).
-</Callout>
 
 ## Troubleshooting
 
@@ -384,6 +379,7 @@ export default function MyCustomNextIntlClientProvider({
   locale,
   timeZone,
   now,
+  formats,
   ...rest
 }) {
   return (
@@ -396,6 +392,7 @@ export default function MyCustomNextIntlClientProvider({
       locale={locale}
       timeZone={timeZone}
       now={now}
+      formats={formats}
       {...props}
     />
   );
@@ -404,4 +401,4 @@ export default function MyCustomNextIntlClientProvider({
 
 By doing this, your custom provider will already be part of the client-side bundle and can therefore define and pass functions as props.
 
-**Important:** Be sure to pass explicit `locale`, `timeZone` and `now` props to `NextIntlClientProvider` in this case, since the props aren't automatically inherited from a Server Component when you import `NextIntlClientProvider` from a Client Component.
+**Important:** Be sure to pass explicit `locale`, `formats`, `timeZone` and `now` props to `NextIntlClientProvider` in this case, since the props aren't automatically inherited from a Server Component when you import `NextIntlClientProvider` from a Client Component.

--- a/docs/pages/docs/environments/server-client-components.mdx
+++ b/docs/pages/docs/environments/server-client-components.mdx
@@ -286,7 +286,7 @@ In particular, page and search params are often a great option because they offe
 
 ### Option 3: Providing individual messages
 
-To reduce bundle size, `next-intl` doesn't automatically provide [messages](/docs/usage/configuration#messages) to Client Components.
+To reduce bundle size, `next-intl` doesn't automatically provide [messages](/docs/usage/configuration#messages) or [formats](/docs/usage/configuration#formats) to Client Components.
 
 If you need to incorporate dynamic state into components that can not be moved to the server side, you can wrap these components with `NextIntlClientProvider` and provide the relevant messages.
 
@@ -379,7 +379,6 @@ export default function MyCustomNextIntlClientProvider({
   locale,
   timeZone,
   now,
-  formats,
   ...rest
 }) {
   return (
@@ -392,7 +391,6 @@ export default function MyCustomNextIntlClientProvider({
       locale={locale}
       timeZone={timeZone}
       now={now}
-      formats={formats}
       {...props}
     />
   );

--- a/docs/pages/docs/environments/server-client-components.mdx
+++ b/docs/pages/docs/environments/server-client-components.mdx
@@ -123,7 +123,20 @@ In regard to performance, async functions and hooks can be used very much interc
 
 ## Using internationalization in Client Components
 
-Depending on your situation, you may need to handle internationalization in Client Components as well. While providing all messages to the client side is typically the easiest way to [get started](/docs/getting-started/app-router#layout) and a reasonable approach for emerging apps, you can be more selective about which messages are passed to the client side to reduce the bundle size of your app.
+Depending on your situation, you may need to handle internationalization in Client Components as well. While providing all messages to the client side is typically the easiest way to [get started](/docs/getting-started/app-router#layout) and a reasonable approach for many apps, you can be more selective about which messages are passed to the client side if you're interested in optimizing the performance of your app.
+
+<Details id="client-messages-performance">
+<summary>How does loading messages on the client side relate to performance?</summary>
+
+Depending on the requirements for your app, you might want to monitor your [Core Web Vitals](https://web.dev/articles/vitals) to ensure your app meets your performance goals.
+
+If you pass messages to `NextIntlClientProvider`, Next.js will emit them during the streaming render to the markup of the page so that they can be used by Client Components. This can contribute to the [total blocking time](https://web.dev/articles/tbt), which in turn can relate to the [interaction to next paint](https://web.dev/articles/inp) metric. If you're seeking to improve these metrics in your app, you can be more selective about which messages are passed to the client side.
+
+However, as the general rule for optimization goes: Always measure before you optimize. If your app already performs well, there's no need for optimization.
+
+Note that an automatic, compiler-driven approach for automatically splitting messages is being evaluated in [`next-intl#1`](https://github.com/amannn/next-intl/issues/1).
+
+</Details>
 
 There are several options for using translations from `next-intl` in Client Components, listed here in order of enabling the best performance:
 

--- a/docs/pages/docs/getting-started/app-router.mdx
+++ b/docs/pages/docs/getting-started/app-router.mdx
@@ -5,8 +5,6 @@ import Details from 'components/Details';
 
 # Next.js App Router Internationalization (i18n)
 
-The Next.js App Router introduces support for [React Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components) and unlocks [many benefits](/docs/environments/server-client-components) when handling internationalization on the server side.
-
 ## Getting started
 
 If you haven't done so already, [create a Next.js app](https://nextjs.org/docs/getting-started/installation) that uses the App Router.

--- a/docs/pages/docs/getting-started/app-router.mdx
+++ b/docs/pages/docs/getting-started/app-router.mdx
@@ -174,15 +174,6 @@ export default async function LocaleLayout({
 
 Note that `NextIntlClientProvider` automatically inherits most configuration from `i18n.ts` here.
 
-<Details id="nextintlclientprovider-messages">
-<summary>Do I need to provide all messages to the client side?</summary>
-
-Not at all! While this is the easiest way to get started and a reasonable approach for emerging apps, you can optionally be more selective about which messages are provided to the client side—or provide none at all.
-
-If you consider yourself a performance aficionado, you might want to explore the [Server & Client Components guide](/docs/environments/server-client-components) after finishing the setup.
-
-</Details>
-
 ### `app/[locale]/page.tsx` [#page]
 
 Use translations in your page components or anywhere else!

--- a/docs/pages/docs/getting-started/app-router.mdx
+++ b/docs/pages/docs/getting-started/app-router.mdx
@@ -176,7 +176,7 @@ export default async function LocaleLayout({
 }
 ```
 
-Note that `NextIntlClientProvider` automatically inherits all configuration from `i18n.ts` here—except for the `messages`.
+Note that `NextIntlClientProvider` automatically inherits most configuration from `i18n.ts` here.
 
 <Details id="nextintlclientprovider-messages">
 <summary>Do I need to provide all messages to the client side?</summary>

--- a/docs/pages/docs/getting-started/app-router.mdx
+++ b/docs/pages/docs/getting-started/app-router.mdx
@@ -176,7 +176,7 @@ export default async function LocaleLayout({
 }
 ```
 
-Note that `NextIntlClientProvider` automatically inherits all configuration from `i18n.ts`, except for the `messages` (in case you prefer to be picky about which ones to provide).
+Note that `NextIntlClientProvider` automatically inherits all configuration from `i18n.ts` here—except for the `messages`.
 
 <Details id="nextintlclientprovider-messages">
 <summary>Do I need to provide all messages to the client side?</summary>

--- a/docs/pages/docs/getting-started/app-router.mdx
+++ b/docs/pages/docs/getting-started/app-router.mdx
@@ -90,7 +90,7 @@ module.exports = withNextIntl(nextConfig);
 
 ### `i18n.ts` [#i18nts]
 
-`next-intl` creates a configuration once per request. Here you can provide messages and other options depending on the locale of the user.
+`next-intl` creates a configuration once per request. Here you can provide messages and other options depending on the locale of the user for usage in Server Components.
 
 ```tsx filename="src/i18n.ts"
 import {notFound} from 'next/navigation';
@@ -148,23 +148,44 @@ export const config = {
 
 ### `app/[locale]/layout.tsx` [#layout]
 
-The `locale` that was matched by the middleware is available via the `locale` param and can be used to configure the document language.
+The `locale` that was matched by the middleware is available via the `locale` param and can be used to configure the document language. Additionally, we can use this place to pass configuration from `i18n.ts` to Client Components via `NextIntlClientProvider`.
 
 ```tsx filename="app/[locale]/layout.tsx"
-export default function LocaleLayout({
+import {getMessages} from 'next-intl/server';
+
+export default async function LocaleLayout({
   children,
   params: {locale}
 }: {
   children: React.ReactNode;
   params: {locale: string};
 }) {
+  // Providing all messages to the client
+  // side is the easiest way to get started
+  const messages = await getMessages();
+
   return (
     <html lang={locale}>
-      <body>{children}</body>
+      <body>
+        <NextIntlClientProvider messages={messages}>
+          {children}
+        </NextIntlClientProvider>
+      </body>
     </html>
   );
 }
 ```
+
+Note that `NextIntlClientProvider` automatically inherits all configuration from `i18n.ts`, except for the `messages` (in case you prefer to be picky about which ones to provide).
+
+<Details id="nextintlclientprovider-messages">
+<summary>Do I need to provide all messages to the client side?</summary>
+
+Not at all! While this is the easiest way to get started and a reasonable approach for emerging apps, you can optionally be more selective about which messages are provided to the client side—or provide none at all.
+
+If you consider yourself a performance aficionado, you might want to explore the [Server & Client Components guide](/docs/environments/server-client-components) after finishing the setup.
+
+</Details>
 
 ### `app/[locale]/page.tsx` [#page]
 

--- a/docs/pages/docs/getting-started/app-router.mdx
+++ b/docs/pages/docs/getting-started/app-router.mdx
@@ -56,8 +56,6 @@ Now, set up the plugin which creates an alias to provide your i18n configuration
 <Tabs items={['next.config.mjs', 'next.config.js']}>
 <Tab>
 
-If you're using ECMAScript modules for your Next.js config, you can use the plugin as follows:
-
 ```js filename="next.config.mjs"
 import createNextIntlPlugin from 'next-intl/plugin';
 
@@ -71,8 +69,6 @@ export default withNextIntl(nextConfig);
 
 </Tab>
 <Tab>
-
-If you're using CommonJS for your Next.js config, you can use the plugin as follows:
 
 ```js filename="next.config.js"
 const createNextIntlPlugin = require('next-intl/plugin');
@@ -90,7 +86,7 @@ module.exports = withNextIntl(nextConfig);
 
 ### `i18n.ts` [#i18nts]
 
-`next-intl` creates a configuration once per request. Here you can provide messages and other options depending on the locale of the user for usage in Server Components.
+`next-intl` creates a request-scoped configuration object that can be used to provide messages and other options depending on the locale of the user for usage in Server Components.
 
 ```tsx filename="src/i18n.ts"
 import {notFound} from 'next/navigation';
@@ -212,10 +208,6 @@ In case you ran into an issue, have a look at [the App Router example](https://n
 
 <ul className="ml-4 list-disc">
   <li>[Usage guide](/docs/usage): Format messages, dates and times</li>
-  <li>
-    [Environments](/docs/environments): Explore usage in Server & Client
-    Components and the Metadata API
-  </li>
   <li>
     [Routing](/docs/routing): Integrate i18n routing with `<Link />` & friends
   </li>

--- a/docs/pages/docs/usage/configuration.mdx
+++ b/docs/pages/docs/usage/configuration.mdx
@@ -57,7 +57,7 @@ export default async function LocaleLayout({children, params: {locale}}) {
 }
 ```
 
-`NextIntlClientProvider` inherits the props `locale`, `formats`, `now` and `timeZone` when the component is rendered from a Server Component. In contrast, `messages` can be provided [as necessary](/docs/environments/server-client-components#using-internationalization-in-client-components).
+`NextIntlClientProvider` inherits the props `locale`, `now` and `timeZone` when the component is rendered from a Server Component. In contrast, `messages` can be provided [as necessary](/docs/environments/server-client-components#using-internationalization-in-client-components).
 
 ## Messages
 
@@ -389,8 +389,6 @@ function Component() {
   t('latitude', {latitude: 47.414329182});
 }
 ```
-
-Formats are automatically inherited from the server side if you wrap the relevant components in a `NextIntlClientProvider` that is rendered by a Server Component.
 
 ## Default translation values
 

--- a/docs/pages/docs/usage/configuration.mdx
+++ b/docs/pages/docs/usage/configuration.mdx
@@ -39,10 +39,11 @@ The configuration object is created once for each request by internally using Re
 `NextIntlClientProvider` can be used to provide configuration for **Client Components**.
 
 ```tsx filename="app/[locale]/layout.tsx" /NextIntlClientProvider/
-import {NextIntlClientProvider, useMessages} from 'next-intl';
+import {NextIntlClientProvider} from 'next-intl';
+import {getMessages} from 'next-intl/server';
 
-export default function LocaleLayout({children, params: {locale}}) {
-  const messages = useMessages();
+export default async function LocaleLayout({children, params: {locale}}) {
+  const messages = await getMessages();
 
   return (
     <html lang={locale}>
@@ -56,13 +57,7 @@ export default function LocaleLayout({children, params: {locale}}) {
 }
 ```
 
-`NextIntlClientProvider` inherits the props `locale`, `now` and `timeZone` when the component is rendered from a Server Component. Other configuration like `messages` and `formats` can be provided as necessary.
-
-<Callout>
-  Before passing all messages to the client side, learn more about the options
-  you have to [use internationalization in Client
-  Components](/docs/environments/server-client-components).
-</Callout>
+`NextIntlClientProvider` inherits the props `locale`, `formats`, `now` and `timeZone` when the component is rendered from a Server Component. In contrast, `messages` can be provided [as necessary](/docs/environments/server-client-components#using-internationalization-in-client-components).
 
 ## Messages
 
@@ -95,29 +90,37 @@ export default getRequestConfig(async ({locale}) => {
 });
 ```
 
-To read configured messages in a component, you can use the `useMessages` hook:
+After messages are configured, they can be used via `useTranslations`.
+
+In case you require access to messages in a component, you can use a convenience API to read them from your configuration:
 
 ```tsx
+// Regular components
 import {useMessages} from 'next-intl';
-
 const messages = useMessages();
+
+// Async Server Components
+import {getMessages} from 'next-intl/server';
+const messages = await getMessages();
 ```
 
 </Tab>
 <Tab>
 
 ```tsx
-import {NextIntlClientProvider, useMessages} from 'next-intl';
+import {NextIntlClientProvider} from 'next-intl';
+import {getMessages} from 'next-intl/server';
 
-// Read messages configured via `i18n.ts`. Alternatively,
-// messages can be fetched from any other source too.
-const messages = useMessages();
+async function Component({children}) {
+  // Read messages configured via `i18n.ts`
+  const messages = await getMessages();
 
-return (
-  <NextIntlClientProvider messages={messages}>
-    {children}
-  </NextIntlClientProvider>
-);
+  return (
+    <NextIntlClientProvider messages={messages}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}
 ```
 
 </Tab>
@@ -211,12 +214,16 @@ const timeZone = 'Europe/Vienna';
 
 The available time zone names can be looked up in [the tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
-To read the time zone in a component, you can use the `useTimeZone` hook:
+The configured time zone can be read from components:
 
 ```tsx
+// Regular components
 import {useTimeZone} from 'next-intl';
+const messages = useTimeZone();
 
-const timeZone = useTimeZone();
+// Async Server Components
+import {getTimeZone} from 'next-intl/server';
+const timeZone = await getTimeZone();
 ```
 
 The time zone in Client Components is automatically inherited from the server
@@ -261,12 +268,16 @@ const now = new Date('2020-11-20T10:36:01.516Z');
 </Tab>
 </Tabs>
 
-To read the now value in a component, you can use the `useNow` hook:
+The configured `now` value can be read from components:
 
 ```tsx
+// Regular components
 import {useNow} from 'next-intl';
-
 const now = useNow();
+
+// Async Server Components
+import {getNow} from 'next-intl/server';
+const now = await getNow();
 ```
 
 Similarly to the `timeZone`, the `now` value in Client Components is
@@ -378,6 +389,8 @@ function Component() {
   t('latitude', {latitude: 47.414329182});
 }
 ```
+
+Formats are automatically inherited from the server side if you wrap the relevant components in a `NextIntlClientProvider` that is rendered by a Server Component.
 
 ## Default translation values
 
@@ -527,12 +540,16 @@ function getMessageFallback({namespace, key, error}) {
 
 The current locale of your app is automatically incorporated into hooks like `useTranslations` & `useFormatter` and will affect the rendered output.
 
-In case you need to use this value in other places of your app, you can read it via the `useLocale` hook:
+In case you need to use this value in other places of your app, you can read it in components:
 
 ```tsx
+// Regular components
 import {useLocale} from 'next-intl';
-
 const locale = useLocale();
+
+// Async Server Components
+import {getLocale} from 'next-intl/server';
+const locale = await getLocale();
 ```
 
 <Details id="locale-change">

--- a/docs/pages/docs/usage/configuration.mdx
+++ b/docs/pages/docs/usage/configuration.mdx
@@ -57,7 +57,18 @@ export default async function LocaleLayout({children, params: {locale}}) {
 }
 ```
 
-`NextIntlClientProvider` inherits the props `locale`, `now` and `timeZone` when the component is rendered from a Server Component. In contrast, `messages` can be provided [as necessary](/docs/environments/server-client-components#using-internationalization-in-client-components).
+These props are inherited if you're rendering `NextIntlClientProvider` from a Server Component:
+
+1. `locale`
+2. `now`
+3. `timeZone`
+
+In contrast, these props can be provided as necessary:
+
+1. `messages` (see [Internationalization in Client Components](/docs/environments/server-client-components#using-internationalization-in-client-components))
+2. `formats`
+3. `defaultTranslationValues`
+4. `onError` and `getMessageFallback`
 
 ## Messages
 


### PR DESCRIPTION
I know that users are frequently bitten by messages not being automatically available on the client side. We do this in the best interest of pushing performance as much as possible, but I think this has gone a bit too far. Especially when just starting out with an i18n setup, this can be frustrating.

Furthermore, I think for a number of apps this doesn't make a huge difference anyway. The number and length of messages in apps can vary significantly, so it's hard to make assumptions, but here are two examples from apps I'm maintaining:

1. An emerging one: 88 messages (1,5K gzip)
2. A more sophisticated one: 317 messages (7,6K gzip)

Apps can of course get much larger and it's important to be able to optimize, but it's questionable how early this is needed.

On top of this, app messages aren't the only place where translations are coming from, but typically they represent a part of the total translatable content (with other parts coming from a CMS, backend APIs, etc.).



We're planning on implementing tree-shaking of messages anyway in https://github.com/amannn/next-intl/issues/1, I think for the time being we could be a bit more relaxed about the suggestions we give to users.

→ [New getting started docs for the App Router](https://next-intl-docs-git-docs-client-components-first-next-intl.vercel.app/docs/getting-started/app-router)

~~As part of this, I'd now also consider automatically inheriting `formats` in Client Components if this is defined in `i18n.ts` for similar reasoning.~~ This is a breaking change that will be part of https://github.com/amannn/next-intl/issues/779


