### PR TITLE
fix: Handle overlapping custom locale prefixes correctly

### DIFF
--- a/packages/next-intl/src/middleware/utils.test.tsx
+++ b/packages/next-intl/src/middleware/utils.test.tsx
@@ -3,6 +3,7 @@ import {
   formatPathnameTemplate,
   getInternalTemplate,
   getNormalizedPathname,
+  getPathnameMatch,
   getRouteParams
 } from './utils';
 
@@ -166,5 +167,24 @@ describe('getInternalTemplate', () => {
       'it',
       '/internal/[id]'
     ]);
+  });
+});
+
+describe('getPathnameMatch', () => {
+  it('prioritizes more specific prefixes for overlapping locales', () => {
+    expect(
+      getPathnameMatch('/de/at/test', ['de', 'de-at'], {
+        mode: 'always',
+        prefixes: {
+          'de-at': '/de/at',
+          de: '/de'
+        }
+      })
+    ).toEqual({
+      locale: 'de-at',
+      prefix: '/de/at',
+      exact: true,
+      matchedPrefix: '/de/at'
+    });
   });
 });

--- a/packages/next-intl/src/middleware/utils.test.tsx
+++ b/packages/next-intl/src/middleware/utils.test.tsx
@@ -171,20 +171,34 @@ describe('getInternalTemplate', () => {
 });
 
 describe('getPathnameMatch', () => {
-  it('prioritizes more specific prefixes for overlapping locales', () => {
-    expect(
-      getPathnameMatch('/de/at/test', ['de', 'de-at'], {
-        mode: 'always',
-        prefixes: {
-          'de-at': '/de/at',
-          de: '/de'
-        }
-      })
-    ).toEqual({
+  it('prioritizes more specific custom prefixes for overlapping ones', () => {
+    const locales = ['de', 'de-at', 'de-at-x-test'] as const;
+    const localePrefix = {
+      mode: 'always',
+      prefixes: {
+        de: '/de',
+        'de-at': '/de/at',
+        // Longer locale, shorter prefix
+        'de-at-x-test': '/de/a'
+      }
+    } as const;
+
+    expect(getPathnameMatch('/de/at/test', locales, localePrefix)).toEqual({
       locale: 'de-at',
       prefix: '/de/at',
       exact: true,
       matchedPrefix: '/de/at'
+    });
+  });
+
+  it('does not confuse unrelated parts of the pathname with a locale', () => {
+    expect(
+      getPathnameMatch('/de/ats', ['de', 'de-at'], {mode: 'always'})
+    ).toEqual({
+      locale: 'de',
+      prefix: '/de',
+      exact: true,
+      matchedPrefix: '/de'
     });
   });
 });

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -151,6 +151,9 @@ export function getPathnameMatch<AppLocales extends Locales>(
   | undefined {
   const localePrefixes = getLocalePrefixes(locales, localePrefix);
 
+  // More specific ones first
+  localePrefixes.sort((a, b) => b[1].length - a[1].length);
+
   for (const [locale, prefix] of localePrefixes) {
     let exact, matches;
     if (pathname === prefix || pathname.startsWith(prefix + '/')) {


### PR DESCRIPTION
Consider this config:

```tsx
export const routing = defineRouting({
  locales: ["en-US", "es-US"],
  defaultLocale: "en-US",
  localePrefix: {
    mode: "always",
    prefixes: {
      "es-US": "/us/es",
      "en-US": "/us"
    },
  }
});
```

… a pathname like `/us/es` would previously be incorrectly rewritten to `/en-US/es` internally. With this change, we now prioritize more specific prefixes in order to rewrite this request correctly to `/es-US`.

Fixes #1329 