### PR TITLE
fix: Apply `useMemo` for `useRouter` returned from `createLocalizedPathnamesNavigation` to keep a stable reference when possible

### DIFF
--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -128,7 +128,7 @@
     },
     {
       "path": "dist/production/navigation.react-client.js",
-      "limit": "3.465 KB"
+      "limit": "3.475 KB"
     },
     {
       "path": "dist/production/navigation.react-server.js",

--- a/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.test.tsx
@@ -4,7 +4,7 @@ import {
   useParams,
   useRouter as useNextRouter
 } from 'next/navigation';
-import React, {ComponentProps} from 'react';
+import React, {ComponentProps, useRef} from 'react';
 import {it, describe, vi, beforeEach, expect, Mock, afterEach} from 'vitest';
 import {Pathnames} from '../../routing';
 import createLocalizedPathnamesNavigation from './createLocalizedPathnamesNavigation';
@@ -229,6 +229,19 @@ describe("localePrefix: 'as-needed'", () => {
   });
 
   describe('useRouter', () => {
+    it('keeps a stable identity when possible', () => {
+      function Component() {
+        const router = useRouter();
+        const initialRouter = useRef(router);
+        return String(router === initialRouter.current);
+      }
+      const {rerender} = render(<Component />);
+      screen.getByText('true');
+
+      rerender(<Component />);
+      screen.getByText('true');
+    });
+
     describe('push', () => {
       it('resolves to the correct path when passing another locale', () => {
         function Component() {


### PR DESCRIPTION
Fix #1198