### PR TITLE
chore: Run playwright tests in parallel

### DIFF
--- a/examples/example-app-router-next-auth/playwright.config.ts
+++ b/examples/example-app-router-next-auth/playwright.config.ts
@@ -14,6 +14,7 @@ const config: PlaywrightTestConfig = {
       use: devices['Desktop Chrome']
     }
   ],
+  fullyParallel: true,
   webServer: {
     command: `PORT=${PORT} pnpm start`,
     port: PORT,

--- a/examples/example-app-router-playground/playwright.config.ts
+++ b/examples/example-app-router-playground/playwright.config.ts
@@ -18,6 +18,7 @@ const config: PlaywrightTestConfig = {
       use: devices['Desktop Chrome']
     }
   ],
+  fullyParallel: true,
   webServer: {
     command: `PORT=${PORT} pnpm start`,
     port: PORT,

--- a/examples/example-app-router-playground/tests/locale-prefix-never.spec.ts
+++ b/examples/example-app-router-playground/tests/locale-prefix-never.spec.ts
@@ -1,7 +1,5 @@
 import {test as it, expect} from '@playwright/test';
 
-it.describe.configure({mode: 'parallel'});
-
 it('clears the router cache when changing the locale', async ({page}) => {
   await page.goto('/');
 

--- a/examples/example-app-router-playground/tests/main.spec.ts
+++ b/examples/example-app-router-playground/tests/main.spec.ts
@@ -1,7 +1,5 @@
 import {test as it, expect, Page, BrowserContext} from '@playwright/test';
 
-it.describe.configure({mode: 'parallel'});
-
 const describe = it.describe;
 
 async function assertLocaleCookieValue(

--- a/examples/example-app-router/playwright.config.ts
+++ b/examples/example-app-router/playwright.config.ts
@@ -14,6 +14,7 @@ const config: PlaywrightTestConfig = {
       use: devices['Desktop Chrome']
     }
   ],
+  fullyParallel: true,
   webServer: {
     command: `PORT=${PORT} pnpm start`,
     port: PORT,


### PR DESCRIPTION
Replace usage of `it.describe.configure({mode: 'parallel'})` with `fullyParallel: true`.

h/t https://twitter.com/sebastienlorber/status/1788165474502443345