### PR TITLE
fix: Handle external URLs passed to `redirect` and `permanentRedirect`

### DIFF
--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -122,7 +122,7 @@
     },
     {
       "path": "dist/production/navigation.react-client.js",
-      "limit": "2.96 KB"
+      "limit": "2.965 KB"
     },
     {
       "path": "dist/production/navigation.react-server.js",

--- a/packages/next-intl/src/navigation/shared/basePermanentRedirect.tsx
+++ b/packages/next-intl/src/navigation/shared/basePermanentRedirect.tsx
@@ -4,7 +4,7 @@ import {
   LocalePrefix,
   ParametersExceptFirst
 } from '../../shared/types';
-import {prefixPathname} from '../../shared/utils';
+import {isLocalHref, prefixPathname} from '../../shared/utils';
 
 export default function basePermanentRedirect(
   params: {
@@ -15,7 +15,7 @@ export default function basePermanentRedirect(
   ...args: ParametersExceptFirst<typeof nextPermanentRedirect>
 ) {
   const localizedPathname =
-    params.localePrefix === 'never' || !params.pathname.startsWith('/')
+    params.localePrefix === 'never' || isLocalHref(params.pathname)
       ? params.pathname
       : prefixPathname(params.locale, params.pathname);
   return nextPermanentRedirect(localizedPathname, ...args);

--- a/packages/next-intl/src/navigation/shared/basePermanentRedirect.tsx
+++ b/packages/next-intl/src/navigation/shared/basePermanentRedirect.tsx
@@ -15,7 +15,7 @@ export default function basePermanentRedirect(
   ...args: ParametersExceptFirst<typeof nextPermanentRedirect>
 ) {
   const localizedPathname =
-    params.localePrefix === 'never'
+    params.localePrefix === 'never' || !params.pathname.startsWith('/')
       ? params.pathname
       : prefixPathname(params.locale, params.pathname);
   return nextPermanentRedirect(localizedPathname, ...args);

--- a/packages/next-intl/src/navigation/shared/basePermanentRedirect.tsx
+++ b/packages/next-intl/src/navigation/shared/basePermanentRedirect.tsx
@@ -15,7 +15,7 @@ export default function basePermanentRedirect(
   ...args: ParametersExceptFirst<typeof nextPermanentRedirect>
 ) {
   const localizedPathname =
-    params.localePrefix === 'never' || isLocalHref(params.pathname)
+    params.localePrefix === 'never' || !isLocalHref(params.pathname)
       ? params.pathname
       : prefixPathname(params.locale, params.pathname);
   return nextPermanentRedirect(localizedPathname, ...args);

--- a/packages/next-intl/src/navigation/shared/baseRedirect.tsx
+++ b/packages/next-intl/src/navigation/shared/baseRedirect.tsx
@@ -4,7 +4,7 @@ import {
   LocalePrefix,
   ParametersExceptFirst
 } from '../../shared/types';
-import {prefixPathname} from '../../shared/utils';
+import {isLocalHref, prefixPathname} from '../../shared/utils';
 
 export default function baseRedirect(
   params: {
@@ -15,7 +15,7 @@ export default function baseRedirect(
   ...args: ParametersExceptFirst<typeof nextRedirect>
 ) {
   const localizedPathname =
-    params.localePrefix === 'never' || !params.pathname.startsWith('/')
+    params.localePrefix === 'never' || isLocalHref(params.pathname)
       ? params.pathname
       : prefixPathname(params.locale, params.pathname);
   return nextRedirect(localizedPathname, ...args);

--- a/packages/next-intl/src/navigation/shared/baseRedirect.tsx
+++ b/packages/next-intl/src/navigation/shared/baseRedirect.tsx
@@ -15,7 +15,7 @@ export default function baseRedirect(
   ...args: ParametersExceptFirst<typeof nextRedirect>
 ) {
   const localizedPathname =
-    params.localePrefix === 'never'
+    params.localePrefix === 'never' || !params.pathname.startsWith('/')
       ? params.pathname
       : prefixPathname(params.locale, params.pathname);
   return nextRedirect(localizedPathname, ...args);

--- a/packages/next-intl/src/navigation/shared/baseRedirect.tsx
+++ b/packages/next-intl/src/navigation/shared/baseRedirect.tsx
@@ -15,7 +15,7 @@ export default function baseRedirect(
   ...args: ParametersExceptFirst<typeof nextRedirect>
 ) {
   const localizedPathname =
-    params.localePrefix === 'never' || isLocalHref(params.pathname)
+    params.localePrefix === 'never' || !isLocalHref(params.pathname)
       ? params.pathname
       : prefixPathname(params.locale, params.pathname);
   return nextRedirect(localizedPathname, ...args);

--- a/packages/next-intl/test/navigation/shared/basePermanentRedirect.test.tsx
+++ b/packages/next-intl/test/navigation/shared/basePermanentRedirect.test.tsx
@@ -1,57 +1,81 @@
-import { permanentRedirect as nextPermanentRedirect } from "next/navigation";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import basePermanentRedirect from "../../../src/navigation/shared/basePermanentRedirect";
+import {permanentRedirect as nextPermanentRedirect} from 'next/navigation';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import basePermanentRedirect from '../../../src/navigation/shared/basePermanentRedirect';
 
-vi.mock("next/navigation");
+vi.mock('next/navigation');
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("localePrefix: 'as-needed'", () => {
-  describe("basePermanentRedirect", () => {
-    it("does localize redirects to internal paths", () => {
+describe("localePrefix: 'always'", () => {
+  describe('basePermanentRedirect', () => {
+    it('handles internal paths', () => {
       basePermanentRedirect({
-        pathname: "/test/path",
-        locale: "en",
-        localePrefix: "as-needed",
+        pathname: '/test/path',
+        locale: 'en',
+        localePrefix: 'always'
       });
       expect(nextPermanentRedirect).toHaveBeenCalledTimes(1);
-      expect(nextPermanentRedirect).toHaveBeenCalledWith("/en/test/path");
+      expect(nextPermanentRedirect).toHaveBeenCalledWith('/en/test/path');
     });
 
-    it("does not localize redirects to external paths", () => {
+    it('handles external paths', () => {
       basePermanentRedirect({
-        pathname: "https://example.com",
-        locale: "en",
-        localePrefix: "as-needed",
+        pathname: 'https://example.com',
+        locale: 'en',
+        localePrefix: 'always'
       });
       expect(nextPermanentRedirect).toHaveBeenCalledTimes(1);
-      expect(nextPermanentRedirect).toHaveBeenCalledWith("https://example.com");
+      expect(nextPermanentRedirect).toHaveBeenCalledWith('https://example.com');
+    });
+  });
+});
+
+describe("localePrefix: 'as-needed'", () => {
+  describe('basePermanentRedirect', () => {
+    it('handles internal paths', () => {
+      basePermanentRedirect({
+        pathname: '/test/path',
+        locale: 'en',
+        localePrefix: 'as-needed'
+      });
+      expect(nextPermanentRedirect).toHaveBeenCalledTimes(1);
+      expect(nextPermanentRedirect).toHaveBeenCalledWith('/en/test/path');
+    });
+
+    it('handles external paths', () => {
+      basePermanentRedirect({
+        pathname: 'https://example.com',
+        locale: 'en',
+        localePrefix: 'as-needed'
+      });
+      expect(nextPermanentRedirect).toHaveBeenCalledTimes(1);
+      expect(nextPermanentRedirect).toHaveBeenCalledWith('https://example.com');
     });
   });
 });
 
 describe("localePrefix: 'never'", () => {
-  describe("basePermanentRedirect", () => {
-    it("does localize redirects to internal paths", () => {
+  describe('basePermanentRedirect', () => {
+    it('handles internal paths', () => {
       basePermanentRedirect({
-        pathname: "/test/path",
-        locale: "en",
-        localePrefix: "never",
+        pathname: '/test/path',
+        locale: 'en',
+        localePrefix: 'never'
       });
       expect(nextPermanentRedirect).toHaveBeenCalledTimes(1);
-      expect(nextPermanentRedirect).toHaveBeenCalledWith("/test/path");
+      expect(nextPermanentRedirect).toHaveBeenCalledWith('/test/path');
     });
 
-    it("does not localize redirects to external paths", () => {
+    it('handles external paths', () => {
       basePermanentRedirect({
-        pathname: "https://example.com",
-        locale: "en",
-        localePrefix: "never",
+        pathname: 'https://example.com',
+        locale: 'en',
+        localePrefix: 'never'
       });
       expect(nextPermanentRedirect).toHaveBeenCalledTimes(1);
-      expect(nextPermanentRedirect).toHaveBeenCalledWith("https://example.com");
+      expect(nextPermanentRedirect).toHaveBeenCalledWith('https://example.com');
     });
   });
 });

--- a/packages/next-intl/test/navigation/shared/basePermanentRedirect.test.tsx
+++ b/packages/next-intl/test/navigation/shared/basePermanentRedirect.test.tsx
@@ -1,0 +1,57 @@
+import { permanentRedirect as nextPermanentRedirect } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import basePermanentRedirect from "../../../src/navigation/shared/basePermanentRedirect";
+
+vi.mock("next/navigation");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("localePrefix: 'as-needed'", () => {
+  describe("basePermanentRedirect", () => {
+    it("does localize redirects to internal paths", () => {
+      basePermanentRedirect({
+        pathname: "/test/path",
+        locale: "en",
+        localePrefix: "as-needed",
+      });
+      expect(nextPermanentRedirect).toHaveBeenCalledTimes(1);
+      expect(nextPermanentRedirect).toHaveBeenCalledWith("/en/test/path");
+    });
+
+    it("does not localize redirects to external paths", () => {
+      basePermanentRedirect({
+        pathname: "https://example.com",
+        locale: "en",
+        localePrefix: "as-needed",
+      });
+      expect(nextPermanentRedirect).toHaveBeenCalledTimes(1);
+      expect(nextPermanentRedirect).toHaveBeenCalledWith("https://example.com");
+    });
+  });
+});
+
+describe("localePrefix: 'never'", () => {
+  describe("basePermanentRedirect", () => {
+    it("does localize redirects to internal paths", () => {
+      basePermanentRedirect({
+        pathname: "/test/path",
+        locale: "en",
+        localePrefix: "never",
+      });
+      expect(nextPermanentRedirect).toHaveBeenCalledTimes(1);
+      expect(nextPermanentRedirect).toHaveBeenCalledWith("/test/path");
+    });
+
+    it("does not localize redirects to external paths", () => {
+      basePermanentRedirect({
+        pathname: "https://example.com",
+        locale: "en",
+        localePrefix: "never",
+      });
+      expect(nextPermanentRedirect).toHaveBeenCalledTimes(1);
+      expect(nextPermanentRedirect).toHaveBeenCalledWith("https://example.com");
+    });
+  });
+});

--- a/packages/next-intl/test/navigation/shared/baseRedirect.test.tsx
+++ b/packages/next-intl/test/navigation/shared/baseRedirect.test.tsx
@@ -1,0 +1,57 @@
+import { redirect as nextRedirect } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import baseRedirect from "../../../src/navigation/shared/baseRedirect";
+
+vi.mock("next/navigation");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("localePrefix: 'as-needed'", () => {
+  describe("baseRedirect", () => {
+    it("does localize redirects to internal paths", () => {
+      baseRedirect({
+        pathname: "/test/path",
+        locale: "en",
+        localePrefix: "as-needed",
+      });
+      expect(nextRedirect).toHaveBeenCalledTimes(1);
+      expect(nextRedirect).toHaveBeenCalledWith("/en/test/path");
+    });
+
+    it("does not localize redirects to external paths", () => {
+      baseRedirect({
+        pathname: "https://example.com",
+        locale: "en",
+        localePrefix: "as-needed",
+      });
+      expect(nextRedirect).toHaveBeenCalledTimes(1);
+      expect(nextRedirect).toHaveBeenCalledWith("https://example.com");
+    });
+  });
+});
+
+describe("localePrefix: 'never'", () => {
+  describe("baseRedirect", () => {
+    it("does localize redirects to internal paths", () => {
+      baseRedirect({
+        pathname: "/test/path",
+        locale: "en",
+        localePrefix: "never",
+      });
+      expect(nextRedirect).toHaveBeenCalledTimes(1);
+      expect(nextRedirect).toHaveBeenCalledWith("/test/path");
+    });
+
+    it("does not localize redirects to external paths", () => {
+      baseRedirect({
+        pathname: "https://example.com",
+        locale: "en",
+        localePrefix: "never",
+      });
+      expect(nextRedirect).toHaveBeenCalledTimes(1);
+      expect(nextRedirect).toHaveBeenCalledWith("https://example.com");
+    });
+  });
+});

--- a/packages/next-intl/test/navigation/shared/baseRedirect.test.tsx
+++ b/packages/next-intl/test/navigation/shared/baseRedirect.test.tsx
@@ -1,57 +1,81 @@
-import { redirect as nextRedirect } from "next/navigation";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import baseRedirect from "../../../src/navigation/shared/baseRedirect";
+import {redirect as nextRedirect} from 'next/navigation';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import baseRedirect from '../../../src/navigation/shared/baseRedirect';
 
-vi.mock("next/navigation");
+vi.mock('next/navigation');
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("localePrefix: 'as-needed'", () => {
-  describe("baseRedirect", () => {
-    it("does localize redirects to internal paths", () => {
+describe("localePrefix: 'always'", () => {
+  describe('basePermanentRedirect', () => {
+    it('handles internal paths', () => {
       baseRedirect({
-        pathname: "/test/path",
-        locale: "en",
-        localePrefix: "as-needed",
+        pathname: '/test/path',
+        locale: 'en',
+        localePrefix: 'always'
       });
       expect(nextRedirect).toHaveBeenCalledTimes(1);
-      expect(nextRedirect).toHaveBeenCalledWith("/en/test/path");
+      expect(nextRedirect).toHaveBeenCalledWith('/en/test/path');
     });
 
-    it("does not localize redirects to external paths", () => {
+    it('handles external paths', () => {
       baseRedirect({
-        pathname: "https://example.com",
-        locale: "en",
-        localePrefix: "as-needed",
+        pathname: 'https://example.com',
+        locale: 'en',
+        localePrefix: 'always'
       });
       expect(nextRedirect).toHaveBeenCalledTimes(1);
-      expect(nextRedirect).toHaveBeenCalledWith("https://example.com");
+      expect(nextRedirect).toHaveBeenCalledWith('https://example.com');
+    });
+  });
+});
+
+describe("localePrefix: 'as-needed'", () => {
+  describe('baseRedirect', () => {
+    it('handles internal paths', () => {
+      baseRedirect({
+        pathname: '/test/path',
+        locale: 'en',
+        localePrefix: 'as-needed'
+      });
+      expect(nextRedirect).toHaveBeenCalledTimes(1);
+      expect(nextRedirect).toHaveBeenCalledWith('/en/test/path');
+    });
+
+    it('handles external paths', () => {
+      baseRedirect({
+        pathname: 'https://example.com',
+        locale: 'en',
+        localePrefix: 'as-needed'
+      });
+      expect(nextRedirect).toHaveBeenCalledTimes(1);
+      expect(nextRedirect).toHaveBeenCalledWith('https://example.com');
     });
   });
 });
 
 describe("localePrefix: 'never'", () => {
-  describe("baseRedirect", () => {
-    it("does localize redirects to internal paths", () => {
+  describe('baseRedirect', () => {
+    it('handles internal paths', () => {
       baseRedirect({
-        pathname: "/test/path",
-        locale: "en",
-        localePrefix: "never",
+        pathname: '/test/path',
+        locale: 'en',
+        localePrefix: 'never'
       });
       expect(nextRedirect).toHaveBeenCalledTimes(1);
-      expect(nextRedirect).toHaveBeenCalledWith("/test/path");
+      expect(nextRedirect).toHaveBeenCalledWith('/test/path');
     });
 
-    it("does not localize redirects to external paths", () => {
+    it('handles external paths', () => {
       baseRedirect({
-        pathname: "https://example.com",
-        locale: "en",
-        localePrefix: "never",
+        pathname: 'https://example.com',
+        locale: 'en',
+        localePrefix: 'never'
       });
       expect(nextRedirect).toHaveBeenCalledTimes(1);
-      expect(nextRedirect).toHaveBeenCalledWith("https://example.com");
+      expect(nextRedirect).toHaveBeenCalledWith('https://example.com');
     });
   });
 });


### PR DESCRIPTION
This PR addresses an issue where absolute URL's used as pathnames in the `redirect` and `permanentRedirect` functions returned from `createSharedPathnamesNavigation` are localized.

**Current behaviour:**

```ts
const { redirect, permanentRedirect } =
  createSharedPathnamesNavigation({
    locales: ['en-GB'],
    localePrefix: 'as-needed',
  })

redirect('https://example.com')
// will result in a redirect to '/en-GBhttps://example.com'

permanentRedirect('https://example.com')
// will result in a redirect to '/en-GBhttps://example.com'
```

**Expected behaviour:**

```ts
const { redirect, permanentRedirect } =
  createSharedPathnamesNavigation({
    locales: ['en-GB'],
    localePrefix: 'as-needed',
  })

redirect('https://example.com')
// will result in a redirect to 'https://example.com'

permanentRedirect('https://example.com')
// will result in a redirect to 'https://example.com'
```

**Proposed solution:**

Include a check whether to localize the given pathname based on the path starting with a `/` in:
- `packages/next-intl/src/navigation/shared/baseRedirect.tsx`
- `packages/next-intl/src/navigation/shared/basePermanentRedirect.tsx`

If there are any questions, feedback, and or further improvements required please let me know 😄 