### PR TITLE
fix: Support relative pathnames in `redirect`

### DIFF
--- a/packages/next-intl/src/navigation/shared/redirects.tsx
+++ b/packages/next-intl/src/navigation/shared/redirects.tsx
@@ -4,7 +4,11 @@ import {
 } from 'next/navigation';
 import {Locales, LocalePrefixConfigVerbose} from '../../routing/types';
 import {ParametersExceptFirst} from '../../shared/types';
-import {getLocalePrefix, isLocalHref, prefixPathname} from '../../shared/utils';
+import {
+  getLocalePrefix,
+  isLocalizableHref,
+  prefixPathname
+} from '../../shared/utils';
 
 function createRedirectFn(redirectFn: typeof nextRedirect) {
   return function baseRedirect<AppLocales extends Locales>(
@@ -17,7 +21,8 @@ function createRedirectFn(redirectFn: typeof nextRedirect) {
   ) {
     const prefix = getLocalePrefix(params.locale, params.localePrefix);
     const localizedPathname =
-      params.localePrefix.mode === 'never' || !isLocalHref(params.pathname)
+      params.localePrefix.mode === 'never' ||
+      !isLocalizableHref(params.pathname)
         ? params.pathname
         : prefixPathname(prefix, params.pathname);
     return redirectFn(localizedPathname, ...args);

--- a/packages/next-intl/src/shared/utils.tsx
+++ b/packages/next-intl/src/shared/utils.tsx
@@ -5,12 +5,12 @@ import {Locales, LocalePrefixConfigVerbose} from '../routing/types';
 
 type Href = ComponentProps<typeof NextLink>['href'];
 
-export function isRelativeHref(href: Href) {
+function isRelativeHref(href: Href) {
   const pathname = typeof href === 'object' ? href.pathname : href;
   return pathname != null && !pathname.startsWith('/');
 }
 
-export function isLocalHref(href: Href) {
+function isLocalHref(href: Href) {
   if (typeof href === 'object') {
     return href.host == null && href.hostname == null;
   } else {

--- a/packages/next-intl/test/navigation/createSharedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/test/navigation/createSharedPathnamesNavigation.test.tsx
@@ -167,6 +167,12 @@ describe.each([
           expect(nextRedirect).toHaveBeenLastCalledWith('/en');
         });
 
+        it('can redirect to a relative pathname', () => {
+          vi.mocked(useNextPathname).mockImplementation(() => '/en/about');
+          render(<Component href="test" />);
+          expect(nextRedirect).toHaveBeenCalledWith('test');
+        });
+
         it('can redirect for a non-default locale', () => {
           vi.mocked(useParams).mockImplementation(() => ({locale: 'en-gb'}));
           vi.mocked(getRequestLocale).mockImplementation(() => 'en-gb');


### PR DESCRIPTION
Fixes #1177