### PR TITLE
docs: Update mixed routing example with improved compatibility for Server Actions

### DIFF
--- a/examples/example-app-router-mixed-routing/src/middleware.ts
+++ b/examples/example-app-router-mixed-routing/src/middleware.ts
@@ -14,7 +14,9 @@ export default function middleware(request: NextRequest) {
   if (isAppRoute) {
     // Add a hint that we can read in `i18n.ts`
     request.headers.set('x-app-route', 'true');
-    return NextResponse.next({headers: request.headers});
+    return NextResponse.next({request: {
+      headers: request.headers
+    });
   } else {
     return intlMiddleware(request);
   }

--- a/examples/example-app-router-mixed-routing/src/middleware.ts
+++ b/examples/example-app-router-mixed-routing/src/middleware.ts
@@ -14,9 +14,7 @@ export default function middleware(request: NextRequest) {
   if (isAppRoute) {
     // Add a hint that we can read in `i18n.ts`
     request.headers.set('x-app-route', 'true');
-    return NextResponse.next({request: {
-      headers: request.headers
-    });
+    return NextResponse.next({request: {headers: request.headers}});
   } else {
     return intlMiddleware(request);
   }


### PR DESCRIPTION
Passing the request headers as response headers messes with server actions. https://github.com/vercel/next.js/issues/50659 

We need to pass the updated request headers to the NextResponse's request object.