### PR TITLE
docs: Fix incorrect locale in example

### DIFF
--- a/docs/pages/docs/usage/messages.mdx
+++ b/docs/pages/docs/usage/messages.mdx
@@ -307,11 +307,11 @@ Values are required to be alphanumeric and can contain underscores. All other ch
 Therefore, e.g. when you're mapping a locale to a human readable string, you should map the dash to an underscore first:
 
 ```tsx filename="en.json"
-"label": "{locale, select, en_BR {British English} en_US {American English} other {Unknown}"
+"label": "{locale, select, en_GB {British English} en_US {American English} other {Unknown}"
 ```
 
 ```tsx
-const locale = 'en-BR';
+const locale = 'en-GB';
 t('message', {locale: locale.replaceAll('-', '_')};
 ```
 


### PR DESCRIPTION
Corrected to `en_GB`. `en_BR` would be Brazilian English :D