### PR TITLE
fix: Don't warn when setting `prefetch={true}` on `<Link />`

### DIFF
--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -15,25 +15,25 @@ const config: SizeLimitConfig = [
     name: "import {createSharedPathnamesNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createSharedPathnamesNavigation}',
-    limit: '4.04 KB'
+    limit: '4.045 KB'
   },
   {
     name: "import {createLocalizedPathnamesNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createLocalizedPathnamesNavigation}',
-    limit: '4.04 KB'
+    limit: '4.045 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createNavigation}',
-    limit: '4.045 KB'
+    limit: '4.055 KB'
   },
   {
     name: "import {createSharedPathnamesNavigation} from 'next-intl/navigation' (react-server)",
     path: 'dist/production/navigation.react-server.js',
     import: '{createSharedPathnamesNavigation}',
-    limit: '16.78 KB'
+    limit: '16.795 KB'
   },
   {
     name: "import {createLocalizedPathnamesNavigation} from 'next-intl/navigation' (react-server)",

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -204,6 +204,17 @@ describe.each([
           }}
         />;
       });
+
+      it('does not warn when setting the `prefetch` prop', () => {
+        const consoleSpy = vi.spyOn(console, 'error');
+        const markup = renderToString(
+          <Link href="/about" prefetch>
+            About
+          </Link>
+        );
+        expect(markup).toContain('href="/en/about"');
+        expect(consoleSpy).not.toHaveBeenCalled();
+      });
     });
 
     describe('getPathname', () => {

--- a/packages/next-intl/src/navigation/shared/BaseLink.tsx
+++ b/packages/next-intl/src/navigation/shared/BaseLink.tsx
@@ -38,7 +38,7 @@ function BaseLink(
   ref: ComponentProps<typeof NextLink>['ref']
 ) {
   const curLocale = useLocale();
-  const isChangingLocale = locale !== curLocale;
+  const isChangingLocale = locale != null && locale !== curLocale;
   const linkLocale = locale || curLocale;
   const host = useHost();
 


### PR DESCRIPTION
Fixes #1462