### PR TITLE
fix: Fix open redirect vulnerability for `localePrefix: 'as-necessary'` by sanitizing pathname in the middleware

### DIFF
--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -144,7 +144,7 @@
     },
     {
       "path": "dist/production/middleware.js",
-      "limit": "6.485 KB"
+      "limit": "6.525 KB"
     },
     {
       "path": "dist/production/routing.js",

--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -187,6 +187,28 @@ describe('prefix-based routing', () => {
       );
     });
 
+    it('redirects requests for the default locale when prefixed at the root with encoded backslashes', () => {
+      middleware(createMockRequest('/en/%5Cexample.org'));
+      middleware(createMockRequest('/en/%5cexample.org'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/%5Cexample.org'
+      );
+      expect(MockedNextResponse.redirect.mock.calls[1][0].toString()).toBe(
+        'http://localhost:3000/%5Cexample.org'
+      );
+    });
+
+    it('redirects requests for the default locale when prefixed at the root with excess slashes', () => {
+      middleware(createMockRequest('/en///example.org'));
+      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+        'http://localhost:3000/example.org'
+      );
+    });
+
     it('redirects requests for the default locale when prefixed at sub paths', () => {
       middleware(createMockRequest('/en/about'));
       expect(MockedNextResponse.next).not.toHaveBeenCalled();

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -292,3 +292,10 @@ export function getLocaleAsPrefix<AppLocales extends Locales>(
 ) {
   return `/${locale}`;
 }
+
+export function sanitizePathname(pathname: string) {
+  // Sanitize malicious URIs, e.g.:
+  // '/en/\\example.org → /en/%5C%5Cexample.org'
+  // '/en////example.org → /en/example.org'
+  return pathname.replace(/\\/g, '%5C').replace(/\/+/g, '/');
+}


### PR DESCRIPTION
Fixes #1207 (see issue for details)
