### PR TITLE
feat: Set `secure` flag for `NEXT_LOCALE` cookie (ON HOLD)

### DIFF
--- a/packages/next-intl/src/middleware/syncCookie.tsx
+++ b/packages/next-intl/src/middleware/syncCookie.tsx
@@ -16,7 +16,8 @@ export default function syncCookie(
     response.cookies.set(COOKIE_LOCALE_NAME, locale, {
       path: request.nextUrl.basePath || undefined,
       sameSite: COOKIE_SAME_SITE,
-      maxAge: COOKIE_MAX_AGE
+      maxAge: COOKIE_MAX_AGE,
+      secure: true
     });
   }
 }


### PR DESCRIPTION
This is a security enhancement and will disallow users to read the `NEXT_LOCALE` cookie if the website is served over HTTP. The only exception is on `localhost`.

See also: [Block access to your cookies on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#block_access_to_your_cookies)

If you'd like to unset this flag, you can [compose the middleware](https://next-intl-docs.vercel.app/docs/routing/middleware#composing-other-middlewares) and modify the cookie accordingly before the response is returned.

Fixes https://github.com/amannn/next-intl/issues/1268