### PR TITLE
docs: Fixed case of variable in example doc

### DIFF
--- a/docs/pages/docs/environments/actions-metadata-route-handlers.mdx
+++ b/docs/pages/docs/environments/actions-metadata-route-handlers.mdx
@@ -211,7 +211,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     locale: (typeof locales)[number]
   ) {
     const pathname = getPathname({locale, href: key});
-    return `${HOST}/${locale}${pathname === '/' ? '' : pathname}`;
+    return `${host}/${locale}${pathname === '/' ? '' : pathname}`;
   }
 
   return keys.map((key) => ({


### PR DESCRIPTION
Fixed case of 'host' variable in example on 'Server Actions, Metadata & Route Handlers' page.
Once the variable was written in uppercase, once in lowercase. I changed the uppercase variant to lowercase, since that is how the 'host' variable in another example is spelled.