### PR TITLE
fix: Handle overlapping locale prefixes correctly pt. 2

### DIFF
--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -27,7 +27,7 @@ const config: SizeLimitConfig = [
   },
   {
     path: 'dist/production/middleware.js',
-    limit: '9.595 KB'
+    limit: '9.61 KB'
   },
   {
     path: 'dist/production/routing.js',

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -69,7 +69,8 @@ export default function getAlternateLinksHeaderValue<
 
   const links = getLocalePrefixes(
     routing.locales as AppLocales,
-    routing.localePrefix
+    routing.localePrefix,
+    false
   ).flatMap(([locale, prefix]) => {
     function prefixPathname(pathname: string) {
       if (pathname === '/') {

--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -1589,6 +1589,23 @@ describe('prefix-based routing', () => {
         );
       });
 
+      it('handles overlapping custom prefixes correctly', () => {
+        createMiddleware({
+          locales: ['en-US', 'es-US'],
+          defaultLocale: 'en-US',
+          localePrefix: {
+            mode: 'always',
+            prefixes: {
+              'es-US': '/us/es',
+              'en-US': '/us'
+            }
+          }
+        })(createMockRequest('/us/es'));
+        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+          'http://localhost:3000/es-US'
+        );
+      });
+
       it('serves requests for a prefixed locale at the root', () => {
         middlewareWithPrefixes(createMockRequest('/uk?test'));
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -129,12 +129,20 @@ export function findCaseInsensitiveString(
 
 export function getLocalePrefixes<AppLocales extends Locales>(
   locales: AppLocales,
-  localePrefix: LocalePrefixConfigVerbose<AppLocales>
+  localePrefix: LocalePrefixConfigVerbose<AppLocales>,
+  sort = true
 ): Array<[AppLocales[number], string]> {
-  return locales.map((locale) => [
+  const prefixes = locales.map((locale) => [
     locale as AppLocales[number],
     getLocalePrefix(locale, localePrefix)
   ]);
+
+  if (sort) {
+    // More specific ones first
+    prefixes.sort((a, b) => b[1].length - a[1].length);
+  }
+
+  return prefixes as Array<[AppLocales[number], string]>;
 }
 
 export function getPathnameMatch<AppLocales extends Locales>(
@@ -150,9 +158,6 @@ export function getPathnameMatch<AppLocales extends Locales>(
     }
   | undefined {
   const localePrefixes = getLocalePrefixes(locales, localePrefix);
-
-  // More specific ones first
-  localePrefixes.sort((a, b) => b[1].length - a[1].length);
 
   for (const [locale, prefix] of localePrefixes) {
     let exact, matches;


### PR DESCRIPTION
Follow-up for https://github.com/amannn/next-intl/pull/1343, as the issue was only addressed partially before.

Closes https://github.com/amannn/next-intl/issues/1329