### PR TITLE
fix: support like 'enAU' 'en_AU' locales in IntlMessageFormat

### DIFF
--- a/examples/example-app-router/messages/enAU.json
+++ b/examples/example-app-router/messages/enAU.json
@@ -1,0 +1,46 @@
+{
+  "Error": {
+    "description": "<p>We've unfortunately encountered an error.</p><p>You can try to <retry>reload the page</retry> you were visiting.</p>",
+    "title": "Something went wrong!"
+  },
+  "IndexPage": {
+    "description": "This is a basic example that demonstrates the usage of <code>next-intl</code> with the Next.js App Router. Try changing the locale in the top right corner and see how the content changes.",
+    "title": "next-intl example"
+  },
+  "LocaleLayout": {
+    "title": "next-intl example"
+  },
+  "LocaleSwitcher": {
+    "label": "Change language",
+    "locale": "{locale, select, de {🇩🇪 Deutsch} en {🇺🇸 English} other {Unknown}}"
+  },
+  "Manifest": {
+    "name": "next-intl example"
+  },
+  "Navigation": {
+    "home": "Home",
+    "pathnames": "Pathnames"
+  },
+  "NotFoundPage": {
+    "description": "Please double-check the browser address bar or use the navigation to go to a known page.",
+    "title": "Page not found"
+  },
+  "PageLayout": {
+    "links": {
+      "docs": {
+        "description": "Learn more about next-intl in the official docs.",
+        "href": "https://next-intl-docs.vercel.app/",
+        "title": "Docs"
+      },
+      "source": {
+        "description": "Browse the source code of this example on GitHub.",
+        "href": "https://github.com/amannn/next-intl/tree/main/examples/example-app-router",
+        "title": "Source code"
+      }
+    }
+  },
+  "PathnamesPage": {
+    "description": "<p>The pathnames are internationalized too.</p><p>If you're using the default language English, you'll see <code>/en/pathnames</code> in the browser address bar on this page.</p><p>If you change the locale to German, the URL is localized accordingly (<code>/de/pfadnamen</code>).</p>",
+    "title": "Pathnames"
+  }
+}

--- a/examples/example-app-router/messages/en_US.json
+++ b/examples/example-app-router/messages/en_US.json
@@ -1,0 +1,46 @@
+{
+  "Error": {
+    "description": "<p>We've unfortunately encountered an error.</p><p>You can try to <retry>reload the page</retry> you were visiting.</p>",
+    "title": "Something went wrong!"
+  },
+  "IndexPage": {
+    "description": "This is a basic example that demonstrates the usage of <code>next-intl</code> with the Next.js App Router. Try changing the locale in the top right corner and see how the content changes.",
+    "title": "next-intl example"
+  },
+  "LocaleLayout": {
+    "title": "next-intl example"
+  },
+  "LocaleSwitcher": {
+    "label": "Change language",
+    "locale": "{locale, select, de {🇩🇪 Deutsch} en {🇺🇸 English} other {Unknown}}"
+  },
+  "Manifest": {
+    "name": "next-intl example"
+  },
+  "Navigation": {
+    "home": "Home",
+    "pathnames": "Pathnames"
+  },
+  "NotFoundPage": {
+    "description": "Please double-check the browser address bar or use the navigation to go to a known page.",
+    "title": "Page not found"
+  },
+  "PageLayout": {
+    "links": {
+      "docs": {
+        "description": "Learn more about next-intl in the official docs.",
+        "href": "https://next-intl-docs.vercel.app/",
+        "title": "Docs"
+      },
+      "source": {
+        "description": "Browse the source code of this example on GitHub.",
+        "href": "https://github.com/amannn/next-intl/tree/main/examples/example-app-router",
+        "title": "Source code"
+      }
+    }
+  },
+  "PathnamesPage": {
+    "description": "<p>The pathnames are internationalized too.</p><p>If you're using the default language English, you'll see <code>/en/pathnames</code> in the browser address bar on this page.</p><p>If you change the locale to German, the URL is localized accordingly (<code>/de/pfadnamen</code>).</p>",
+    "title": "Pathnames"
+  }
+}

--- a/examples/example-app-router/src/i18n/routing.ts
+++ b/examples/example-app-router/src/i18n/routing.ts
@@ -2,13 +2,15 @@ import {createLocalizedPathnamesNavigation} from 'next-intl/navigation';
 import {defineRouting} from 'next-intl/routing';
 
 export const routing = defineRouting({
-  locales: ['en', 'de'],
+  locales: ['en', 'de', 'enAU', 'en_US'],
   defaultLocale: 'en',
   pathnames: {
     '/': '/',
     '/pathnames': {
       en: '/pathnames',
-      de: '/pfadnamen'
+      de: '/pfadnamen',
+      enAU: '/pathnames',
+      en_US: '/pathnames'
     }
   }
 });

--- a/packages/use-intl/src/core/createBaseTranslator.tsx
+++ b/packages/use-intl/src/core/createBaseTranslator.tsx
@@ -190,6 +190,29 @@ export default function createBaseTranslator<
   });
 }
 
+const localeFormattedMap: Record<string,string> = {}
+function arrayInsert<T>(tArr: T[], index: number, arr: T[]): T[] {
+  const _tArr = [...tArr];
+  const left = _tArr.splice(0, index),
+      right = _tArr;
+    return [...left, ...arr, ...right];
+}
+
+function formatLocale(locale: string) {
+  if (localeFormattedMap[locale]) return localeFormattedMap[locale];
+  let hasUnderline = locale.indexOf('_') !== -1;
+  // If locale is like 'en_US', transform to 'en-US'
+  locale = locale.replaceAll('_', '-');
+  const localeArr = [...locale];
+  const camelCaseSplitPos = localeArr.findIndex(v=>v.toUpperCase() === v);
+  if (!hasUnderline && camelCaseSplitPos !== -1) {
+    // If locale is like 'enUS', transform to 'en-US'
+    locale = arrayInsert(localeArr, camelCaseSplitPos, ['-']).join('');
+    localeFormattedMap[locale] = locale;
+  }
+  return locale;
+}
+
 function createBaseTranslatorImpl<
   Messages extends AbstractIntlMessages,
   NestedKey extends NestedKeyOf<Messages>
@@ -284,7 +307,7 @@ function createBaseTranslatorImpl<
     try {
       messageFormat = formatters.getMessageFormat(
         message,
-        locale,
+        formatLocale(locale),
         convertFormatsToIntlMessageFormat(
           {...globalFormats, ...formats},
           timeZone


### PR DESCRIPTION
If locales params like camel case 'enUS', undline 'en_US', it will throw err when i use dynamic values template, i find that `intl-messageformat` only support kebab-case locale.

Error like this
```txt
IntlError: INVALID_MESSAGE: Incorrect locale information provided
    at getFallbackFromErrorAndNotify (webpack-internal:///(rsc)/../../packages/use-intl/dist/development/createFormatter-DbsypjTl.js:170:23)
    at translateBaseFn (webpack-internal:///(rsc)/../../packages/use-intl/dist/development/createFormatter-DbsypjTl.js:236:20)
    at translateFn (webpack-internal:///(rsc)/../../packages/use-intl/dist/development/createFormatter-DbsypjTl.js:258:24)
```

So i try to fixed it, many repositories have these naming schemes, it very distressed when i using dynamic values template