### PR TITLE
Middleware matcher showed on docs does not work properly

### DIFF
--- a/docs/pages/docs/getting-started/app-router/with-i18n-routing.mdx
+++ b/docs/pages/docs/getting-started/app-router/with-i18n-routing.mdx
@@ -138,8 +138,7 @@ export default createMiddleware({
 });
 
 export const config = {
-  // Match only internationalized pathnames
-  matcher: ['/', '/(de|en)/:path*']
+  matcher: ['/((?!_next).*)'],
 };
 ```
 


### PR DESCRIPTION
I was having trouble finding out why my intl wasnt working. After a lot of research i have found that i just needed to change the matcher.