### PR TITLE
feat: add typesafe i18n with next-intl blog link in community blog posts

### DIFF
--- a/docs/pages/blog/index.mdx
+++ b/docs/pages/blog/index.mdx
@@ -29,6 +29,14 @@ Resources on `next-intl` created by and for the community.
 
 <div className="flex flex-col gap-4 py-8">
   <CommunityLink
+    href="https://www.adarsha.dev/blog/next-intl-i18n"
+    title="Typesafe Internationalization (i18n) in Next.js with next-intl"
+    date="September 30, 2024"
+    author="By Adarsha Acharya"
+    target="_blank"
+    type="article"
+  />
+  <CommunityLink
     href="https://crowdin.com/blog/2024/02/19/next-js-internationalization"
     title="Next.js i18n: Going international with next-intl"
     date="Feb 19, 2024"


### PR DESCRIPTION
Added link to blog that includes following:

- Integrate next-intl in Next.js app (App router)
- Use next-intl outside of React components
- Split translations strings into multiple files
- Introduce typesafety in translations
- Use next-intl with server components
