### PR TITLE
docs: Add missing curly bracket

### DIFF
--- a/docs/pages/docs/usage/messages.mdx
+++ b/docs/pages/docs/usage/messages.mdx
@@ -309,7 +309,7 @@ Values are required to be alphanumeric and can contain underscores. All other ch
 Therefore, e.g. when you're mapping a locale to a human readable string, you should map the dash to an underscore first:
 
 ```tsx filename="en.json"
-"label": "{locale, select, en_GB {British English} en_US {American English} other {Unknown}"
+"label": "{locale, select, en_GB {British English} en_US {American English} other {Unknown}}"
 ```
 
 ```tsx


### PR DESCRIPTION
Just copied some example code into my own code and noticed a missing curly bracket there.