### PR TITLE
fix: Update link to Static Rendering across all the docs

### DIFF
--- a/docs/pages/blog/next-intl-3-0.mdx
+++ b/docs/pages/blog/next-intl-3-0.mdx
@@ -97,7 +97,7 @@ If you want to stay on the `as-needed` strategy, you can [configure this option]
 
 With the newly introduced Server Components support comes a temporary workaround for static rendering.
 
-If you call APIs from `next-intl` in Server Components, the page will by default opt into [dynamic rendering](https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering). This is a limitation that we aim to remove in the future, but as a stopgap solution, we've added the [`unstable_setRequestLocale`](/docs/getting-started/app-router#static-rendering) API so that you can keep your pages fully static.
+If you call APIs from `next-intl` in Server Components, the page will by default opt into [dynamic rendering](https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering). This is a limitation that we aim to remove in the future, but as a stopgap solution, we've added the [`unstable_setRequestLocale`](/docs/getting-started/app-router/with-i18n-routing#static-rendering) API so that you can keep your pages fully static.
 
 Note that if you're using `next-intl` exclusively in Client Components, this doesn't apply to your app and static rendering will continue to work as it did before.
 

--- a/docs/pages/docs/environments/error-files.mdx
+++ b/docs/pages/docs/environments/error-files.mdx
@@ -96,7 +96,7 @@ export default getRequestConfig(async ({locale}) => {
 });
 ```
 
-Note that `next-intl` will also call the `notFound` function internally when it tries to resolve a locale for component usage, but can not find one attached to the request (either from the middleware, or manually via [`unstable_setRequestLocale`](https://next-intl-docs.vercel.app/docs/getting-started/app-router#static-rendering)).
+Note that `next-intl` will also call the `notFound` function internally when it tries to resolve a locale for component usage, but can not find one attached to the request (either from the middleware, or manually via [`unstable_setRequestLocale`](https://next-intl-docs.vercel.app/docs/getting-started/app-router/with-i18n-routing#static-rendering)).
 
 ## `error.js`
 

--- a/docs/pages/docs/environments/metadata-route-handlers.mdx
+++ b/docs/pages/docs/environments/metadata-route-handlers.mdx
@@ -32,7 +32,7 @@ export async function generateMetadata({params: {locale}}) {
 <Callout>
   By passing an explicit `locale` to the awaitable functions from `next-intl`,
   you can make the metadata handler eligible for [static
-  rendering](/docs/getting-started/app-router#static-rendering) if you're using
+  rendering](/docs/getting-started/app-router/with-i18n-routing#static-rendering) if you're using
   [i18n routing](/docs/getting-started/app-router).
 </Callout>
 

--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -775,7 +775,7 @@ If you're using the [static export feature from Next.js](https://nextjs.org/docs
 1. There's no default locale that can be used without a prefix (same as [`localePrefix: 'always'`](#locale-prefix-always))
 2. The locale can't be negotiated at runtime (same as [`localeDetection: false`](#locale-detection))
 3. You can't use [pathname localization](#localizing-pathnames)
-4. This requires [static rendering](/docs/getting-started/app-router#static-rendering)
+4. This requires [static rendering](/docs/getting-started/app-router/with-i18n-routing#static-rendering)
 5. You need to add a redirect for the root of the app
 
 ```tsx filename="app/page.tsx"
@@ -810,6 +810,6 @@ To recover from this error, please make sure that:
    1. You're using APIs from `next-intl` (including [the navigation APIs](/docs/routing/navigation)) exclusively within the `[locale]` segment.
    2. Your [middleware matcher](#matcher-config) matches all routes of your application, including dynamic segments with potentially unexpected characters like dots (e.g. `/users/jane.doe`).
    3. If you're using [`localePrefix: 'as-needed'`](#locale-prefix-as-needed), the `locale` segment effectively acts like a catch-all for all unknown routes. You should make sure that the `locale` is [validated](/docs/usage/configuration#i18nts) before it's used by any APIs from `next-intl`.
-   4. To implement static rendering, make sure to [provide a static locale](/docs/getting-started/app-router#static-rendering) to `next-intl` instead of using `force-static`.
+   4. To implement static rendering, make sure to [provide a static locale](/docs/getting-started/app-router/with-i18n-routing#static-rendering) to `next-intl` instead of using `force-static`.
 
 Note that `next-intl` will invoke the `notFound()` function to abort the render if the locale can't be found. You should consider adding [a `not-found` page](/docs/environments/error-files#not-foundjs) due to this.

--- a/docs/pages/docs/usage/configuration.mdx
+++ b/docs/pages/docs/usage/configuration.mdx
@@ -603,7 +603,7 @@ In case you're using i18n routing, changing the locale means changing the pathna
 
 The returned value is resolved based on these priorities:
 
-1. **Server Components**: If you're using [i18n routing](/docs/getting-started/app-router), the returned locale is the one that you've either provided via [`unstable_setRequestLocale`](/docs/getting-started/app-router#static-rendering) or alternatively the one in the `[locale]` segment that was matched by the middleware. If you're not using i18n routing, the returned locale is the one that you've provided via `getRequestConfig`.
+1. **Server Components**: If you're using [i18n routing](/docs/getting-started/app-router), the returned locale is the one that you've either provided via [`unstable_setRequestLocale`](/docs/getting-started/app-router/with-i18n-routing#static-rendering) or alternatively the one in the `[locale]` segment that was matched by the middleware. If you're not using i18n routing, the returned locale is the one that you've provided via `getRequestConfig`.
 2. **Client Components**: A `locale` received from `NextIntlClientProvider` or alternatively `useParams().locale`. Note that `NextIntlClientProvider` automatically inherits the locale if the component is rendered by a Server Component. For all other cases, you can specify the value
    explicitly.
 


### PR DESCRIPTION
I encountered an incorrect anchor link for the Static Rendering Page in the documentation. The current anchor link was pointing to the wrong section, causing confusion and navigation issues.

This pull request updates the anchor link for the Static Rendering Page to point to the correct section. This ensures that users are directed to the intended part of the documentation, improving the overall user experience.