### PR TITLE
fix: Remove usage of deprecated `ReactNodeArray` which is removed in React 19

### DIFF
--- a/packages/next-intl/src/react-server/getTranslator.tsx
+++ b/packages/next-intl/src/react-server/getTranslator.tsx
@@ -1,4 +1,4 @@
-import {ReactElement, ReactNodeArray, cache} from 'react';
+import {ReactNode, cache} from 'react';
 import {
   Formats,
   MarkupTranslationValues,
@@ -59,7 +59,7 @@ function getTranslatorImpl<
     key: TargetKey,
     values?: RichTranslationValues,
     formats?: Formats
-  ): string | ReactElement | ReactNodeArray;
+  ): ReactNode;
 
   // `markup`
   markup<

--- a/packages/next-intl/src/server/react-server/getTranslations.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslations.tsx
@@ -1,4 +1,4 @@
-import {ReactElement, ReactNodeArray, cache} from 'react';
+import {ReactNode, cache} from 'react';
 import {
   Formats,
   MarkupTranslationValues,
@@ -64,7 +64,7 @@ Promise<{
     key: [TargetKey] extends [never] ? string : TargetKey,
     values?: RichTranslationValues,
     formats?: Formats
-  ): string | ReactElement | ReactNodeArray;
+  ): ReactNode;
 
   // `markup`
   markup<
@@ -171,7 +171,7 @@ Promise<{
     key: TargetKey,
     values?: RichTranslationValues,
     formats?: Formats
-  ): string | ReactElement | ReactNodeArray;
+  ): ReactNode;
 
   // `markup`
   markup<

--- a/packages/use-intl/src/core/createBaseTranslator.tsx
+++ b/packages/use-intl/src/core/createBaseTranslator.tsx
@@ -1,11 +1,5 @@
 import IntlMessageFormat from 'intl-messageformat';
-import {
-  ReactElement,
-  ReactNode,
-  ReactNodeArray,
-  cloneElement,
-  isValidElement
-} from 'react';
+import {ReactNode, cloneElement, isValidElement} from 'react';
 import AbstractIntlMessages from './AbstractIntlMessages';
 import Formats from './Formats';
 import {InitializedIntlConfig} from './IntlConfig';
@@ -225,7 +219,7 @@ function createBaseTranslatorImpl<
     values?: RichTranslationValues,
     /** Provide custom formats for numbers, dates and times. */
     formats?: Formats
-  ): string | ReactElement | ReactNodeArray {
+  ): ReactNode {
     if (hasMessagesError) {
       // We have already warned about this during render
       return getMessageFallback({

--- a/packages/use-intl/src/core/createTranslator.tsx
+++ b/packages/use-intl/src/core/createTranslator.tsx
@@ -1,4 +1,4 @@
-import {ReactElement, ReactNodeArray} from 'react';
+import {ReactNode} from 'react';
 import Formats from './Formats';
 import IntlConfig from './IntlConfig';
 import TranslationValues, {
@@ -86,7 +86,7 @@ export default function createTranslator<
     key: TargetKey,
     values?: RichTranslationValues,
     formats?: Formats
-  ): string | ReactElement | ReactNodeArray;
+  ): ReactNode;
 
   // `markup`
   markup<

--- a/packages/use-intl/src/react/useTranslations.tsx
+++ b/packages/use-intl/src/react/useTranslations.tsx
@@ -1,4 +1,4 @@
-import {ReactElement, ReactNodeArray} from 'react';
+import {ReactNode} from 'react';
 import Formats from '../core/Formats';
 import TranslationValues, {
   MarkupTranslationValues,
@@ -66,7 +66,7 @@ export default function useTranslations<
     key: TargetKey,
     values?: RichTranslationValues,
     formats?: Formats
-  ): string | ReactElement | ReactNodeArray;
+  ): ReactNode;
 
   // `markup`
   markup<


### PR DESCRIPTION
Fixes https://github.com/amannn/next-intl/issues/1440