### PR TITLE
Removed unused code from 'Wihout i18n routing documentation'

### DIFF
--- a/docs/pages/docs/getting-started/app-router/without-i18n-routing.mdx
+++ b/docs/pages/docs/getting-started/app-router/without-i18n-routing.mdx
@@ -88,7 +88,6 @@ module.exports = withNextIntl(nextConfig);
 `next-intl` creates a request-scoped configuration object that can be used to provide messages and other options based on the user's locale for usage in Server Components.
 
 ```tsx filename="src/i18n.ts"
-import {NextIntlClientProvider} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 
 export default getRequestConfig(async () => {


### PR DESCRIPTION
The PR removes a line of code from 'Without i18n routing documentation' which is unused in the `src/i18n.ts` file.