### PR TITLE
docs: How to load messages from several files.

### DIFF
--- a/docs/pages/docs/usage/messages.mdx
+++ b/docs/pages/docs/usage/messages.mdx
@@ -178,6 +178,70 @@ If you've previously used human readable sentences for keys, you can theoretical
 
 </Details>
 
+<Details id="messages-other-styles">
+<summary>Can I split messages into several files?</summary>
+When the application is large and you have a lot of texts to translate.
+You can create several files to configure the messages.
+
+First you need to define where you will store the files, for example, in a folder named **messages**.
+
+Suppose you have this file, `/messages/es/auth.json`, with this code.
+
+```json
+{
+  "title": "My title"
+}
+```
+
+Secondly you need to put this code in the file `i18n.ts` to implement the loading of messages from all files.
+
+```ts
+import { notFound } from 'next/navigation';
+import { getRequestConfig } from 'next-intl/server';
+import fs from 'fs'
+
+// Can be imported from a shared config
+const locales = ['en', 'de'];
+
+const loadLocale = async (locale: string) => {
+  if (!fs.existsSync(`${process.cwd()}/messages/${locale}`)) {
+    return {}
+  };
+  const files = fs.readdirSync(`${process.cwd()}/messages/${locale}`);
+  return files.reduce(async (acc, fileName) => {
+    const prev = await acc;
+    return {
+      ...prev,
+      [fileName.replace(/\.[^/.]+$/, "")]: (await import(`@/messages/${locale}/${fileName}`)).default
+    }
+  }, {});
+}
+
+export default getRequestConfig(async ({ locale }) => {
+  // Validate that the incoming `locale` parameter is valid
+  if (!locales.includes(locale as any)) notFound();
+  const messages = await loadLocale(locale);
+  return {
+    messages,
+    timeZone: 'America/Mexico_City',
+  };
+});
+```
+
+To use this message in your page you need to do this.
+
+```ts
+import { useTranslations } from 'next-intl';
+ 
+export default function Index() {
+  const t = useTranslations('Index');
+  return <h1>{t('auth.title')}</h1>;
+}
+```
+
+The first part is the file's name and the second is the key in the file.
+</Details>
+
 ## Rendering ICU messages
 
 `next-intl` uses [ICU message syntax](https://unicode-org.github.io/icu/userguide/format_parse/messages/) that allows you to express language nuances and separates state handling within messages from your app code.


### PR DESCRIPTION
This PR is to add more documentations to explain, how the users can split the messages into several files.

The goal is create the file `i18n.ts` with this code.

```ts
import { notFound } from 'next/navigation';
import { getRequestConfig } from 'next-intl/server';
import fs from 'fs'

// Can be imported from a shared config
const locales = ['en', 'de'];

const loadLocale = async (locale: string) => {
  if (!fs.existsSync(`${process.cwd()}/messages/${locale}`)) {
    return {}
  };
  const files = fs.readdirSync(`${process.cwd()}/messages/${locale}`);
  return files.reduce(async (acc, fileName) => {
    const prev = await acc;
    return {
      ...prev,
      [fileName.replace(/\.[^/.]+$/, "")]: (await import(`@/messages/${locale}/${fileName}`)).default
    }
  }, {});
}

export default getRequestConfig(async ({ locale }) => {
  // Validate that the incoming `locale` parameter is valid
  if (!locales.includes(locale as any)) notFound();
  const messages = await loadLocale(locale);
  return {
    messages,
    timeZone: 'America/Mexico_City',
  };
});
```