### PR TITLE
chore: Add prettier config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "bracketSpacing": false,
+  "trailingComma": "none"
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -35,5 +35,6 @@
     "next-sitemap": "^4.0.7",
     "typescript": "^5.2.2"
   },
-  "funding": "https://github.com/amannn/next-intl?sponsor=1"
+  "funding": "https://github.com/amannn/next-intl?sponsor=1",
+  "prettier": "../.prettierrc.json"
 }

--- a/docs/prettier.config.js
+++ b/docs/prettier.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  singleQuote: true,
-  trailingComma: 'none',
-  bracketSpacing: false
-};

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -111,6 +111,7 @@
     "typescript": "^5.2.2",
     "vitest": "^1.0.1"
   },
+  "prettier": "../../.prettierrc.json",
   "size-limit": [
     {
       "path": "dist/production/index.react-client.js",

--- a/packages/use-intl/package.json
+++ b/packages/use-intl/package.json
@@ -87,6 +87,7 @@
     "typescript": "^5.2.2",
     "vitest": "^1.0.1"
   },
+  "prettier": "../../.prettierrc.json",
   "size-limit": [
     {
       "path": "dist/production/index.js",


### PR DESCRIPTION
… for docs and packages. Not for examples for the time being as this would lead to an error when a user clones an example. Publishing a prettier config and referencing it everywhere should be the final solution (see https://github.com/molindo/eslint-config-molindo/issues/99).