### PR TITLE
docs: update with-i18n-routing.mdx with nextjs 15 `params` change

### DIFF
--- a/docs/pages/docs/getting-started/app-router/with-i18n-routing.mdx
+++ b/docs/pages/docs/getting-started/app-router/with-i18n-routing.mdx
@@ -186,11 +186,12 @@ import {getMessages} from 'next-intl/server';
 
 export default async function LocaleLayout({
   children,
-  params: {locale}
+  params
 }: {
   children: React.ReactNode;
-  params: {locale: string};
+  params: Promise<{locale: string}>;
 }) {
+  const {locale} = await params;
   // Providing all messages to the client
   // side is the easiest way to get started
   const messages = await getMessages();
@@ -286,7 +287,8 @@ export function generateStaticParams() {
 ```tsx filename="app/[locale]/layout.tsx"
 import {unstable_setRequestLocale} from 'next-intl/server';
 
-export default async function LocaleLayout({children, params: {locale}}) {
+export default async function LocaleLayout({children, params}) {
+  const {locale} = await params;
   unstable_setRequestLocale(locale);
 
   return (
@@ -298,7 +300,8 @@ export default async function LocaleLayout({children, params: {locale}}) {
 ```tsx filename="app/[locale]/page.tsx"
 import {unstable_setRequestLocale} from 'next-intl/server';
 
-export default function IndexPage({params: {locale}}) {
+export default function IndexPage({params}) {
+  const {locale} = await params;
   unstable_setRequestLocale(locale);
 
   // Once the request locale is set, you
@@ -359,7 +362,8 @@ To achieve this, you can forward the `locale` that you receive from Next.js via 
 ```tsx filename="page.tsx"
 import {getTranslations} from 'next-intl/server';
 
-export async function generateMetadata({params: {locale}}) {
+export async function generateMetadata({params}) {
+  const {locale} = await params
   const t = await getTranslations({locale, namespace: 'Metadata'});
 
   return {


### PR DESCRIPTION
Update app router with-i18n-routing with a nextjs 15 `params` change. In nextjs 15, the `params` property is a promise. Although direct access is still supported, it is deprecated.

If params is accessed directly, and not awaited then we get the following warning
```
In route /[locale] a param property was accessed directly with `params.locale`. `params` is now a Promise and should be awaited before accessing properties of the underlying params object. In this version of Next.js direct access to param properties is still supported to facilitate migration but in a future version you will be required to await `params`. If this use is inside an async function await it. If this use is inside a synchronous function then convert the function to async or await it from outside this function and pass the result in.
```

For more information see https://github.com/vercel/next.js/pull/68812