### PR TITLE
fix: Print warning for inconsistent i18n setup where no `locale` is read in `getRequestConfig` and also none is returned

### DIFF
--- a/docs/pages/docs/routing/middleware.mdx
+++ b/docs/pages/docs/routing/middleware.mdx
@@ -564,7 +564,7 @@ Note that other [limitations as documented by Next.js](https://nextjs.org/docs/a
 This can happen either because:
 
 1. You're using a setup _with_ [i18n routing](/docs/getting-started/app-router) but the middleware is not set up.
-2. You're using a setup _without_ [i18n routing](/docs/getting-started/app-router) but are reading the `locale` param passed to the function within `getRequestConfig`.
+2. You're using a setup _without_ [i18n routing](/docs/getting-started/app-router) but are reading the `locale` param passed to the function within `getRequestConfig` or you're not returning a `locale`.
 3. The middleware is set up in the wrong file (e.g. you're using the `src` folder, but `middleware.ts` was added in the root folder).
 4. The middleware matcher didn't match a request, but you're using APIs from `next-intl` in server code (e.g. a Server Component, a Server Action, etc.).
 5. You're attempting to implement static rendering via [`force-static`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic).

--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -15,7 +15,7 @@ const config: SizeLimitConfig = [
   },
   {
     path: 'dist/production/navigation.react-server.js',
-    limit: '15.975 KB'
+    limit: '15.845 KB'
   },
   {
     path: 'dist/production/server.react-client.js',
@@ -23,7 +23,7 @@ const config: SizeLimitConfig = [
   },
   {
     path: 'dist/production/server.react-server.js',
-    limit: '13.975 KB'
+    limit: '13.865 KB'
   },
   {
     path: 'dist/production/middleware.js',

--- a/packages/next-intl/src/server/react-server/getConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getConfig.tsx
@@ -42,10 +42,18 @@ async function receiveRuntimeConfigImpl(
     result = await result;
   }
 
-  if (result.locale && hasReadLocale) {
-    console.error(
-      "\nYou've read the `locale` param that was passed to `getRequestConfig` but have also returned one from the function. This is likely an error, please ensure that you're consistently using a setup with or without i18n routing: https://next-intl-docs.vercel.app/docs/getting-started/app-router\n"
-    );
+  if (hasReadLocale) {
+    if (result.locale) {
+      console.error(
+        "\nYou've read the `locale` param that was passed to `getRequestConfig` but have also returned one from the function. This is likely an error, please ensure that you're consistently using a setup with or without i18n routing: https://next-intl-docs.vercel.app/docs/getting-started/app-router\n"
+      );
+    }
+  } else {
+    if (!result.locale) {
+      console.error(
+        "\nYou haven't read the `locale` param that was passed to `getRequestConfig` and also haven't returned one from the function. This is likely an error, please ensure that you're consistently using a setup with or without i18n routing: https://next-intl-docs.vercel.app/docs/getting-started/app-router\n"
+      );
+    }
   }
 
   return {

--- a/packages/next-intl/src/server/react-server/getConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getConfig.tsx
@@ -42,17 +42,19 @@ async function receiveRuntimeConfigImpl(
     result = await result;
   }
 
-  if (hasReadLocale) {
-    if (result.locale) {
-      console.error(
-        "\nYou've read the `locale` param that was passed to `getRequestConfig` but have also returned one from the function. This is likely an error, please ensure that you're consistently using a setup with or without i18n routing: https://next-intl-docs.vercel.app/docs/getting-started/app-router\n"
-      );
-    }
-  } else {
-    if (!result.locale) {
-      console.error(
-        "\nYou haven't read the `locale` param that was passed to `getRequestConfig` and also haven't returned one from the function. This is likely an error, please ensure that you're consistently using a setup with or without i18n routing: https://next-intl-docs.vercel.app/docs/getting-started/app-router\n"
-      );
+  if (process.env.NODE_ENV !== 'production') {
+    if (hasReadLocale) {
+      if (result.locale) {
+        console.error(
+          "\nYou've read the `locale` param that was passed to `getRequestConfig` but have also returned one from the function. This is likely an error, please ensure that you're consistently using a setup with or without i18n routing: https://next-intl-docs.vercel.app/docs/getting-started/app-router\n"
+        );
+      }
+    } else {
+      if (!result.locale) {
+        console.error(
+          "\nYou haven't read the `locale` param that was passed to `getRequestConfig` and also haven't returned one from the function. This is likely an error, please ensure that you're consistently using a setup with or without i18n routing: https://next-intl-docs.vercel.app/docs/getting-started/app-router\n"
+        );
+      }
     }
   }
 


### PR DESCRIPTION
/cc @raphaelbadia