### PR TITLE
feat!: Make package ESM-only, target modern browsers, use modern JSX transform

### DIFF
--- a/examples/example-app-router-mixed-routing/package.json
+++ b/examples/example-app-router-mixed-routing/package.json
@@ -2,7 +2,7 @@
   "name": "example-app-router-mixed-routing",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "lint": "eslint src && tsc && prettier src --check",
     "test": "playwright test",
     "build": "next build",

--- a/examples/example-app-router-playground/src/app/[locale]/client/DelayedServerContent.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/client/DelayedServerContent.tsx
@@ -1,5 +1,5 @@
 import {useNow} from 'next-intl';
-// @ts-expect-error -- Not available in current types
+// @ts-ignore -- Not available in current types
 import {use} from 'react';
 
 export default function DelayedServerContent() {

--- a/examples/example-app-router-playground/src/app/[locale]/client/DelayedServerContent.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/client/DelayedServerContent.tsx
@@ -1,5 +1,4 @@
 import {useNow} from 'next-intl';
-// @ts-ignore -- Not available in current types
 import {use} from 'react';
 
 export default function DelayedServerContent() {

--- a/examples/example-app-router-playground/src/app/[locale]/client/DelayedServerContent.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/client/DelayedServerContent.tsx
@@ -1,4 +1,5 @@
 import {useNow} from 'next-intl';
+// @ts-expect-error -- Not available in current types
 import {use} from 'react';
 
 export default function DelayedServerContent() {

--- a/examples/example-app-router-single-locale/next.config.js
+++ b/examples/example-app-router-single-locale/next.config.js
@@ -1,3 +1,0 @@
-const withNextIntl = require('next-intl/plugin')();
-
-module.exports = withNextIntl();

--- a/examples/example-app-router-single-locale/next.config.mjs
+++ b/examples/example-app-router-single-locale/next.config.mjs
@@ -1,0 +1,8 @@
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin();
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default withNextIntl(nextConfig);

--- a/examples/example-app-router-single-locale/package.json
+++ b/examples/example-app-router-single-locale/package.json
@@ -2,7 +2,7 @@
   "name": "example-app-router-single-locale",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "lint": "eslint src && tsc && prettier src --check",
     "test": "playwright test",
     "build": "next build",

--- a/examples/example-app-router-without-i18n-routing/next.config.js
+++ b/examples/example-app-router-without-i18n-routing/next.config.js
@@ -1,3 +1,0 @@
-const withNextIntl = require('next-intl/plugin')();
-
-module.exports = withNextIntl();

--- a/examples/example-app-router-without-i18n-routing/next.config.mjs
+++ b/examples/example-app-router-without-i18n-routing/next.config.mjs
@@ -1,0 +1,8 @@
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin();
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default withNextIntl(nextConfig);

--- a/examples/example-app-router-without-i18n-routing/package.json
+++ b/examples/example-app-router-without-i18n-routing/package.json
@@ -2,7 +2,7 @@
   "name": "example-app-router-without-i18n-routing",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "lint": "eslint src && tsc && prettier src --check",
     "test": "playwright test",
     "build": "next build",

--- a/examples/example-app-router/next.config.js
+++ b/examples/example-app-router/next.config.js
@@ -1,8 +1,0 @@
-// @ts-check
-
-const withNextIntl = require('next-intl/plugin')();
-
-/** @type {import('next').NextConfig} */
-const config = {};
-
-module.exports = withNextIntl(config);

--- a/examples/example-app-router/next.config.mjs
+++ b/examples/example-app-router/next.config.mjs
@@ -1,0 +1,10 @@
+// @ts-check
+
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin();
+
+/** @type {import('next').NextConfig} */
+const config = {};
+
+export default withNextIntl(config);

--- a/examples/example-app-router/package.json
+++ b/examples/example-app-router/package.json
@@ -2,7 +2,7 @@
   "name": "example-app-router",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "lint": "eslint src && tsc && prettier src --check",
     "test": "pnpm run test:playwright && pnpm run test:jest",
     "test:playwright": "playwright test",

--- a/examples/example-app-router/src/i18n/request.ts
+++ b/examples/example-app-router/src/i18n/request.ts
@@ -12,11 +12,6 @@ export default getRequestConfig(async ({requestLocale}) => {
 
   return {
     locale,
-    messages: (
-      await (locale === 'en'
-        ? // When using Turbopack, this will enable HMR for `en`
-          import('../../messages/en.json')
-        : import(`../../messages/${locale}.json`))
-    ).default
+    messages: (await import(`../../messages/${locale}.json`)).default
   };
 });

--- a/examples/example-pages-router-advanced/config/babel.config.js
+++ b/examples/example-pages-router-advanced/config/babel.config.js
@@ -1,5 +1,0 @@
-// Used by Jest
-
-module.exports = {
-  presets: ['next/babel']
-};

--- a/examples/example-pages-router-advanced/config/jest.json
+++ b/examples/example-pages-router-advanced/config/jest.json
@@ -1,7 +1,0 @@
-{
-  "testEnvironment": "jsdom",
-  "rootDir": "../",
-  "transform": {
-    "\\.tsx$": ["babel-jest", {"configFile": "./config/babel.config.js"}]
-  }
-}

--- a/examples/example-pages-router-advanced/jest.config.js
+++ b/examples/example-pages-router-advanced/jest.config.js
@@ -1,0 +1,9 @@
+/* eslint-env node */
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({dir: './'});
+
+module.exports = createJestConfig({
+  testEnvironment: 'jsdom',
+  rootDir: 'src'
+});

--- a/examples/example-pages-router-advanced/package.json
+++ b/examples/example-pages-router-advanced/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "lint": "eslint src && tsc && prettier src --check",
-    "test": "jest --config config/jest.json",
+    "test": "jest",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/example-use-intl/vite.config.ts
+++ b/examples/example-use-intl/vite.config.ts
@@ -1,11 +1,6 @@
-import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
+import {defineConfig} from 'vite';
 
 export default defineConfig({
-  plugins: [react()],
-
-  // TODO: Remove after use-intl has full ESM support
-  // https://vitejs.dev/guide/dep-pre-bundling#monorepos-and-linked-dependencies
-  optimizeDeps: {include: ['use-intl']},
-  build: {commonjsOptions: {include: [/use-intl/, /node_modules/]}}
+  plugins: [react()]
 });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@lerna-lite/cli": "^3.9.0",
     "@lerna-lite/publish": "^3.9.0",
     "@rollup/plugin-babel": "^6.0.3",
-    "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-replace": "^5.0.7",
     "@rollup/plugin-terser": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -6,19 +6,9 @@
     "publish": "lerna publish"
   },
   "devDependencies": {
-    "@babel/core": "^7.24.7",
-    "@babel/preset-env": "^7.24.7",
-    "@babel/preset-react": "^7.24.7",
-    "@babel/preset-typescript": "^7.24.7",
     "@lerna-lite/cli": "^3.9.0",
     "@lerna-lite/publish": "^3.9.0",
-    "@rollup/plugin-babel": "^6.0.3",
-    "@rollup/plugin-node-resolve": "^15.2.1",
-    "@rollup/plugin-replace": "^5.0.7",
-    "@rollup/plugin-terser": "^0.4.3",
     "conventional-changelog-conventionalcommits": "^7.0.0",
-    "execa": "^9.2.0",
-    "rollup": "^4.18.0",
     "turbo": "^2.2.3"
   },
   "pnpm": {

--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -2,82 +2,52 @@ import type {SizeLimitConfig} from 'size-limit';
 
 const config: SizeLimitConfig = [
   {
-    name: "import * from 'next-intl' (react-client)",
-    path: 'dist/production/index.react-client.js',
+    name: "import * from 'next-intl' (react-client, production)",
+    path: 'dist/esm/production/index.react-client.js',
     limit: '14.125 KB'
   },
   {
-    name: "import * from 'next-intl' (react-server)",
-    path: 'dist/production/index.react-server.js',
-    limit: '14.845 KB'
+    name: "import {NextIntlClientProvider} from 'next-intl' (react-client, production)",
+    import: '{NextIntlClientProvider}',
+    path: 'dist/esm/production/index.react-client.js',
+    limit: '1.55 KB'
   },
   {
-    name: "import {createSharedPathnamesNavigation} from 'next-intl/navigation' (react-client)",
-    path: 'dist/production/navigation.react-client.js',
-    import: '{createSharedPathnamesNavigation}',
+    name: "import * from 'next-intl' (react-server, production)",
+    path: 'dist/esm/production/index.react-server.js',
+    limit: '14.125 KB'
+  },
+  {
+    name: "import {createNavigation} from 'next-intl/navigation' (react-client, production)",
+    path: 'dist/esm/production/navigation.react-client.js',
+    import: '{createNavigation}',
     limit: '4.045 KB'
   },
   {
-    name: "import {createLocalizedPathnamesNavigation} from 'next-intl/navigation' (react-client)",
-    path: 'dist/production/navigation.react-client.js',
-    import: '{createLocalizedPathnamesNavigation}',
+    name: "import {createNavigation} from 'next-intl/navigation' (react-server, production)",
+    path: 'dist/esm/production/navigation.react-server.js',
+    import: '{createNavigation}',
     limit: '4.045 KB'
   },
   {
-    name: "import {createNavigation} from 'next-intl/navigation' (react-client)",
-    path: 'dist/production/navigation.react-client.js',
-    import: '{createNavigation}',
-    limit: '4.055 KB'
-  },
-  {
-    name: "import {createSharedPathnamesNavigation} from 'next-intl/navigation' (react-server)",
-    path: 'dist/production/navigation.react-server.js',
-    import: '{createSharedPathnamesNavigation}',
-    limit: '16.795 KB'
-  },
-  {
-    name: "import {createLocalizedPathnamesNavigation} from 'next-intl/navigation' (react-server)",
-    path: 'dist/production/navigation.react-server.js',
-    import: '{createLocalizedPathnamesNavigation}',
-    limit: '16.785 KB'
-  },
-  {
-    name: "import {createNavigation} from 'next-intl/navigation' (react-server)",
-    path: 'dist/production/navigation.react-server.js',
-    import: '{createNavigation}',
-    limit: '16.8 KB'
-  },
-  {
-    name: "import * from 'next-intl/server' (react-client)",
-    path: 'dist/production/server.react-client.js',
+    name: "import * from 'next-intl/server' (react-client, production)",
+    path: 'dist/esm/production/server.react-client.js',
     limit: '1 KB'
   },
   {
-    name: "import * from 'next-intl/server' (react-server)",
-    path: 'dist/production/server.react-server.js',
+    name: "import * from 'next-intl/server' (react-server, production)",
+    path: 'dist/esm/production/server.react-server.js',
     limit: '14.035 KB'
   },
   {
-    name: "import createMiddleware from 'next-intl/middleware'",
-    path: 'dist/production/middleware.js',
+    name: "import createMiddleware from 'next-intl/middleware' (production)",
+    path: 'dist/esm/production/middleware.js',
     limit: '9.725 KB'
   },
   {
-    name: "import * from 'next-intl/routing'",
-    path: 'dist/production/routing.js',
+    name: "import * from 'next-intl/routing' (production)",
+    path: 'dist/esm/production/routing.js',
     limit: '1 KB'
-  },
-  {
-    name: "import * from 'next-intl' (react-client, ESM)",
-    path: 'dist/esm/index.react-client.js',
-    import: '*',
-    limit: '14.295 kB'
-  },
-  {
-    name: "import {NextIntlProvider} from 'next-intl' (react-client, ESM)",
-    path: 'dist/esm/index.react-client.js',
-    import: '{NextIntlClientProvider}',
-    limit: '1.55 kB'
   }
 ];
 

--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -15,7 +15,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-server, production)",
     path: 'dist/esm/production/index.react-server.js',
-    limit: '14.125 KB'
+    limit: '14.135 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-client, production)",

--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -4,7 +4,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-client, production)",
     path: 'dist/esm/production/index.react-client.js',
-    limit: '13.195 KB'
+    limit: '13.205 KB'
   },
   {
     name: "import {NextIntlClientProvider} from 'next-intl' (react-client, production)",
@@ -15,7 +15,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-server, production)",
     path: 'dist/esm/production/index.react-server.js',
-    limit: '14.135 KB'
+    limit: '14.165 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-client, production)",

--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -4,30 +4,30 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-client, production)",
     path: 'dist/esm/production/index.react-client.js',
-    limit: '14.125 KB'
+    limit: '13.195 KB'
   },
   {
     name: "import {NextIntlClientProvider} from 'next-intl' (react-client, production)",
     import: '{NextIntlClientProvider}',
     path: 'dist/esm/production/index.react-client.js',
-    limit: '1.55 KB'
+    limit: '1.035 KB'
   },
   {
     name: "import * from 'next-intl' (react-server, production)",
     path: 'dist/esm/production/index.react-server.js',
-    limit: '14.135 KB'
+    limit: '14.125 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-client, production)",
     path: 'dist/esm/production/navigation.react-client.js',
     import: '{createNavigation}',
-    limit: '4.045 KB'
+    limit: '2.525 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-server, production)",
     path: 'dist/esm/production/navigation.react-server.js',
     import: '{createNavigation}',
-    limit: '4.045 KB'
+    limit: '3.425 KB'
   },
   {
     name: "import * from 'next-intl/server' (react-client, production)",
@@ -37,12 +37,12 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl/server' (react-server, production)",
     path: 'dist/esm/production/server.react-server.js',
-    limit: '14.035 KB'
+    limit: '13.385 KB'
   },
   {
     name: "import * from 'next-intl/middleware' (production)",
     path: 'dist/esm/production/middleware.js',
-    limit: '9.725 KB'
+    limit: '9.295 KB'
   },
   {
     name: "import * from 'next-intl/routing' (production)",

--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -15,7 +15,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-server, production)",
     path: 'dist/esm/production/index.react-server.js',
-    limit: '14.125 KB'
+    limit: '14.135 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-client, production)",
@@ -40,7 +40,7 @@ const config: SizeLimitConfig = [
     limit: '14.035 KB'
   },
   {
-    name: "import createMiddleware from 'next-intl/middleware' (production)",
+    name: "import * from 'next-intl/middleware' (production)",
     path: 'dist/esm/production/middleware.js',
     limit: '9.725 KB'
   },

--- a/packages/next-intl/config.d.ts
+++ b/packages/next-intl/config.d.ts
@@ -1,3 +1,4 @@
+// Needed for project with `moduleResolution: 'node'`
 import config from './dist/types/src/config';
 
 export = config;

--- a/packages/next-intl/config.d.ts
+++ b/packages/next-intl/config.d.ts
@@ -1,4 +1,4 @@
 // Needed for project with `moduleResolution: 'node'`
-import config from './dist/types/src/config';
+import config from './dist/types/config';
 
 export = config;

--- a/packages/next-intl/config.d.ts
+++ b/packages/next-intl/config.d.ts
@@ -1,4 +1,4 @@
-// Needed for project with `moduleResolution: 'node'`
+// Needed for projects with `moduleResolution: 'node'`
 import config from './dist/types/config';
 
 export = config;

--- a/packages/next-intl/middleware.d.ts
+++ b/packages/next-intl/middleware.d.ts
@@ -1,3 +1,4 @@
+// Needed for project with `moduleResolution: 'node'`
 import createMiddleware from './dist/types/src/middleware';
 
 export = createMiddleware;

--- a/packages/next-intl/middleware.d.ts
+++ b/packages/next-intl/middleware.d.ts
@@ -1,4 +1,4 @@
 // Needed for project with `moduleResolution: 'node'`
-import createMiddleware from './dist/types/src/middleware';
+import createMiddleware from './dist/types/middleware';
 
 export = createMiddleware;

--- a/packages/next-intl/middleware.d.ts
+++ b/packages/next-intl/middleware.d.ts
@@ -1,4 +1,4 @@
-// Needed for project with `moduleResolution: 'node'`
+// Needed for projects with `moduleResolution: 'node'`
 import createMiddleware from './dist/types/middleware';
 
 export = createMiddleware;

--- a/packages/next-intl/navigation.d.ts
+++ b/packages/next-intl/navigation.d.ts
@@ -1,1 +1,2 @@
+// Needed for project with `moduleResolution: 'node'`
 export * from './dist/types/src/navigation.react-client';

--- a/packages/next-intl/navigation.d.ts
+++ b/packages/next-intl/navigation.d.ts
@@ -1,2 +1,2 @@
-// Needed for project with `moduleResolution: 'node'`
+// Needed for projects with `moduleResolution: 'node'`
 export * from './dist/types/navigation.react-client';

--- a/packages/next-intl/navigation.d.ts
+++ b/packages/next-intl/navigation.d.ts
@@ -1,2 +1,2 @@
 // Needed for project with `moduleResolution: 'node'`
-export * from './dist/types/src/navigation.react-client';
+export * from './dist/types/navigation.react-client';

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -76,7 +76,10 @@
     "./plugin": {
       "types": "./dist/types/plugin.d.ts",
       "development": "./dist/esm/development/plugin.js",
-      "require": "./dist/cjs/production/plugin.cjs",
+      "require": {
+        "types": "./plugin.d.cts",
+        "default": "./dist/cjs/development/plugin.cjs"
+      },
       "default": "./dist/esm/production/plugin.js"
     }
   },
@@ -86,6 +89,7 @@
     "navigation.d.ts",
     "middleware.d.ts",
     "plugin.d.ts",
+    "plugin.d.cts",
     "routing.d.ts",
     "config.d.ts"
   ],

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -74,8 +74,11 @@
       "default": "./dist/esm/production/routing.js"
     },
     "./plugin": {
-      "types": "./dist/types/plugin.d.ts",
-      "development": "./dist/esm/development/plugin.js",
+      "import": {
+        "types": "./dist/types/plugin.d.ts",
+        "development": "./dist/esm/development/plugin.js",
+        "default": "./dist/esm/production/plugin.js"
+      },
       "require": {
         "types": "./plugin.d.cts",
         "default": "./dist/cjs/development/plugin.cjs"
@@ -116,7 +119,7 @@
     "react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.15.3",
+    "@arethetypeswrong/cli": "^0.16.4",
     "@edge-runtime/vm": "^3.2.0",
     "@size-limit/preset-small-lib": "^11.1.4",
     "@testing-library/react": "^16.0.0",

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -139,6 +139,7 @@
     "rollup": "^4.18.0",
     "rollup-plugin-preserve-directives": "0.4.0",
     "size-limit": "^11.1.4",
+    "tools": "workspace:^",
     "typescript": "^5.5.3",
     "vitest": "^2.0.2"
   },

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -41,7 +41,7 @@
       "default": "./dist/esm/production/index.react-client.js"
     },
     "./server": {
-      "types": "./dist/types/server.react-client.d.ts",
+      "types": "./dist/types/server.react-server.d.ts",
       "react-server": {
         "development": "./dist/esm/development/server.react-server.js",
         "default": "./dist/esm/production/server.react-server.js"

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -76,6 +76,7 @@
     "./plugin": {
       "types": "./dist/types/plugin.d.ts",
       "development": "./dist/esm/development/plugin.js",
+      "require": "./dist/cjs/production/plugin.cjs",
       "default": "./dist/esm/production/plugin.js"
     }
   },

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -21,46 +21,61 @@
     "test": "TZ=Europe/Berlin vitest",
     "lint": "pnpm run lint:source && pnpm run lint:package",
     "lint:source": "eslint src test && tsc --noEmit && pnpm run lint:prettier",
-    "lint:package": "publint && attw --pack",
+    "lint:package": "publint && attw --pack --ignore-rules=cjs-resolves-to-esm",
     "lint:prettier": "prettier src --check",
     "prepublishOnly": "turbo build && cp ../../README.md .",
     "postpublish": "git checkout . && rm ./README.md",
     "size": "size-limit"
   },
-  "main": "./dist/index.react-client.js",
-  "module": "./dist/esm/index.react-client.js",
-  "typings": "./dist/types/src/index.react-client.d.ts",
+  "type": "module",
+  "main": "./dist/esm/production/index.react-client.js",
+  "typings": "./dist/types/index.react-client.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/types/src/index.react-client.d.ts",
-      "react-server": "./dist/esm/index.react-server.js",
-      "default": "./dist/index.react-client.js"
+      "types": "./dist/types/index.react-client.d.ts",
+      "development": "./dist/esm/development/index.react-client.js",
+      "react-server": {
+        "development": "./dist/esm/development/index.react-server.js",
+        "default": "./dist/esm/production/index.react-server.js"
+      },
+      "default": "./dist/esm/production/index.react-client.js"
     },
     "./server": {
-      "types": "./server.d.ts",
-      "react-server": "./dist/esm/server.react-server.js",
-      "default": "./dist/server.react-client.js"
+      "types": "./dist/types/server.react-client.d.ts",
+      "development": "./dist/esm/development/server.react-client.js",
+      "react-server": {
+        "development": "./dist/esm/development/server.react-server.js",
+        "default": "./dist/esm/production/server.react-server.js"
+      },
+      "default": "./dist/esm/production/server.react-client.js"
     },
     "./config": {
-      "types": "./config.d.ts",
-      "default": "./dist/config.js"
+      "types": "./dist/types/config.d.ts",
+      "development": "./dist/esm/development/config.js",
+      "default": "./dist/esm/production/config.js"
     },
     "./middleware": {
-      "types": "./middleware.d.ts",
-      "default": "./dist/middleware.js"
+      "types": "./dist/types/middleware.d.ts",
+      "development": "./dist/esm/development/middleware.js",
+      "default": "./dist/esm/production/middleware.js"
     },
     "./navigation": {
-      "types": "./navigation.d.ts",
-      "react-server": "./dist/esm/navigation.react-server.js",
-      "default": "./dist/navigation.react-client.js"
+      "types": "./dist/types/navigation.react-client.d.ts",
+      "react-server": {
+        "development": "./dist/esm/development/navigation.react-server.js",
+        "default": "./dist/esm/production/navigation.react-server.js"
+      },
+      "default": "./dist/esm/production/navigation.react-client.js"
     },
     "./routing": {
-      "types": "./routing.d.ts",
-      "default": "./dist/routing.js"
+      "types": "./dist/types/routing.d.ts",
+      "development": "./dist/esm/development/routing.js",
+      "default": "./dist/esm/production/routing.js"
     },
     "./plugin": {
-      "types": "./plugin.d.ts",
-      "default": "./dist/plugin.js"
+      "types": "./dist/types/plugin.d.ts",
+      "development": "./dist/esm/development/plugin.js",
+      "default": "./dist/esm/production/plugin.js"
     }
   },
   "files": [
@@ -91,13 +106,13 @@
     "use-intl": "workspace:^"
   },
   "peerDependencies": {
-    "next": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+    "react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.3",
     "@edge-runtime/vm": "^3.2.0",
-    "@size-limit/preset-big-lib": "^11.1.4",
+    "@size-limit/preset-small-lib": "^11.1.4",
     "@testing-library/react": "^16.0.0",
     "@types/negotiator": "^0.6.3",
     "@types/node": "^20.14.5",

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -33,20 +33,20 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.react-client.d.ts",
-      "development": "./dist/esm/development/index.react-client.js",
       "react-server": {
         "development": "./dist/esm/development/index.react-server.js",
         "default": "./dist/esm/production/index.react-server.js"
       },
+      "development": "./dist/esm/development/index.react-client.js",
       "default": "./dist/esm/production/index.react-client.js"
     },
     "./server": {
       "types": "./dist/types/server.react-client.d.ts",
-      "development": "./dist/esm/development/server.react-client.js",
       "react-server": {
         "development": "./dist/esm/development/server.react-server.js",
         "default": "./dist/esm/production/server.react-server.js"
       },
+      "development": "./dist/esm/development/server.react-client.js",
       "default": "./dist/esm/production/server.react-client.js"
     },
     "./config": {
@@ -65,6 +65,7 @@
         "development": "./dist/esm/development/navigation.react-server.js",
         "default": "./dist/esm/production/navigation.react-server.js"
       },
+      "development": "./dist/esm/development/navigation.react-client.js",
       "default": "./dist/esm/production/navigation.react-client.js"
     },
     "./routing": {

--- a/packages/next-intl/plugin.d.cts
+++ b/packages/next-intl/plugin.d.cts
@@ -1,0 +1,7 @@
+import {NextConfig} from 'next';
+
+function createNextIntlPlugin(
+  i18nPath?: string
+): (config?: NextConfig) => NextConfig;
+
+export = createNextIntlPlugin;

--- a/packages/next-intl/plugin.d.ts
+++ b/packages/next-intl/plugin.d.ts
@@ -1,9 +1,4 @@
 // Needed for project with `moduleResolution: 'node'`
-import {NextConfig} from 'next';
+import plugin from './dist/types/plugin';
 
-function createNextIntlPlugin(
-  i18nPath?: string
-): (config?: NextConfig) => NextConfig;
-
-// Currently only available via CJS
-export = createNextIntlPlugin;
+export = plugin;

--- a/packages/next-intl/plugin.d.ts
+++ b/packages/next-intl/plugin.d.ts
@@ -1,4 +1,4 @@
-// Needed for project with `moduleResolution: 'node'`
+// Needed for projects with `moduleResolution: 'node'`
 import plugin from './dist/types/plugin';
 
 export = plugin;

--- a/packages/next-intl/plugin.d.ts
+++ b/packages/next-intl/plugin.d.ts
@@ -1,3 +1,4 @@
+// Needed for project with `moduleResolution: 'node'`
 import {NextConfig} from 'next';
 
 function createNextIntlPlugin(

--- a/packages/next-intl/rollup.config.js
+++ b/packages/next-intl/rollup.config.js
@@ -37,12 +37,12 @@ export default [
     plugins: [preserveDirectives()]
   }),
   ...getBuildConfig({
-    env: ['production'],
+    env: ['development'],
     input: {
       plugin: 'src/plugin.tsx'
     },
     output: {
-      dir: 'dist/cjs/production',
+      dir: 'dist/cjs/development',
       format: 'cjs',
       entryFileNames: '[name].cjs'
     }

--- a/packages/next-intl/rollup.config.js
+++ b/packages/next-intl/rollup.config.js
@@ -1,8 +1,8 @@
-/* eslint-env node */
 import preserveDirectives from 'rollup-plugin-preserve-directives';
 import getBuildConfig from '../../scripts/getBuildConfig.mjs';
+import pkg from './package.json' with {type: 'json'};
 
-const config = {
+export default getBuildConfig({
   input: {
     'index.react-client': 'src/index.react-client.tsx',
     'index.react-server': 'src/index.react-server.tsx',
@@ -18,7 +18,14 @@ const config = {
     plugin: 'src/plugin.tsx',
     config: 'src/config.tsx'
   },
-  external: ['next-intl/config', /use-intl/],
+  external: [
+    ...Object.keys(pkg.dependencies),
+    ...Object.keys(pkg.peerDependencies),
+    'react/jsx-runtime',
+    'next-intl/config',
+    'use-intl/core',
+    'use-intl/react'
+  ],
   output: {
     preserveModules: true
   },
@@ -27,23 +34,4 @@ const config = {
     warn(warning);
   },
   plugins: [preserveDirectives()]
-};
-
-export default [
-  getBuildConfig({
-    ...config,
-    env: 'development'
-  }),
-  getBuildConfig({
-    ...config,
-    output: {
-      ...config.output,
-      format: 'es'
-    },
-    env: 'esm'
-  }),
-  getBuildConfig({
-    ...config,
-    env: 'production'
-  })
-];
+});

--- a/packages/next-intl/rollup.config.js
+++ b/packages/next-intl/rollup.config.js
@@ -1,5 +1,5 @@
 import preserveDirectives from 'rollup-plugin-preserve-directives';
-import getBuildConfig from '../../scripts/getBuildConfig.mjs';
+import {getBuildConfig} from 'tools';
 import pkg from './package.json' with {type: 'json'};
 
 export default [

--- a/packages/next-intl/rollup.config.js
+++ b/packages/next-intl/rollup.config.js
@@ -2,36 +2,49 @@ import preserveDirectives from 'rollup-plugin-preserve-directives';
 import getBuildConfig from '../../scripts/getBuildConfig.mjs';
 import pkg from './package.json' with {type: 'json'};
 
-export default getBuildConfig({
-  input: {
-    'index.react-client': 'src/index.react-client.tsx',
-    'index.react-server': 'src/index.react-server.tsx',
+export default [
+  ...getBuildConfig({
+    input: {
+      'index.react-client': 'src/index.react-client.tsx',
+      'index.react-server': 'src/index.react-server.tsx',
 
-    'navigation.react-client': 'src/navigation.react-client.tsx',
-    'navigation.react-server': 'src/navigation.react-server.tsx',
+      'navigation.react-client': 'src/navigation.react-client.tsx',
+      'navigation.react-server': 'src/navigation.react-server.tsx',
 
-    'server.react-client': 'src/server.react-client.tsx',
-    'server.react-server': 'src/server.react-server.tsx',
+      'server.react-client': 'src/server.react-client.tsx',
+      'server.react-server': 'src/server.react-server.tsx',
 
-    middleware: 'src/middleware.tsx',
-    routing: 'src/routing.tsx',
-    plugin: 'src/plugin.tsx',
-    config: 'src/config.tsx'
-  },
-  external: [
-    ...Object.keys(pkg.dependencies),
-    ...Object.keys(pkg.peerDependencies),
-    'react/jsx-runtime',
-    'next-intl/config',
-    'use-intl/core',
-    'use-intl/react'
-  ],
-  output: {
-    preserveModules: true
-  },
-  onwarn(warning, warn) {
-    if (warning.code === 'MODULE_LEVEL_DIRECTIVE') return;
-    warn(warning);
-  },
-  plugins: [preserveDirectives()]
-});
+      middleware: 'src/middleware.tsx',
+      routing: 'src/routing.tsx',
+      plugin: 'src/plugin.tsx',
+      config: 'src/config.tsx'
+    },
+    external: [
+      ...Object.keys(pkg.dependencies),
+      ...Object.keys(pkg.peerDependencies),
+      'react/jsx-runtime',
+      'next-intl/config',
+      'use-intl/core',
+      'use-intl/react'
+    ],
+    output: {
+      preserveModules: true
+    },
+    onwarn(warning, warn) {
+      if (warning.code === 'MODULE_LEVEL_DIRECTIVE') return;
+      warn(warning);
+    },
+    plugins: [preserveDirectives()]
+  }),
+  ...getBuildConfig({
+    env: ['production'],
+    input: {
+      plugin: 'src/plugin.tsx'
+    },
+    output: {
+      dir: 'dist/cjs/production',
+      format: 'cjs',
+      entryFileNames: '[name].cjs'
+    }
+  })
+];

--- a/packages/next-intl/routing.d.ts
+++ b/packages/next-intl/routing.d.ts
@@ -1,2 +1,2 @@
-// Needed for project with `moduleResolution: 'node'`
+// Needed for projects with `moduleResolution: 'node'`
 export * from './dist/types/routing';

--- a/packages/next-intl/routing.d.ts
+++ b/packages/next-intl/routing.d.ts
@@ -1,1 +1,2 @@
+// Needed for project with `moduleResolution: 'node'`
 export * from './dist/types/src/routing';

--- a/packages/next-intl/routing.d.ts
+++ b/packages/next-intl/routing.d.ts
@@ -1,2 +1,2 @@
 // Needed for project with `moduleResolution: 'node'`
-export * from './dist/types/src/routing';
+export * from './dist/types/routing';

--- a/packages/next-intl/server.d.ts
+++ b/packages/next-intl/server.d.ts
@@ -1,2 +1,2 @@
-// Needed for project with `moduleResolution: 'node'`
+// Needed for projects with `moduleResolution: 'node'`
 export * from './dist/types/server/react-server';

--- a/packages/next-intl/server.d.ts
+++ b/packages/next-intl/server.d.ts
@@ -1,1 +1,2 @@
+// Needed for project with `moduleResolution: 'node'`
 export * from './dist/types/src/server/react-server';

--- a/packages/next-intl/server.d.ts
+++ b/packages/next-intl/server.d.ts
@@ -1,2 +1,2 @@
 // Needed for project with `moduleResolution: 'node'`
-export * from './dist/types/src/server/react-server';
+export * from './dist/types/server/react-server';

--- a/packages/next-intl/src/index.react-client.tsx
+++ b/packages/next-intl/src/index.react-client.tsx
@@ -6,4 +6,4 @@
  * from `./react-server` instead.
  */
 
-export * from './react-client';
+export * from './react-client/index.tsx';

--- a/packages/next-intl/src/index.react-server.tsx
+++ b/packages/next-intl/src/index.react-server.tsx
@@ -1,1 +1,1 @@
-export * from './react-server';
+export * from './react-server/index.tsx';

--- a/packages/next-intl/src/middleware.tsx
+++ b/packages/next-intl/src/middleware.tsx
@@ -1,1 +1,1 @@
-export {default} from './middleware/index';
+export {default} from './middleware/index.tsx';

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment edge-runtime
 
-import {NextRequest} from 'next/server';
+import {NextRequest} from 'next/server.js';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {receiveRoutingConfig} from '../routing/config.tsx';
 import {Pathnames} from '../routing.tsx';

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -2,9 +2,9 @@
 
 import {NextRequest} from 'next/server';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
-import {Pathnames} from '../routing';
-import {receiveRoutingConfig} from '../routing/config';
-import getAlternateLinksHeaderValue from './getAlternateLinksHeaderValue';
+import {receiveRoutingConfig} from '../routing/config.tsx';
+import {Pathnames} from '../routing.tsx';
+import getAlternateLinksHeaderValue from './getAlternateLinksHeaderValue.tsx';
 
 describe.each([{basePath: undefined}, {basePath: '/base'}])(
   'basePath: $basePath',

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -1,12 +1,12 @@
 import {NextRequest} from 'next/server';
-import {ResolvedRoutingConfig} from '../routing/config';
+import {ResolvedRoutingConfig} from '../routing/config.tsx';
 import {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../routing/types';
-import {normalizeTrailingSlash} from '../shared/utils';
+} from '../routing/types.tsx';
+import {normalizeTrailingSlash} from '../shared/utils.tsx';
 import {
   applyBasePath,
   formatTemplatePathname,
@@ -14,7 +14,7 @@ import {
   getLocalePrefixes,
   getNormalizedPathname,
   isLocaleSupportedOnDomain
-} from './utils';
+} from './utils.tsx';
 
 /**
  * See https://developers.google.com/search/docs/specialty/international/localized-versions

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -1,4 +1,4 @@
-import {NextRequest} from 'next/server';
+import {NextRequest} from 'next/server.js';
 import {ResolvedRoutingConfig} from '../routing/config.tsx';
 import {
   DomainsConfig,

--- a/packages/next-intl/src/middleware/index.tsx
+++ b/packages/next-intl/src/middleware/index.tsx
@@ -2,4 +2,4 @@
  * The middleware, available as `next-intl/middleware`.
  */
 
-export {default} from './middleware';
+export {default} from './middleware.tsx';

--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -4,8 +4,8 @@ import {RequestCookies} from 'next/dist/compiled/@edge-runtime/cookies';
 import {NextRequest, NextResponse} from 'next/server';
 import {pathToRegexp} from 'path-to-regexp';
 import {Mock, afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import createMiddleware from '../middleware';
-import {Pathnames, defineRouting} from '../routing';
+import createMiddleware from '../middleware.tsx';
+import {Pathnames, defineRouting} from '../routing.tsx';
 
 const COOKIE_LOCALE_NAME = 'NEXT_LOCALE';
 

--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment edge-runtime
 
 import {RequestCookies} from 'next/dist/compiled/@edge-runtime/cookies';
-import {NextRequest, NextResponse} from 'next/server';
+import {NextRequest, NextResponse} from 'next/server.js';
 import {pathToRegexp} from 'path-to-regexp';
 import {Mock, afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import createMiddleware from '../middleware.tsx';
@@ -9,7 +9,7 @@ import {Pathnames, defineRouting} from '../routing.tsx';
 
 const COOKIE_LOCALE_NAME = 'NEXT_LOCALE';
 
-vi.mock('next/server', async (importActual) => {
+vi.mock('next/server.js', async (importActual) => {
   const ActualNextServer = (await importActual()) as any;
   type MiddlewareResponseInit = Parameters<(typeof NextResponse)['next']>[0];
 

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -1,4 +1,4 @@
-import {NextRequest, NextResponse} from 'next/server';
+import {NextRequest, NextResponse} from 'next/server.js';
 import {RoutingConfig, receiveRoutingConfig} from '../routing/config.tsx';
 import {
   DomainsConfig,

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -1,20 +1,20 @@
 import {NextRequest, NextResponse} from 'next/server';
-import {RoutingConfig, receiveRoutingConfig} from '../routing/config';
+import {RoutingConfig, receiveRoutingConfig} from '../routing/config.tsx';
 import {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../routing/types';
-import {HEADER_LOCALE_NAME} from '../shared/constants';
+} from '../routing/types.tsx';
+import {HEADER_LOCALE_NAME} from '../shared/constants.tsx';
 import {
   getLocalePrefix,
   matchesPathname,
   normalizeTrailingSlash
-} from '../shared/utils';
-import getAlternateLinksHeaderValue from './getAlternateLinksHeaderValue';
-import resolveLocale from './resolveLocale';
-import syncCookie from './syncCookie';
+} from '../shared/utils.tsx';
+import getAlternateLinksHeaderValue from './getAlternateLinksHeaderValue.tsx';
+import resolveLocale from './resolveLocale.tsx';
+import syncCookie from './syncCookie.tsx';
 import {
   applyBasePath,
   formatPathname,
@@ -26,7 +26,7 @@ import {
   getPathnameMatch,
   isLocaleSupportedOnDomain,
   sanitizePathname
-} from './utils';
+} from './utils.tsx';
 
 export default function createMiddleware<
   AppLocales extends Locales,

--- a/packages/next-intl/src/middleware/resolveLocale.test.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.test.tsx
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {getAcceptLanguageLocale} from './resolveLocale';
+import {getAcceptLanguageLocale} from './resolveLocale.tsx';
 
 describe('getAcceptLanguageLocale', () => {
   it('resolves a more specific locale to a generic one', () => {

--- a/packages/next-intl/src/middleware/resolveLocale.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.tsx
@@ -1,6 +1,6 @@
 import {match} from '@formatjs/intl-localematcher';
 import Negotiator from 'negotiator';
-import {RequestCookies} from 'next/dist/server/web/spec-extension/cookies';
+import {RequestCookies} from 'next/dist/server/web/spec-extension/cookies.js';
 import {ResolvedRoutingConfig} from '../routing/config.tsx';
 import {
   DomainConfig,

--- a/packages/next-intl/src/middleware/resolveLocale.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.tsx
@@ -1,15 +1,19 @@
 import {match} from '@formatjs/intl-localematcher';
 import Negotiator from 'negotiator';
 import {RequestCookies} from 'next/dist/server/web/spec-extension/cookies';
-import {ResolvedRoutingConfig} from '../routing/config';
+import {ResolvedRoutingConfig} from '../routing/config.tsx';
 import {
   DomainConfig,
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../routing/types';
-import {getHost, getPathnameMatch, isLocaleSupportedOnDomain} from './utils';
+} from '../routing/types.tsx';
+import {
+  getHost,
+  getPathnameMatch,
+  isLocaleSupportedOnDomain
+} from './utils.tsx';
 
 function findDomainFromHost<AppLocales extends Locales>(
   requestHeaders: Headers,

--- a/packages/next-intl/src/middleware/syncCookie.tsx
+++ b/packages/next-intl/src/middleware/syncCookie.tsx
@@ -1,4 +1,4 @@
-import {NextRequest, NextResponse} from 'next/server';
+import {NextRequest, NextResponse} from 'next/server.js';
 import {LocaleCookieConfig} from '../routing/config.tsx';
 
 export default function syncCookie(

--- a/packages/next-intl/src/middleware/syncCookie.tsx
+++ b/packages/next-intl/src/middleware/syncCookie.tsx
@@ -1,5 +1,5 @@
 import {NextRequest, NextResponse} from 'next/server';
-import {LocaleCookieConfig} from '../routing/config';
+import {LocaleCookieConfig} from '../routing/config.tsx';
 
 export default function syncCookie(
   request: NextRequest,

--- a/packages/next-intl/src/middleware/utils.test.tsx
+++ b/packages/next-intl/src/middleware/utils.test.tsx
@@ -5,7 +5,7 @@ import {
   getNormalizedPathname,
   getPathnameMatch,
   getRouteParams
-} from './utils';
+} from './utils.tsx';
 
 describe('getNormalizedPathname', () => {
   it('should return the normalized pathname', () => {

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -5,7 +5,7 @@ import {
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../routing/types';
+} from '../routing/types.tsx';
 import {
   getLocalePrefix,
   getSortedPathnames,
@@ -13,7 +13,7 @@ import {
   normalizeTrailingSlash,
   prefixPathname,
   templateToRegex
-} from '../shared/utils';
+} from '../shared/utils.tsx';
 
 export function getFirstPathnameSegment(pathname: string) {
   return pathname.split('/')[1];

--- a/packages/next-intl/src/navigation.react-client.tsx
+++ b/packages/next-intl/src/navigation.react-client.tsx
@@ -1,1 +1,1 @@
-export * from './navigation/react-client/index';
+export * from './navigation/react-client/index.tsx';

--- a/packages/next-intl/src/navigation.react-server.tsx
+++ b/packages/next-intl/src/navigation.react-server.tsx
@@ -1,1 +1,1 @@
-export * from './navigation/react-server';
+export * from './navigation/react-server/index.tsx';

--- a/packages/next-intl/src/navigation/createLocalizedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createLocalizedPathnamesNavigation.test.tsx
@@ -6,7 +6,6 @@ import {
   usePathname as useNextPathname,
   useParams
 } from 'next/navigation';
-import React from 'react';
 import {renderToString} from 'react-dom/server';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {Pathnames, defineRouting} from '../routing.tsx';

--- a/packages/next-intl/src/navigation/createLocalizedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createLocalizedPathnamesNavigation.test.tsx
@@ -5,7 +5,7 @@ import {
   redirect as nextRedirect,
   usePathname as useNextPathname,
   useParams
-} from 'next/navigation';
+} from 'next/navigation.js';
 import {renderToString} from 'react-dom/server';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {Pathnames, defineRouting} from '../routing.tsx';
@@ -15,8 +15,8 @@ import createLocalizedPathnamesNavigationClient from './react-client/createLocal
 import createLocalizedPathnamesNavigationServer from './react-server/createLocalizedPathnamesNavigation.tsx';
 import LegacyBaseLink from './shared/LegacyBaseLink.tsx';
 
-vi.mock('next/navigation', async () => {
-  const actual = await vi.importActual('next/navigation');
+vi.mock('next/navigation.js', async () => {
+  const actual = await vi.importActual('next/navigation.js');
   return {
     ...actual,
     usePathname: vi.fn(),

--- a/packages/next-intl/src/navigation/createLocalizedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createLocalizedPathnamesNavigation.test.tsx
@@ -9,12 +9,12 @@ import {
 import React from 'react';
 import {renderToString} from 'react-dom/server';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {Pathnames, defineRouting} from '../routing';
-import {getRequestLocale} from '../server/react-server/RequestLocaleLegacy';
-import {getLocalePrefix} from '../shared/utils';
-import createLocalizedPathnamesNavigationClient from './react-client/createLocalizedPathnamesNavigation';
-import createLocalizedPathnamesNavigationServer from './react-server/createLocalizedPathnamesNavigation';
-import LegacyBaseLink from './shared/LegacyBaseLink';
+import {Pathnames, defineRouting} from '../routing.tsx';
+import {getRequestLocale} from '../server/react-server/RequestLocaleLegacy.tsx';
+import {getLocalePrefix} from '../shared/utils.tsx';
+import createLocalizedPathnamesNavigationClient from './react-client/createLocalizedPathnamesNavigation.tsx';
+import createLocalizedPathnamesNavigationServer from './react-server/createLocalizedPathnamesNavigation.tsx';
+import LegacyBaseLink from './shared/LegacyBaseLink.tsx';
 
 vi.mock('next/navigation', async () => {
   const actual = await vi.importActual('next/navigation');

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -8,10 +8,10 @@ import {
 import React from 'react';
 import {renderToString} from 'react-dom/server';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {DomainsConfig, Pathnames, defineRouting} from '../routing';
-import createNavigationClient from './react-client/createNavigation';
-import createNavigationServer from './react-server/createNavigation';
-import getServerLocale from './react-server/getServerLocale';
+import {DomainsConfig, Pathnames, defineRouting} from '../routing.tsx';
+import createNavigationClient from './react-client/createNavigation.tsx';
+import createNavigationServer from './react-server/createNavigation.tsx';
+import getServerLocale from './react-server/getServerLocale.tsx';
 
 vi.mock('react');
 vi.mock('next/navigation', async () => {

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -4,7 +4,7 @@ import {
   permanentRedirect as nextPermanentRedirect,
   redirect as nextRedirect,
   useParams as nextUseParams
-} from 'next/navigation';
+} from 'next/navigation.js';
 import {renderToString} from 'react-dom/server';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {DomainsConfig, Pathnames, defineRouting} from '../routing.tsx';
@@ -13,8 +13,8 @@ import createNavigationServer from './react-server/createNavigation.tsx';
 import getServerLocale from './react-server/getServerLocale.tsx';
 
 vi.mock('react');
-vi.mock('next/navigation', async () => {
-  const actual = await vi.importActual('next/navigation');
+vi.mock('next/navigation.js', async () => {
+  const actual = await vi.importActual('next/navigation.js');
   return {
     ...actual,
     useParams: vi.fn(() => ({locale: 'en'})),

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -5,7 +5,6 @@ import {
   redirect as nextRedirect,
   useParams as nextUseParams
 } from 'next/navigation';
-import React from 'react';
 import {renderToString} from 'react-dom/server';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {DomainsConfig, Pathnames, defineRouting} from '../routing.tsx';

--- a/packages/next-intl/src/navigation/createSharedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createSharedPathnamesNavigation.test.tsx
@@ -6,7 +6,6 @@ import {
   usePathname as useNextPathname,
   useParams
 } from 'next/navigation';
-import React from 'react';
 import {renderToString} from 'react-dom/server';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {defineRouting} from '../routing.tsx';

--- a/packages/next-intl/src/navigation/createSharedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createSharedPathnamesNavigation.test.tsx
@@ -5,7 +5,7 @@ import {
   redirect as nextRedirect,
   usePathname as useNextPathname,
   useParams
-} from 'next/navigation';
+} from 'next/navigation.js';
 import {renderToString} from 'react-dom/server';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {defineRouting} from '../routing.tsx';
@@ -15,8 +15,8 @@ import createSharedPathnamesNavigationClient from './react-client/createSharedPa
 import createSharedPathnamesNavigationServer from './react-server/createSharedPathnamesNavigation.tsx';
 import LegacyBaseLink from './shared/LegacyBaseLink.tsx';
 
-vi.mock('next/navigation', async () => {
-  const actual = await vi.importActual('next/navigation');
+vi.mock('next/navigation.js', async () => {
+  const actual = await vi.importActual('next/navigation.js');
   return {
     ...actual,
     useParams: vi.fn(() => ({locale: 'en'})),

--- a/packages/next-intl/src/navigation/createSharedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createSharedPathnamesNavigation.test.tsx
@@ -9,12 +9,12 @@ import {
 import React from 'react';
 import {renderToString} from 'react-dom/server';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {defineRouting} from '../routing';
-import {getRequestLocale} from '../server/react-server/RequestLocaleLegacy';
-import {getLocalePrefix} from '../shared/utils';
-import createSharedPathnamesNavigationClient from './react-client/createSharedPathnamesNavigation';
-import createSharedPathnamesNavigationServer from './react-server/createSharedPathnamesNavigation';
-import LegacyBaseLink from './shared/LegacyBaseLink';
+import {defineRouting} from '../routing.tsx';
+import {getRequestLocale} from '../server/react-server/RequestLocaleLegacy.tsx';
+import {getLocalePrefix} from '../shared/utils.tsx';
+import createSharedPathnamesNavigationClient from './react-client/createSharedPathnamesNavigation.tsx';
+import createSharedPathnamesNavigationServer from './react-server/createSharedPathnamesNavigation.tsx';
+import LegacyBaseLink from './shared/LegacyBaseLink.tsx';
 
 vi.mock('next/navigation', async () => {
   const actual = await vi.importActual('next/navigation');

--- a/packages/next-intl/src/navigation/react-client/ClientLink.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/ClientLink.test.tsx
@@ -1,5 +1,5 @@
 import {fireEvent, render, screen} from '@testing-library/react';
-import {useParams, usePathname} from 'next/navigation';
+import {useParams, usePathname} from 'next/navigation.js';
 import {ComponentProps, LegacyRef, forwardRef} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {NextIntlClientProvider} from '../../index.react-client.tsx';
@@ -9,7 +9,7 @@ import ClientLink from './ClientLink.tsx';
 // Note: Once we remove the legacy navigation APIs, this test suite can be
 // removed too. All relevant tests have been moved to the new navigation API.
 
-vi.mock('next/navigation');
+vi.mock('next/navigation.js');
 
 function mockLocation(pathname: string, basePath = '') {
   vi.mocked(usePathname).mockReturnValue(pathname);

--- a/packages/next-intl/src/navigation/react-client/ClientLink.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/ClientLink.test.tsx
@@ -1,6 +1,6 @@
 import {fireEvent, render, screen} from '@testing-library/react';
 import {useParams, usePathname} from 'next/navigation';
-import React, {ComponentProps, LegacyRef, forwardRef} from 'react';
+import {ComponentProps, LegacyRef, forwardRef} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {NextIntlClientProvider} from '../../index.react-client.tsx';
 import {LocalePrefixConfigVerbose} from '../../routing/types.tsx';

--- a/packages/next-intl/src/navigation/react-client/ClientLink.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/ClientLink.test.tsx
@@ -2,9 +2,9 @@ import {fireEvent, render, screen} from '@testing-library/react';
 import {useParams, usePathname} from 'next/navigation';
 import React, {ComponentProps, LegacyRef, forwardRef} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {NextIntlClientProvider} from '../../index.react-client';
-import {LocalePrefixConfigVerbose} from '../../routing/types';
-import ClientLink from './ClientLink';
+import {NextIntlClientProvider} from '../../index.react-client.tsx';
+import {LocalePrefixConfigVerbose} from '../../routing/types.tsx';
+import ClientLink from './ClientLink.tsx';
 
 // Note: Once we remove the legacy navigation APIs, this test suite can be
 // removed too. All relevant tests have been moved to the new navigation API.

--- a/packages/next-intl/src/navigation/react-client/ClientLink.tsx
+++ b/packages/next-intl/src/navigation/react-client/ClientLink.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps, ReactElement, forwardRef} from 'react';
+import {ComponentProps, ReactElement, forwardRef} from 'react';
 import useLocale from '../../react-client/useLocale.tsx';
 import {
   LocalePrefixConfigVerbose,

--- a/packages/next-intl/src/navigation/react-client/ClientLink.tsx
+++ b/packages/next-intl/src/navigation/react-client/ClientLink.tsx
@@ -1,12 +1,12 @@
 import React, {ComponentProps, ReactElement, forwardRef} from 'react';
-import useLocale from '../../react-client/useLocale';
+import useLocale from '../../react-client/useLocale.tsx';
 import {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,
   Locales
-} from '../../routing/types';
-import {getLocalePrefix} from '../../shared/utils';
-import LegacyBaseLink from '../shared/LegacyBaseLink';
+} from '../../routing/types.tsx';
+import {getLocalePrefix} from '../../shared/utils.tsx';
+import LegacyBaseLink from '../shared/LegacyBaseLink.tsx';
 
 type Props<
   AppLocales extends Locales,

--- a/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.test.tsx
@@ -4,7 +4,7 @@ import {
   useRouter as useNextRouter,
   useParams
 } from 'next/navigation';
-import React, {ComponentProps, useRef} from 'react';
+import {ComponentProps, useRef} from 'react';
 import {Mock, afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {Pathnames} from '../../routing.tsx';
 import createLocalizedPathnamesNavigation from './createLocalizedPathnamesNavigation.tsx';

--- a/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.test.tsx
@@ -6,8 +6,8 @@ import {
 } from 'next/navigation';
 import React, {ComponentProps, useRef} from 'react';
 import {Mock, afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {Pathnames} from '../../routing';
-import createLocalizedPathnamesNavigation from './createLocalizedPathnamesNavigation';
+import {Pathnames} from '../../routing.tsx';
+import createLocalizedPathnamesNavigation from './createLocalizedPathnamesNavigation.tsx';
 
 vi.mock('next/navigation');
 

--- a/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.test.tsx
@@ -3,13 +3,13 @@ import {
   usePathname as useNextPathname,
   useRouter as useNextRouter,
   useParams
-} from 'next/navigation';
-import {ComponentProps, useRef} from 'react';
+} from 'next/navigation.js';
+import {ComponentProps, createRef, useRef} from 'react';
 import {Mock, afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {Pathnames} from '../../routing.tsx';
 import createLocalizedPathnamesNavigation from './createLocalizedPathnamesNavigation.tsx';
 
-vi.mock('next/navigation');
+vi.mock('next/navigation.js');
 
 const locales = ['en', 'de', 'ja'] as const;
 const pathnames = {
@@ -64,7 +64,7 @@ describe("localePrefix: 'as-needed'", () => {
 
   describe('Link', () => {
     it('supports receiving a ref', () => {
-      const ref = React.createRef<HTMLAnchorElement>();
+      const ref = createRef<HTMLAnchorElement>();
       render(<Link ref={ref} href="/about" />);
       expect(ref.current).not.toBe(null);
     });

--- a/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps, ReactElement, forwardRef, useMemo} from 'react';
+import {ComponentProps, ReactElement, forwardRef, useMemo} from 'react';
 import useLocale from '../../react-client/useLocale.tsx';
 import {
   RoutingConfigLocalizedNavigation,

--- a/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.tsx
@@ -1,28 +1,28 @@
 import React, {ComponentProps, ReactElement, forwardRef, useMemo} from 'react';
-import useLocale from '../../react-client/useLocale';
+import useLocale from '../../react-client/useLocale.tsx';
 import {
   RoutingConfigLocalizedNavigation,
   receiveLocaleCookie,
   receiveRoutingConfig
-} from '../../routing/config';
+} from '../../routing/config.tsx';
 import {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../../routing/types';
-import {ParametersExceptFirst} from '../../shared/types';
+} from '../../routing/types.tsx';
+import {ParametersExceptFirst} from '../../shared/types.tsx';
 import {
   HrefOrHrefWithParams,
   HrefOrUrlObjectWithParams,
   compileLocalizedPathname,
   getRoute,
   normalizeNameOrNameWithParams
-} from '../shared/utils';
-import ClientLink from './ClientLink';
-import {clientPermanentRedirect, clientRedirect} from './redirects';
-import useBasePathname from './useBasePathname';
-import useBaseRouter from './useBaseRouter';
+} from '../shared/utils.tsx';
+import ClientLink from './ClientLink.tsx';
+import {clientPermanentRedirect, clientRedirect} from './redirects.tsx';
+import useBasePathname from './useBasePathname.tsx';
+import useBaseRouter from './useBaseRouter.tsx';
 
 /**
  * @deprecated Consider switching to `createNavigation` (see https://next-intl-docs.vercel.app/blog/next-intl-3-22#create-navigation)

--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -228,7 +228,7 @@ describe("localePrefix: 'always'", () => {
         invokeRouter((router) =>
           router.prefetch('/about', {
             locale: 'de',
-            // @ts-expect-error -- Somhow only works via the enum (which is not exported)
+            // @ts-expect-error -- Somehow only works via the enum (which is not exported)
             kind: 'full'
           })
         );
@@ -751,7 +751,7 @@ describe("localePrefix: 'never'", () => {
       invokeRouter((router) =>
         router.prefetch('/about', {
           locale: 'ja',
-          // @ts-expect-error -- Somhow only works via the enum (which is not exported)
+          // @ts-expect-error -- Somehow only works via the enum (which is not exported)
           kind: 'auto'
         })
       );

--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -1,16 +1,15 @@
 import {fireEvent, render, screen} from '@testing-library/react';
-import {PrefetchKind} from 'next/dist/client/components/router-reducer/router-reducer-types';
 import {
   usePathname as useNextPathname,
   useRouter as useNextRouter,
   useParams
-} from 'next/navigation';
+} from 'next/navigation.js';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {NextIntlClientProvider} from '../../react-client.tsx';
+import {NextIntlClientProvider} from '../../index.react-client.tsx';
 import {DomainsConfig, Pathnames} from '../../routing.tsx';
 import createNavigation from './createNavigation.tsx';
 
-vi.mock('next/navigation');
+vi.mock('next/navigation.js');
 
 function mockCurrentLocale(locale: string) {
   vi.mocked(useParams<{locale: string}>).mockImplementation(() => ({
@@ -227,7 +226,11 @@ describe("localePrefix: 'always'", () => {
 
       it('prefixes with a secondary locale', () => {
         invokeRouter((router) =>
-          router.prefetch('/about', {locale: 'de', kind: PrefetchKind.FULL})
+          router.prefetch('/about', {
+            locale: 'de',
+            // @ts-expect-error -- Somhow only works via the enum (which is not exported)
+            kind: 'full'
+          })
         );
         expect(useNextRouter().prefetch).toHaveBeenCalledWith('/de/about', {
           kind: 'full'
@@ -746,7 +749,11 @@ describe("localePrefix: 'never'", () => {
       expect(document.cookie).toContain('NEXT_LOCALE=de');
 
       invokeRouter((router) =>
-        router.prefetch('/about', {locale: 'ja', kind: PrefetchKind.AUTO})
+        router.prefetch('/about', {
+          locale: 'ja',
+          // @ts-expect-error -- Somhow only works via the enum (which is not exported)
+          kind: 'auto'
+        })
       );
       expect(document.cookie).toContain('NEXT_LOCALE=ja');
     });

--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -5,7 +5,6 @@ import {
   useRouter as useNextRouter,
   useParams
 } from 'next/navigation';
-import React from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {NextIntlClientProvider} from '../../react-client.tsx';
 import {DomainsConfig, Pathnames} from '../../routing.tsx';

--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -7,9 +7,9 @@ import {
 } from 'next/navigation';
 import React from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {NextIntlClientProvider} from '../../react-client';
-import {DomainsConfig, Pathnames} from '../../routing';
-import createNavigation from './createNavigation';
+import {NextIntlClientProvider} from '../../react-client.tsx';
+import {DomainsConfig, Pathnames} from '../../routing.tsx';
+import createNavigation from './createNavigation.tsx';
 
 vi.mock('next/navigation');
 

--- a/packages/next-intl/src/navigation/react-client/createNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.tsx
@@ -1,7 +1,7 @@
 import {
   usePathname as useNextPathname,
   useRouter as useNextRouter
-} from 'next/navigation';
+} from 'next/navigation.js';
 import {useMemo} from 'react';
 import useLocale from '../../react-client/useLocale.tsx';
 import {

--- a/packages/next-intl/src/navigation/react-client/createNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.tsx
@@ -3,21 +3,21 @@ import {
   useRouter as useNextRouter
 } from 'next/navigation';
 import {useMemo} from 'react';
-import useLocale from '../../react-client/useLocale';
+import useLocale from '../../react-client/useLocale.tsx';
 import {
   RoutingConfigLocalizedNavigation,
   RoutingConfigSharedNavigation
-} from '../../routing/config';
+} from '../../routing/config.tsx';
 import {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../../routing/types';
-import createSharedNavigationFns from '../shared/createSharedNavigationFns';
-import syncLocaleCookie from '../shared/syncLocaleCookie';
-import {getRoute} from '../shared/utils';
-import useBasePathname from './useBasePathname';
+} from '../../routing/types.tsx';
+import createSharedNavigationFns from '../shared/createSharedNavigationFns.tsx';
+import syncLocaleCookie from '../shared/syncLocaleCookie.tsx';
+import {getRoute} from '../shared/utils.tsx';
+import useBasePathname from './useBasePathname.tsx';
 
 export default function createNavigation<
   const AppLocales extends Locales,

--- a/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.test.tsx
@@ -3,11 +3,12 @@ import {
   usePathname as useNextPathname,
   useRouter as useNextRouter,
   useParams
-} from 'next/navigation';
+} from 'next/navigation.js';
+import {createRef} from 'react';
 import {Mock, beforeEach, describe, expect, it, vi} from 'vitest';
 import createSharedPathnamesNavigation from './createSharedPathnamesNavigation.tsx';
 
-vi.mock('next/navigation');
+vi.mock('next/navigation.js');
 
 const locales = ['en', 'de'] as const;
 
@@ -33,7 +34,7 @@ describe("localePrefix: 'as-needed'", () => {
 
   describe('Link', () => {
     it('supports receiving a ref', () => {
-      const ref = React.createRef<HTMLAnchorElement>();
+      const ref = createRef<HTMLAnchorElement>();
       render(<Link ref={ref} href="/about" />);
       expect(ref.current).not.toBe(null);
     });

--- a/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.test.tsx
@@ -6,7 +6,7 @@ import {
 } from 'next/navigation';
 import React from 'react';
 import {Mock, beforeEach, describe, expect, it, vi} from 'vitest';
-import createSharedPathnamesNavigation from './createSharedPathnamesNavigation';
+import createSharedPathnamesNavigation from './createSharedPathnamesNavigation.tsx';
 
 vi.mock('next/navigation');
 

--- a/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.test.tsx
@@ -4,7 +4,6 @@ import {
   useRouter as useNextRouter,
   useParams
 } from 'next/navigation';
-import React from 'react';
 import {Mock, beforeEach, describe, expect, it, vi} from 'vitest';
 import createSharedPathnamesNavigation from './createSharedPathnamesNavigation.tsx';
 

--- a/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps, ReactElement, forwardRef} from 'react';
+import {ComponentProps, ReactElement, forwardRef} from 'react';
 import {
   RoutingConfigSharedNavigation,
   receiveLocaleCookie,

--- a/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.tsx
@@ -3,13 +3,17 @@ import {
   RoutingConfigSharedNavigation,
   receiveLocaleCookie,
   receiveLocalePrefixConfig
-} from '../../routing/config';
-import {DomainsConfig, LocalePrefixMode, Locales} from '../../routing/types';
-import {ParametersExceptFirst} from '../../shared/types';
-import ClientLink from './ClientLink';
-import {clientPermanentRedirect, clientRedirect} from './redirects';
-import useBasePathname from './useBasePathname';
-import useBaseRouter from './useBaseRouter';
+} from '../../routing/config.tsx';
+import {
+  DomainsConfig,
+  LocalePrefixMode,
+  Locales
+} from '../../routing/types.tsx';
+import {ParametersExceptFirst} from '../../shared/types.tsx';
+import ClientLink from './ClientLink.tsx';
+import {clientPermanentRedirect, clientRedirect} from './redirects.tsx';
+import useBasePathname from './useBasePathname.tsx';
+import useBaseRouter from './useBaseRouter.tsx';
 
 /**
  * @deprecated Consider switching to `createNavigation` (see https://next-intl-docs.vercel.app/blog/next-intl-3-22#create-navigation)

--- a/packages/next-intl/src/navigation/react-client/index.tsx
+++ b/packages/next-intl/src/navigation/react-client/index.tsx
@@ -1,11 +1,11 @@
-export {default as createSharedPathnamesNavigation} from './createSharedPathnamesNavigation';
-export {default as createLocalizedPathnamesNavigation} from './createLocalizedPathnamesNavigation';
-export {default as createNavigation} from './createNavigation';
+export {default as createSharedPathnamesNavigation} from './createSharedPathnamesNavigation.tsx';
+export {default as createLocalizedPathnamesNavigation} from './createLocalizedPathnamesNavigation.tsx';
+export {default as createNavigation} from './createNavigation.tsx';
 
 import type {
   Locales,
   Pathnames as PathnamesDeprecatedExport
-} from '../../routing/types';
+} from '../../routing/types.tsx';
 
 /** @deprecated Please import from `next-intl/routing` instead. */
 export type Pathnames<AppLocales extends Locales> =

--- a/packages/next-intl/src/navigation/react-client/redirects.tsx
+++ b/packages/next-intl/src/navigation/react-client/redirects.tsx
@@ -1,6 +1,6 @@
-import useLocale from '../../react-client/useLocale';
-import {ParametersExceptFirst} from '../../shared/types';
-import {basePermanentRedirect, baseRedirect} from '../shared/redirects';
+import useLocale from '../../react-client/useLocale.tsx';
+import {ParametersExceptFirst} from '../../shared/types.tsx';
+import {basePermanentRedirect, baseRedirect} from '../shared/redirects.tsx';
 
 function createRedirectFn(redirectFn: typeof baseRedirect) {
   return function clientRedirect(

--- a/packages/next-intl/src/navigation/react-client/useBasePathname.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBasePathname.test.tsx
@@ -1,6 +1,5 @@
 import {render, screen} from '@testing-library/react';
 import {usePathname as useNextPathname, useParams} from 'next/navigation';
-import React from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {NextIntlClientProvider} from '../../index.react-client.tsx';
 import useBasePathname from './useBasePathname.tsx';

--- a/packages/next-intl/src/navigation/react-client/useBasePathname.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBasePathname.test.tsx
@@ -2,8 +2,8 @@ import {render, screen} from '@testing-library/react';
 import {usePathname as useNextPathname, useParams} from 'next/navigation';
 import React from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {NextIntlClientProvider} from '../../index.react-client';
-import useBasePathname from './useBasePathname';
+import {NextIntlClientProvider} from '../../index.react-client.tsx';
+import useBasePathname from './useBasePathname.tsx';
 
 vi.mock('next/navigation');
 

--- a/packages/next-intl/src/navigation/react-client/useBasePathname.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBasePathname.test.tsx
@@ -1,10 +1,10 @@
 import {render, screen} from '@testing-library/react';
-import {usePathname as useNextPathname, useParams} from 'next/navigation';
+import {usePathname as useNextPathname, useParams} from 'next/navigation.js';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {NextIntlClientProvider} from '../../index.react-client.tsx';
 import useBasePathname from './useBasePathname.tsx';
 
-vi.mock('next/navigation');
+vi.mock('next/navigation.js');
 
 function mockPathname(pathname: string) {
   vi.mocked(useNextPathname).mockImplementation(() => pathname);

--- a/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
@@ -1,16 +1,16 @@
 import {usePathname as useNextPathname} from 'next/navigation';
 import {useMemo} from 'react';
-import useLocale from '../../react-client/useLocale';
+import useLocale from '../../react-client/useLocale.tsx';
 import {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,
   Locales
-} from '../../routing/types';
+} from '../../routing/types.tsx';
 import {
   getLocalePrefix,
   hasPathnamePrefixed,
   unprefixPathname
-} from '../../shared/utils';
+} from '../../shared/utils.tsx';
 
 export default function useBasePathname<
   AppLocales extends Locales,

--- a/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
@@ -1,4 +1,4 @@
-import {usePathname as useNextPathname} from 'next/navigation';
+import {usePathname as useNextPathname} from 'next/navigation.js';
 import {useMemo} from 'react';
 import useLocale from '../../react-client/useLocale.tsx';
 import {

--- a/packages/next-intl/src/navigation/react-client/useBaseRouter.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBaseRouter.test.tsx
@@ -109,7 +109,7 @@ describe('unprefixed routing', () => {
     callRouter((router) =>
       router.prefetch('/about', {
         locale: 'es',
-        // @ts-expect-error -- Somhow only works via the enum (which is not exported)
+        // @ts-expect-error -- Somehow only works via the enum (which is not exported)
         kind: 'auto'
       })
     );
@@ -133,7 +133,7 @@ describe('unprefixed routing', () => {
     callRouter((router) =>
       router.prefetch('/about', {
         locale: 'it',
-        // @ts-expect-error -- Somhow only works via the enum (which is not exported)
+        // @ts-expect-error -- Somehow only works via the enum (which is not exported)
         kind: 'auto'
       })
     );

--- a/packages/next-intl/src/navigation/react-client/useBaseRouter.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBaseRouter.test.tsx
@@ -1,16 +1,15 @@
 import {render} from '@testing-library/react';
-import {PrefetchKind} from 'next/dist/client/components/router-reducer/router-reducer-types';
-import {AppRouterInstance} from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import {
   usePathname as useNextPathname,
-  useRouter as useNextRouter
-} from 'next/navigation';
+  useRouter as useNextRouter,
+  type useRouter
+} from 'next/navigation.js';
 import {useEffect} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import useBaseRouter from './useBaseRouter.tsx';
 
-vi.mock('next/navigation', () => {
-  const router: AppRouterInstance = {
+vi.mock('next/navigation.js', () => {
+  const router: ReturnType<typeof useRouter> = {
     push: vi.fn(),
     replace: vi.fn(),
     prefetch: vi.fn(),
@@ -108,10 +107,14 @@ describe('unprefixed routing', () => {
 
   it('can prefetch a new locale', () => {
     callRouter((router) =>
-      router.prefetch('/about', {locale: 'es', kind: PrefetchKind.AUTO})
+      router.prefetch('/about', {
+        locale: 'es',
+        // @ts-expect-error -- Somhow only works via the enum (which is not exported)
+        kind: 'auto'
+      })
     );
     expect(useNextRouter().prefetch).toHaveBeenCalledWith('/es/about', {
-      kind: PrefetchKind.AUTO
+      kind: 'auto'
     });
   });
 
@@ -128,7 +131,11 @@ describe('unprefixed routing', () => {
     expect(document.cookie).toContain('NEXT_LOCALE=es');
 
     callRouter((router) =>
-      router.prefetch('/about', {locale: 'it', kind: PrefetchKind.AUTO})
+      router.prefetch('/about', {
+        locale: 'it',
+        // @ts-expect-error -- Somhow only works via the enum (which is not exported)
+        kind: 'auto'
+      })
     );
     expect(document.cookie).toContain('NEXT_LOCALE=it');
   });

--- a/packages/next-intl/src/navigation/react-client/useBaseRouter.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBaseRouter.test.tsx
@@ -7,7 +7,7 @@ import {
 } from 'next/navigation';
 import React, {useEffect} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import useBaseRouter from './useBaseRouter';
+import useBaseRouter from './useBaseRouter.tsx';
 
 vi.mock('next/navigation', () => {
   const router: AppRouterInstance = {

--- a/packages/next-intl/src/navigation/react-client/useBaseRouter.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBaseRouter.test.tsx
@@ -5,7 +5,7 @@ import {
   usePathname as useNextPathname,
   useRouter as useNextRouter
 } from 'next/navigation';
-import React, {useEffect} from 'react';
+import {useEffect} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import useBaseRouter from './useBaseRouter.tsx';
 

--- a/packages/next-intl/src/navigation/react-client/useBaseRouter.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBaseRouter.tsx
@@ -1,15 +1,15 @@
 import {useRouter as useNextRouter, usePathname} from 'next/navigation';
 import {useMemo} from 'react';
-import useLocale from '../../react-client/useLocale';
-import {InitializedLocaleCookieConfig} from '../../routing/config';
+import useLocale from '../../react-client/useLocale.tsx';
+import {InitializedLocaleCookieConfig} from '../../routing/config.tsx';
 import {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,
   Locales
-} from '../../routing/types';
-import {getLocalePrefix, localizeHref} from '../../shared/utils';
-import syncLocaleCookie from '../shared/syncLocaleCookie';
-import {getBasePath} from '../shared/utils';
+} from '../../routing/types.tsx';
+import {getLocalePrefix, localizeHref} from '../../shared/utils.tsx';
+import syncLocaleCookie from '../shared/syncLocaleCookie.tsx';
+import {getBasePath} from '../shared/utils.tsx';
 
 type IntlNavigateOptions<AppLocales extends Locales> = {
   locale?: AppLocales[number];

--- a/packages/next-intl/src/navigation/react-client/useBaseRouter.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBaseRouter.tsx
@@ -1,4 +1,4 @@
-import {useRouter as useNextRouter, usePathname} from 'next/navigation';
+import {useRouter as useNextRouter, usePathname} from 'next/navigation.js';
 import {useMemo} from 'react';
 import useLocale from '../../react-client/useLocale.tsx';
 import {InitializedLocaleCookieConfig} from '../../routing/config.tsx';

--- a/packages/next-intl/src/navigation/react-server/ServerLink.tsx
+++ b/packages/next-intl/src/navigation/react-server/ServerLink.tsx
@@ -3,10 +3,10 @@ import {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,
   Locales
-} from '../../routing/types';
-import {getLocale} from '../../server.react-server';
-import {getLocalePrefix} from '../../shared/utils';
-import LegacyBaseLink from '../shared/LegacyBaseLink';
+} from '../../routing/types.tsx';
+import {getLocale} from '../../server.react-server.tsx';
+import {getLocalePrefix} from '../../shared/utils.tsx';
+import LegacyBaseLink from '../shared/LegacyBaseLink.tsx';
 
 // Only used by legacy navigation APIs, can be removed when they are removed
 

--- a/packages/next-intl/src/navigation/react-server/ServerLink.tsx
+++ b/packages/next-intl/src/navigation/react-server/ServerLink.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps} from 'react';
+import {ComponentProps} from 'react';
 import {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,

--- a/packages/next-intl/src/navigation/react-server/createLocalizedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-server/createLocalizedPathnamesNavigation.tsx
@@ -2,23 +2,23 @@ import React, {ComponentProps} from 'react';
 import {
   RoutingConfigLocalizedNavigation,
   receiveRoutingConfig
-} from '../../routing/config';
+} from '../../routing/config.tsx';
 import {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../../routing/types';
-import {getRequestLocale} from '../../server/react-server/RequestLocaleLegacy';
-import {ParametersExceptFirst} from '../../shared/types';
+} from '../../routing/types.tsx';
+import {getRequestLocale} from '../../server/react-server/RequestLocaleLegacy.tsx';
+import {ParametersExceptFirst} from '../../shared/types.tsx';
 import {
   HrefOrHrefWithParams,
   HrefOrUrlObjectWithParams,
   compileLocalizedPathname,
   normalizeNameOrNameWithParams
-} from '../shared/utils';
-import ServerLink from './ServerLink';
-import {serverPermanentRedirect, serverRedirect} from './redirects';
+} from '../shared/utils.tsx';
+import ServerLink from './ServerLink.tsx';
+import {serverPermanentRedirect, serverRedirect} from './redirects.tsx';
 
 export default function createLocalizedPathnamesNavigation<
   AppLocales extends Locales,

--- a/packages/next-intl/src/navigation/react-server/createLocalizedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-server/createLocalizedPathnamesNavigation.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps} from 'react';
+import {ComponentProps} from 'react';
 import {
   RoutingConfigLocalizedNavigation,
   receiveRoutingConfig

--- a/packages/next-intl/src/navigation/react-server/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-server/createNavigation.test.tsx
@@ -1,5 +1,5 @@
 import {describe, expect, it, vi} from 'vitest';
-import createNavigation from './createNavigation';
+import createNavigation from './createNavigation.tsx';
 
 vi.mock('react');
 

--- a/packages/next-intl/src/navigation/react-server/createNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-server/createNavigation.tsx
@@ -1,15 +1,15 @@
 import {
   RoutingConfigLocalizedNavigation,
   RoutingConfigSharedNavigation
-} from '../../routing/config';
+} from '../../routing/config.tsx';
 import {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../../routing/types';
-import createSharedNavigationFns from '../shared/createSharedNavigationFns';
-import getServerLocale from './getServerLocale';
+} from '../../routing/types.tsx';
+import createSharedNavigationFns from '../shared/createSharedNavigationFns.tsx';
+import getServerLocale from './getServerLocale.tsx';
 
 export default function createNavigation<
   const AppLocales extends Locales,

--- a/packages/next-intl/src/navigation/react-server/createSharedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-server/createSharedPathnamesNavigation.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps} from 'react';
+import {ComponentProps} from 'react';
 import {
   RoutingConfigSharedNavigation,
   receiveLocaleCookie,

--- a/packages/next-intl/src/navigation/react-server/createSharedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-server/createSharedPathnamesNavigation.tsx
@@ -3,11 +3,15 @@ import {
   RoutingConfigSharedNavigation,
   receiveLocaleCookie,
   receiveLocalePrefixConfig
-} from '../../routing/config';
-import {DomainsConfig, LocalePrefixMode, Locales} from '../../routing/types';
-import {ParametersExceptFirst} from '../../shared/types';
-import ServerLink from './ServerLink';
-import {serverPermanentRedirect, serverRedirect} from './redirects';
+} from '../../routing/config.tsx';
+import {
+  DomainsConfig,
+  LocalePrefixMode,
+  Locales
+} from '../../routing/types.tsx';
+import {ParametersExceptFirst} from '../../shared/types.tsx';
+import ServerLink from './ServerLink.tsx';
+import {serverPermanentRedirect, serverRedirect} from './redirects.tsx';
 
 export default function createSharedPathnamesNavigation<
   AppLocales extends Locales,

--- a/packages/next-intl/src/navigation/react-server/getServerLocale.tsx
+++ b/packages/next-intl/src/navigation/react-server/getServerLocale.tsx
@@ -1,4 +1,4 @@
-import getConfig from '../../server/react-server/getConfig';
+import getConfig from '../../server/react-server/getConfig.tsx';
 
 /**
  * This is only moved to a separate module for easier mocking in

--- a/packages/next-intl/src/navigation/react-server/index.tsx
+++ b/packages/next-intl/src/navigation/react-server/index.tsx
@@ -1,4 +1,4 @@
-export {default as createSharedPathnamesNavigation} from './createSharedPathnamesNavigation';
-export {default as createLocalizedPathnamesNavigation} from './createLocalizedPathnamesNavigation';
-export {default as createNavigation} from './createNavigation';
-export type {Pathnames} from '../../routing/types';
+export {default as createSharedPathnamesNavigation} from './createSharedPathnamesNavigation.tsx';
+export {default as createLocalizedPathnamesNavigation} from './createLocalizedPathnamesNavigation.tsx';
+export {default as createNavigation} from './createNavigation.tsx';
+export type {Pathnames} from '../../routing/types.tsx';

--- a/packages/next-intl/src/navigation/react-server/redirects.tsx
+++ b/packages/next-intl/src/navigation/react-server/redirects.tsx
@@ -1,6 +1,6 @@
-import {getRequestLocale} from '../../server/react-server/RequestLocaleLegacy';
-import {ParametersExceptFirst} from '../../shared/types';
-import {basePermanentRedirect, baseRedirect} from '../shared/redirects';
+import {getRequestLocale} from '../../server/react-server/RequestLocaleLegacy.tsx';
+import {ParametersExceptFirst} from '../../shared/types.tsx';
+import {basePermanentRedirect, baseRedirect} from '../shared/redirects.tsx';
 
 function createRedirectFn(redirectFn: typeof baseRedirect) {
   return function serverRedirect(

--- a/packages/next-intl/src/navigation/shared/BaseLink.tsx
+++ b/packages/next-intl/src/navigation/shared/BaseLink.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import NextLink from 'next/link';
-import {usePathname} from 'next/navigation';
+import NextLink, {LinkProps} from 'next/link.js';
+import {usePathname} from 'next/navigation.js';
 import {
   ComponentProps,
   MouseEvent,
+  Ref,
   forwardRef,
   useEffect,
   useState
@@ -13,7 +14,10 @@ import useLocale from '../../react-client/useLocale.tsx';
 import {InitializedLocaleCookieConfig} from '../../routing/config.tsx';
 import syncLocaleCookie from './syncLocaleCookie.tsx';
 
-type Props = Omit<ComponentProps<typeof NextLink>, 'locale'> & {
+type NextLinkProps = Omit<ComponentProps<'a'>, keyof LinkProps> &
+  Omit<LinkProps, 'locale'>;
+
+type Props = NextLinkProps & {
   locale?: string;
   defaultLocale?: string;
   localeCookie: InitializedLocaleCookieConfig;
@@ -35,7 +39,7 @@ function BaseLink(
     unprefixed,
     ...rest
   }: Props,
-  ref: ComponentProps<typeof NextLink>['ref']
+  ref: Ref<HTMLAnchorElement>
 ) {
   const curLocale = useLocale();
   const isChangingLocale = locale != null && locale !== curLocale;
@@ -76,8 +80,12 @@ function BaseLink(
     prefetch = false;
   }
 
+  // Somehow the types for `next/link` don't work as expected
+  // when `moduleResolution: "nodenext"` is used.
+  const Link = NextLink as unknown as (props: NextLinkProps) => JSX.Element;
+
   return (
-    <NextLink
+    <Link
       ref={ref}
       href={finalHref}
       hrefLang={isChangingLocale ? locale : undefined}

--- a/packages/next-intl/src/navigation/shared/BaseLink.tsx
+++ b/packages/next-intl/src/navigation/shared/BaseLink.tsx
@@ -2,7 +2,7 @@
 
 import NextLink from 'next/link';
 import {usePathname} from 'next/navigation';
-import React, {
+import {
   ComponentProps,
   MouseEvent,
   forwardRef,

--- a/packages/next-intl/src/navigation/shared/BaseLink.tsx
+++ b/packages/next-intl/src/navigation/shared/BaseLink.tsx
@@ -9,9 +9,9 @@ import React, {
   useEffect,
   useState
 } from 'react';
-import useLocale from '../../react-client/useLocale';
-import {InitializedLocaleCookieConfig} from '../../routing/config';
-import syncLocaleCookie from './syncLocaleCookie';
+import useLocale from '../../react-client/useLocale.tsx';
+import {InitializedLocaleCookieConfig} from '../../routing/config.tsx';
+import syncLocaleCookie from './syncLocaleCookie.tsx';
 
 type Props = Omit<ComponentProps<typeof NextLink>, 'locale'> & {
   locale?: string;

--- a/packages/next-intl/src/navigation/shared/LegacyBaseLink.tsx
+++ b/packages/next-intl/src/navigation/shared/LegacyBaseLink.tsx
@@ -3,11 +3,15 @@
 import NextLink from 'next/link';
 import {usePathname} from 'next/navigation';
 import React, {ComponentProps, forwardRef, useEffect, useState} from 'react';
-import useLocale from '../../react-client/useLocale';
-import {InitializedLocaleCookieConfig} from '../../routing/config';
-import {LocalePrefixMode} from '../../routing/types';
-import {isLocalizableHref, localizeHref, prefixHref} from '../../shared/utils';
-import BaseLink from './BaseLink';
+import useLocale from '../../react-client/useLocale.tsx';
+import {InitializedLocaleCookieConfig} from '../../routing/config.tsx';
+import {LocalePrefixMode} from '../../routing/types.tsx';
+import {
+  isLocalizableHref,
+  localizeHref,
+  prefixHref
+} from '../../shared/utils.tsx';
+import BaseLink from './BaseLink.tsx';
 
 type Props = Omit<ComponentProps<typeof NextLink>, 'locale'> & {
   locale: string;

--- a/packages/next-intl/src/navigation/shared/LegacyBaseLink.tsx
+++ b/packages/next-intl/src/navigation/shared/LegacyBaseLink.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import NextLink from 'next/link';
-import {usePathname} from 'next/navigation';
+import {usePathname} from 'next/navigation.js';
 import {ComponentProps, forwardRef, useEffect, useState} from 'react';
 import useLocale from '../../react-client/useLocale.tsx';
 import {InitializedLocaleCookieConfig} from '../../routing/config.tsx';
@@ -13,7 +12,10 @@ import {
 } from '../../shared/utils.tsx';
 import BaseLink from './BaseLink.tsx';
 
-type Props = Omit<ComponentProps<typeof NextLink>, 'locale'> & {
+type Props = Omit<
+  ComponentProps<typeof BaseLink>,
+  'locale' | 'unprefixed' | 'defaultLocale'
+> & {
   locale: string;
   prefix: string;
   localePrefixMode: LocalePrefixMode;

--- a/packages/next-intl/src/navigation/shared/LegacyBaseLink.tsx
+++ b/packages/next-intl/src/navigation/shared/LegacyBaseLink.tsx
@@ -2,7 +2,7 @@
 
 import NextLink from 'next/link';
 import {usePathname} from 'next/navigation';
-import React, {ComponentProps, forwardRef, useEffect, useState} from 'react';
+import {ComponentProps, forwardRef, useEffect, useState} from 'react';
 import useLocale from '../../react-client/useLocale.tsx';
 import {InitializedLocaleCookieConfig} from '../../routing/config.tsx';
 import {LocalePrefixMode} from '../../routing/types.tsx';

--- a/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
+++ b/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
@@ -2,7 +2,7 @@ import {
   permanentRedirect as nextPermanentRedirect,
   redirect as nextRedirect
 } from 'next/navigation.js';
-import {ComponentProps, forwardRef, use} from 'react';
+import {ComponentProps, forwardRef} from 'react';
 import {
   RoutingConfigLocalizedNavigation,
   RoutingConfigSharedNavigation,
@@ -16,6 +16,7 @@ import {
   Pathnames
 } from '../../routing/types.tsx';
 import {ParametersExceptFirst, Prettify} from '../../shared/types.tsx';
+import use from '../../shared/use.tsx';
 import {isLocalizableHref} from '../../shared/utils.tsx';
 import BaseLink from './BaseLink.tsx';
 import {
@@ -111,7 +112,7 @@ export default function createSharedNavigationFns<
     const isLocalizable = isLocalizableHref(href);
 
     const localePromiseOrValue = getLocale();
-    const curLocale =
+    const curLocale: AppLocales extends never ? string : AppLocales[number] =
       localePromiseOrValue instanceof Promise
         ? use(localePromiseOrValue)
         : localePromiseOrValue;

--- a/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
+++ b/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
@@ -7,17 +7,17 @@ import {
   RoutingConfigLocalizedNavigation,
   RoutingConfigSharedNavigation,
   receiveRoutingConfig
-} from '../../routing/config';
+} from '../../routing/config.tsx';
 import {
   DomainConfig,
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../../routing/types';
-import {ParametersExceptFirst, Prettify} from '../../shared/types';
-import {isLocalizableHref} from '../../shared/utils';
-import BaseLink from './BaseLink';
+} from '../../routing/types.tsx';
+import {ParametersExceptFirst, Prettify} from '../../shared/types.tsx';
+import {isLocalizableHref} from '../../shared/utils.tsx';
+import BaseLink from './BaseLink.tsx';
 import {
   HrefOrHrefWithParams,
   HrefOrUrlObjectWithParams,
@@ -27,7 +27,7 @@ import {
   normalizeNameOrNameWithParams,
   serializeSearchParams,
   validateReceivedConfig
-} from './utils';
+} from './utils.tsx';
 
 type PromiseOrValue<Type> = Type | Promise<Type>;
 type UnwrapPromiseOrValue<Type> =

--- a/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
+++ b/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
@@ -1,7 +1,7 @@
 import {
   permanentRedirect as nextPermanentRedirect,
   redirect as nextRedirect
-} from 'next/navigation';
+} from 'next/navigation.js';
 import {ComponentProps, forwardRef, use} from 'react';
 import {
   RoutingConfigLocalizedNavigation,

--- a/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
+++ b/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
@@ -2,7 +2,7 @@ import {
   permanentRedirect as nextPermanentRedirect,
   redirect as nextRedirect
 } from 'next/navigation';
-import React, {ComponentProps, forwardRef, use} from 'react';
+import {ComponentProps, forwardRef, use} from 'react';
 import {
   RoutingConfigLocalizedNavigation,
   RoutingConfigSharedNavigation,

--- a/packages/next-intl/src/navigation/shared/redirects.test.tsx
+++ b/packages/next-intl/src/navigation/shared/redirects.test.tsx
@@ -3,7 +3,7 @@ import {
   redirect as nextRedirect
 } from 'next/navigation';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {basePermanentRedirect, baseRedirect} from './redirects';
+import {basePermanentRedirect, baseRedirect} from './redirects.tsx';
 
 vi.mock('next/navigation');
 

--- a/packages/next-intl/src/navigation/shared/redirects.test.tsx
+++ b/packages/next-intl/src/navigation/shared/redirects.test.tsx
@@ -1,11 +1,11 @@
 import {
   permanentRedirect as nextPermanentRedirect,
   redirect as nextRedirect
-} from 'next/navigation';
+} from 'next/navigation.js';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {basePermanentRedirect, baseRedirect} from './redirects.tsx';
 
-vi.mock('next/navigation');
+vi.mock('next/navigation.js');
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/packages/next-intl/src/navigation/shared/redirects.tsx
+++ b/packages/next-intl/src/navigation/shared/redirects.tsx
@@ -1,7 +1,7 @@
 import {
   permanentRedirect as nextPermanentRedirect,
   redirect as nextRedirect
-} from 'next/navigation';
+} from 'next/navigation.js';
 import {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,

--- a/packages/next-intl/src/navigation/shared/redirects.tsx
+++ b/packages/next-intl/src/navigation/shared/redirects.tsx
@@ -6,13 +6,13 @@ import {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,
   Locales
-} from '../../routing/types';
-import {ParametersExceptFirst} from '../../shared/types';
+} from '../../routing/types.tsx';
+import {ParametersExceptFirst} from '../../shared/types.tsx';
 import {
   getLocalePrefix,
   isLocalizableHref,
   prefixPathname
-} from '../../shared/utils';
+} from '../../shared/utils.tsx';
 
 function createRedirectFn(redirectFn: typeof nextRedirect) {
   return function baseRedirect<

--- a/packages/next-intl/src/navigation/shared/syncLocaleCookie.tsx
+++ b/packages/next-intl/src/navigation/shared/syncLocaleCookie.tsx
@@ -1,5 +1,5 @@
-import {InitializedLocaleCookieConfig} from '../../routing/config';
-import {getBasePath} from './utils';
+import {InitializedLocaleCookieConfig} from '../../routing/config.tsx';
+import {getBasePath} from './utils.tsx';
 
 /**
  * We have to keep the cookie value in sync as Next.js might

--- a/packages/next-intl/src/navigation/shared/utils.test.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.test.tsx
@@ -3,7 +3,7 @@ import {
   compileLocalizedPathname,
   getBasePath,
   serializeSearchParams
-} from './utils';
+} from './utils.tsx';
 
 describe('serializeSearchParams', () => {
   it('handles strings', () => {

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -1,12 +1,12 @@
 import type {ParsedUrlQueryInput} from 'node:querystring';
 import type {UrlObject} from 'url';
-import {ResolvedRoutingConfig} from '../../routing/config';
+import {ResolvedRoutingConfig} from '../../routing/config.tsx';
 import {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../../routing/types';
+} from '../../routing/types.tsx';
 import {
   getLocalePrefix,
   getSortedPathnames,
@@ -14,8 +14,8 @@ import {
   matchesPathname,
   normalizeTrailingSlash,
   prefixPathname
-} from '../../shared/utils';
-import StrictParams from './StrictParams';
+} from '../../shared/utils.tsx';
+import StrictParams from './StrictParams.tsx';
 
 type SearchParamValue = ParsedUrlQueryInput[keyof ParsedUrlQueryInput];
 

--- a/packages/next-intl/src/plugin.tsx
+++ b/packages/next-intl/src/plugin.tsx
@@ -132,8 +132,8 @@ function initPlugin(i18nPath?: string, nextConfig?: NextConfig): NextConfig {
   return Object.assign({}, nextConfig, nextIntlConfig);
 }
 
-module.exports = function createNextIntlPlugin(i18nPath?: string) {
+export default function createNextIntlPlugin(i18nPath?: string) {
   return function withNextIntl(nextConfig?: NextConfig) {
     return initPlugin(i18nPath, nextConfig);
   };
-};
+}

--- a/packages/next-intl/src/react-client/index.tsx
+++ b/packages/next-intl/src/react-client/index.tsx
@@ -47,6 +47,6 @@ export const useFormatter = callHook(
 ) as typeof base_useFormatter;
 
 // Replace `useLocale` export from `use-intl`
-export {default as useLocale} from './useLocale';
+export {default as useLocale} from './useLocale.tsx';
 
-export {default as NextIntlClientProvider} from '../shared/NextIntlClientProvider';
+export {default as NextIntlClientProvider} from '../shared/NextIntlClientProvider.tsx';

--- a/packages/next-intl/src/react-client/useFormatter.test.tsx
+++ b/packages/next-intl/src/react-client/useFormatter.test.tsx
@@ -1,7 +1,7 @@
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {expect, it} from 'vitest';
-import {NextIntlClientProvider, useFormatter} from '.';
+import {NextIntlClientProvider, useFormatter} from './index.tsx';
 
 function Component() {
   const format = useFormatter();

--- a/packages/next-intl/src/react-client/useFormatter.test.tsx
+++ b/packages/next-intl/src/react-client/useFormatter.test.tsx
@@ -1,5 +1,4 @@
 import {render, screen} from '@testing-library/react';
-import React from 'react';
 import {expect, it} from 'vitest';
 import {NextIntlClientProvider, useFormatter} from './index.tsx';
 

--- a/packages/next-intl/src/react-client/useLocale.test.tsx
+++ b/packages/next-intl/src/react-client/useLocale.test.tsx
@@ -2,7 +2,7 @@ import {render, screen} from '@testing-library/react';
 import {useParams} from 'next/navigation';
 import React from 'react';
 import {expect, it, vi} from 'vitest';
-import {NextIntlClientProvider, useLocale} from '.';
+import {NextIntlClientProvider, useLocale} from './index.tsx';
 
 vi.mock('next/navigation', () => ({
   useParams: vi.fn(() => ({locale: 'en'}))

--- a/packages/next-intl/src/react-client/useLocale.test.tsx
+++ b/packages/next-intl/src/react-client/useLocale.test.tsx
@@ -1,9 +1,9 @@
 import {render, screen} from '@testing-library/react';
-import {useParams} from 'next/navigation';
+import {useParams} from 'next/navigation.js';
 import {expect, it, vi} from 'vitest';
 import {NextIntlClientProvider, useLocale} from './index.tsx';
 
-vi.mock('next/navigation', () => ({
+vi.mock('next/navigation.js', () => ({
   useParams: vi.fn(() => ({locale: 'en'}))
 }));
 

--- a/packages/next-intl/src/react-client/useLocale.test.tsx
+++ b/packages/next-intl/src/react-client/useLocale.test.tsx
@@ -1,6 +1,5 @@
 import {render, screen} from '@testing-library/react';
 import {useParams} from 'next/navigation';
-import React from 'react';
 import {expect, it, vi} from 'vitest';
 import {NextIntlClientProvider, useLocale} from './index.tsx';
 

--- a/packages/next-intl/src/react-client/useLocale.tsx
+++ b/packages/next-intl/src/react-client/useLocale.tsx
@@ -1,4 +1,4 @@
-import {useParams} from 'next/navigation';
+import {useParams} from 'next/navigation.js';
 import {useLocale as useBaseLocale} from 'use-intl/react';
 import {LOCALE_SEGMENT_NAME} from '../shared/constants.tsx';
 

--- a/packages/next-intl/src/react-client/useLocale.tsx
+++ b/packages/next-intl/src/react-client/useLocale.tsx
@@ -1,7 +1,6 @@
 import {useParams} from 'next/navigation';
-// Workaround for some bundle splitting until we have ESM
-import {useLocale as useBaseLocale} from 'use-intl/_useLocale';
-import {LOCALE_SEGMENT_NAME} from '../shared/constants';
+import {useLocale as useBaseLocale} from 'use-intl/react';
+import {LOCALE_SEGMENT_NAME} from '../shared/constants.tsx';
 
 export default function useLocale(): string {
   // The types aren't entirely correct here. Outside of Next.js

--- a/packages/next-intl/src/react-client/useNow.test.tsx
+++ b/packages/next-intl/src/react-client/useNow.test.tsx
@@ -1,5 +1,4 @@
 import {render, screen} from '@testing-library/react';
-import React from 'react';
 import {it} from 'vitest';
 import {NextIntlClientProvider, useNow} from './index.tsx';
 

--- a/packages/next-intl/src/react-client/useNow.test.tsx
+++ b/packages/next-intl/src/react-client/useNow.test.tsx
@@ -1,7 +1,7 @@
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {it} from 'vitest';
-import {NextIntlClientProvider, useNow} from '.';
+import {NextIntlClientProvider, useNow} from './index.tsx';
 
 function Component() {
   const now = useNow();

--- a/packages/next-intl/src/react-client/useTimeZone.test.tsx
+++ b/packages/next-intl/src/react-client/useTimeZone.test.tsx
@@ -1,7 +1,7 @@
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {it} from 'vitest';
-import {NextIntlClientProvider, useTimeZone} from '.';
+import {NextIntlClientProvider, useTimeZone} from './index.tsx';
 
 function Component() {
   const timeZone = useTimeZone();

--- a/packages/next-intl/src/react-client/useTimeZone.test.tsx
+++ b/packages/next-intl/src/react-client/useTimeZone.test.tsx
@@ -1,5 +1,4 @@
 import {render, screen} from '@testing-library/react';
-import React from 'react';
 import {it} from 'vitest';
 import {NextIntlClientProvider, useTimeZone} from './index.tsx';
 

--- a/packages/next-intl/src/react-client/useTranslations.test.tsx
+++ b/packages/next-intl/src/react-client/useTranslations.test.tsx
@@ -1,7 +1,7 @@
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {expect, it, vi} from 'vitest';
-import {NextIntlClientProvider, useTranslations} from '.';
+import {NextIntlClientProvider, useTranslations} from './index.tsx';
 
 function Component() {
   const t = useTranslations('Component');

--- a/packages/next-intl/src/react-client/useTranslations.test.tsx
+++ b/packages/next-intl/src/react-client/useTranslations.test.tsx
@@ -1,5 +1,4 @@
 import {render, screen} from '@testing-library/react';
-import React from 'react';
 import {expect, it, vi} from 'vitest';
 import {NextIntlClientProvider, useTranslations} from './index.tsx';
 

--- a/packages/next-intl/src/react-server/NextIntlClientProviderServer.test.tsx
+++ b/packages/next-intl/src/react-server/NextIntlClientProviderServer.test.tsx
@@ -1,8 +1,8 @@
 import {expect, it, vi} from 'vitest';
-import getFormats from '../server/react-server/getFormats';
-import {getLocale, getNow, getTimeZone} from '../server.react-server';
-import NextIntlClientProvider from '../shared/NextIntlClientProvider';
-import NextIntlClientProviderServer from './NextIntlClientProviderServer';
+import getFormats from '../server/react-server/getFormats.tsx';
+import {getLocale, getNow, getTimeZone} from '../server.react-server.tsx';
+import NextIntlClientProvider from '../shared/NextIntlClientProvider.tsx';
+import NextIntlClientProviderServer from './NextIntlClientProviderServer.tsx';
 
 vi.mock('../../src/server/react-server', async () => ({
   getLocale: vi.fn(async () => 'en-US'),

--- a/packages/next-intl/src/react-server/NextIntlClientProviderServer.tsx
+++ b/packages/next-intl/src/react-server/NextIntlClientProviderServer.tsx
@@ -1,7 +1,7 @@
 import React, {ComponentProps} from 'react';
-import getFormats from '../server/react-server/getFormats';
-import {getLocale, getNow, getTimeZone} from '../server.react-server';
-import BaseNextIntlClientProvider from '../shared/NextIntlClientProvider';
+import getFormats from '../server/react-server/getFormats.tsx';
+import {getLocale, getNow, getTimeZone} from '../server.react-server.tsx';
+import BaseNextIntlClientProvider from '../shared/NextIntlClientProvider.tsx';
 
 type Props = ComponentProps<typeof BaseNextIntlClientProvider>;
 

--- a/packages/next-intl/src/react-server/NextIntlClientProviderServer.tsx
+++ b/packages/next-intl/src/react-server/NextIntlClientProviderServer.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps} from 'react';
+import {ComponentProps} from 'react';
 import getFormats from '../server/react-server/getFormats.tsx';
 import {getLocale, getNow, getTimeZone} from '../server.react-server.tsx';
 import BaseNextIntlClientProvider from '../shared/NextIntlClientProvider.tsx';

--- a/packages/next-intl/src/react-server/index.test.tsx
+++ b/packages/next-intl/src/react-server/index.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {describe, expect, it, vi} from 'vitest';
 import {getTranslations} from '../server.react-server.tsx';
 import {

--- a/packages/next-intl/src/react-server/index.test.tsx
+++ b/packages/next-intl/src/react-server/index.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {describe, expect, it, vi} from 'vitest';
-import {getTranslations} from '../server.react-server';
-import {renderToStream} from './testUtils';
+import {getTranslations} from '../server.react-server.tsx';
 import {
   _createCache,
   useFormatter,
@@ -9,7 +8,8 @@ import {
   useMessages,
   useNow,
   useTranslations
-} from '.';
+} from './index.tsx';
+import {renderToStream} from './testUtils.tsx';
 
 vi.mock('react');
 

--- a/packages/next-intl/src/react-server/index.tsx
+++ b/packages/next-intl/src/react-server/index.tsx
@@ -7,13 +7,13 @@
  */
 
 // Replaced exports from the `react` package
-export {default as useLocale} from './useLocale';
-export {default as useTranslations} from './useTranslations';
-export {default as useFormatter} from './useFormatter';
-export {default as useNow} from './useNow';
-export {default as useTimeZone} from './useTimeZone';
-export {default as useMessages} from './useMessages';
-export {default as NextIntlClientProvider} from './NextIntlClientProviderServer';
+export {default as useLocale} from './useLocale.tsx';
+export {default as useTranslations} from './useTranslations.tsx';
+export {default as useFormatter} from './useFormatter.tsx';
+export {default as useNow} from './useNow.tsx';
+export {default as useTimeZone} from './useTimeZone.tsx';
+export {default as useMessages} from './useMessages.tsx';
+export {default as NextIntlClientProvider} from './NextIntlClientProviderServer.tsx';
 
 // Everything from `core`
 export * from 'use-intl/core';

--- a/packages/next-intl/src/react-server/testUtils.tsx
+++ b/packages/next-intl/src/react-server/testUtils.tsx
@@ -1,4 +1,4 @@
-import React, {ReactNode, Suspense} from 'react';
+import {ReactNode, Suspense} from 'react';
 import {ReactDOMServerReadableStream} from 'react-dom/server';
 // @ts-expect-error -- Not available in types
 import {renderToReadableStream as _renderToReadableStream} from 'react-dom/server.browser';

--- a/packages/next-intl/src/react-server/useConfig.tsx
+++ b/packages/next-intl/src/react-server/useConfig.tsx
@@ -1,5 +1,5 @@
-import {use} from 'react';
 import getConfig from '../server/react-server/getConfig.tsx';
+import use from '../shared/use.tsx';
 
 function useHook<Value>(hookName: string, promise: Promise<Value>) {
   try {

--- a/packages/next-intl/src/react-server/useConfig.tsx
+++ b/packages/next-intl/src/react-server/useConfig.tsx
@@ -1,5 +1,5 @@
 import {use} from 'react';
-import getConfig from '../server/react-server/getConfig';
+import getConfig from '../server/react-server/getConfig.tsx';
 
 function useHook<Value>(hookName: string, promise: Promise<Value>) {
   try {

--- a/packages/next-intl/src/react-server/useFormatter.tsx
+++ b/packages/next-intl/src/react-server/useFormatter.tsx
@@ -1,14 +1,11 @@
 import {cache} from 'react';
-import {type useFormatter as useFormatterType} from 'use-intl';
+import type {useFormatter as useFormatterType} from 'use-intl';
 import {createFormatter} from 'use-intl/core';
 import useConfig from './useConfig.tsx';
 
 const createFormatterCached = cache(createFormatter);
 
-export default function useFormatter(
-  // eslint-disable-next-line no-empty-pattern
-  ...[]: Parameters<typeof useFormatterType>
-): ReturnType<typeof useFormatterType> {
+export default function useFormatter(): ReturnType<typeof useFormatterType> {
   const config = useConfig('useFormatter');
   return createFormatterCached(config);
 }

--- a/packages/next-intl/src/react-server/useFormatter.tsx
+++ b/packages/next-intl/src/react-server/useFormatter.tsx
@@ -1,7 +1,7 @@
 import {cache} from 'react';
 import {type useFormatter as useFormatterType} from 'use-intl';
 import {createFormatter} from 'use-intl/core';
-import useConfig from './useConfig';
+import useConfig from './useConfig.tsx';
 
 const createFormatterCached = cache(createFormatter);
 

--- a/packages/next-intl/src/react-server/useLocale.tsx
+++ b/packages/next-intl/src/react-server/useLocale.tsx
@@ -1,5 +1,5 @@
 import type {useLocale as useLocaleType} from 'use-intl';
-import useConfig from './useConfig';
+import useConfig from './useConfig.tsx';
 
 export default function useLocale(
   // eslint-disable-next-line no-empty-pattern

--- a/packages/next-intl/src/react-server/useLocale.tsx
+++ b/packages/next-intl/src/react-server/useLocale.tsx
@@ -1,10 +1,7 @@
 import type {useLocale as useLocaleType} from 'use-intl';
 import useConfig from './useConfig.tsx';
 
-export default function useLocale(
-  // eslint-disable-next-line no-empty-pattern
-  ...[]: Parameters<typeof useLocaleType>
-): ReturnType<typeof useLocaleType> {
+export default function useLocale(): ReturnType<typeof useLocaleType> {
   const config = useConfig('useLocale');
   return config.locale;
 }

--- a/packages/next-intl/src/react-server/useMessages.tsx
+++ b/packages/next-intl/src/react-server/useMessages.tsx
@@ -1,6 +1,6 @@
 import type {useMessages as useMessagesType} from 'use-intl';
-import {getMessagesFromConfig} from '../server/react-server/getMessages';
-import useConfig from './useConfig';
+import {getMessagesFromConfig} from '../server/react-server/getMessages.tsx';
+import useConfig from './useConfig.tsx';
 
 export default function useMessages(
   // eslint-disable-next-line no-empty-pattern

--- a/packages/next-intl/src/react-server/useMessages.tsx
+++ b/packages/next-intl/src/react-server/useMessages.tsx
@@ -2,10 +2,7 @@ import type {useMessages as useMessagesType} from 'use-intl';
 import {getMessagesFromConfig} from '../server/react-server/getMessages.tsx';
 import useConfig from './useConfig.tsx';
 
-export default function useMessages(
-  // eslint-disable-next-line no-empty-pattern
-  ...[]: Parameters<typeof useMessagesType>
-): ReturnType<typeof useMessagesType> {
+export default function useMessages(): ReturnType<typeof useMessagesType> {
   const config = useConfig('useMessages');
   return getMessagesFromConfig(config);
 }

--- a/packages/next-intl/src/react-server/useNow.tsx
+++ b/packages/next-intl/src/react-server/useNow.tsx
@@ -2,7 +2,7 @@ import type {useNow as useNowType} from 'use-intl';
 import useConfig from './useConfig.tsx';
 
 export default function useNow(
-  ...[options]: Parameters<typeof useNowType>
+  options?: Parameters<typeof useNowType>[0]
 ): ReturnType<typeof useNowType> {
   if (options?.updateInterval != null) {
     console.error(

--- a/packages/next-intl/src/react-server/useNow.tsx
+++ b/packages/next-intl/src/react-server/useNow.tsx
@@ -1,5 +1,5 @@
 import type {useNow as useNowType} from 'use-intl';
-import useConfig from './useConfig';
+import useConfig from './useConfig.tsx';
 
 export default function useNow(
   ...[options]: Parameters<typeof useNowType>

--- a/packages/next-intl/src/react-server/useTimeZone.tsx
+++ b/packages/next-intl/src/react-server/useTimeZone.tsx
@@ -1,5 +1,5 @@
 import type {useTimeZone as useTimeZoneType} from 'use-intl';
-import useConfig from './useConfig';
+import useConfig from './useConfig.tsx';
 
 export default function useTimeZone(
   // eslint-disable-next-line no-empty-pattern

--- a/packages/next-intl/src/react-server/useTimeZone.tsx
+++ b/packages/next-intl/src/react-server/useTimeZone.tsx
@@ -1,10 +1,7 @@
 import type {useTimeZone as useTimeZoneType} from 'use-intl';
 import useConfig from './useConfig.tsx';
 
-export default function useTimeZone(
-  // eslint-disable-next-line no-empty-pattern
-  ...[]: Parameters<typeof useTimeZoneType>
-): ReturnType<typeof useTimeZoneType> {
+export default function useTimeZone(): ReturnType<typeof useTimeZoneType> {
   const config = useConfig('useTimeZone');
   return config.timeZone;
 }

--- a/packages/next-intl/src/react-server/useTranslations.test.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.test.tsx
@@ -1,7 +1,7 @@
 import {cache} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {renderToStream} from './testUtils.tsx';
 import {createTranslator, useTranslations} from './index.tsx';
+import {renderToStream} from './testUtils.tsx';
 
 vi.mock('../../src/server/react-server/createRequestConfig', () => ({
   default: async () => ({

--- a/packages/next-intl/src/react-server/useTranslations.test.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.test.tsx
@@ -1,7 +1,7 @@
 import React, {cache} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {renderToStream} from './testUtils';
-import {createTranslator, useTranslations} from '.';
+import {renderToStream} from './testUtils.tsx';
+import {createTranslator, useTranslations} from './index.tsx';
 
 vi.mock('../../src/server/react-server/createRequestConfig', () => ({
   default: async () => ({

--- a/packages/next-intl/src/react-server/useTranslations.test.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.test.tsx
@@ -1,4 +1,4 @@
-import React, {cache} from 'react';
+import {cache} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {renderToStream} from './testUtils.tsx';
 import {createTranslator, useTranslations} from './index.tsx';

--- a/packages/next-intl/src/react-server/useTranslations.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.tsx
@@ -1,6 +1,6 @@
 import type {useTranslations as useTranslationsType} from 'use-intl';
-import getBaseTranslator from './getTranslator';
-import useConfig from './useConfig';
+import getBaseTranslator from './getTranslator.tsx';
+import useConfig from './useConfig.tsx';
 
 export default function useTranslations(
   ...[namespace]: Parameters<typeof useTranslationsType>

--- a/packages/next-intl/src/routing.tsx
+++ b/packages/next-intl/src/routing.tsx
@@ -1,1 +1,1 @@
-export * from './routing/index';
+export * from './routing/index.tsx';

--- a/packages/next-intl/src/routing/config.tsx
+++ b/packages/next-intl/src/routing/config.tsx
@@ -6,7 +6,7 @@ import {
   LocalePrefixMode,
   Locales,
   Pathnames
-} from './types';
+} from './types.tsx';
 
 type CookieAttributes = Pick<
   NonNullable<Parameters<typeof NextResponse.prototype.cookies.set>['2']>,

--- a/packages/next-intl/src/routing/config.tsx
+++ b/packages/next-intl/src/routing/config.tsx
@@ -1,4 +1,4 @@
-import type {NextResponse} from 'next/server';
+import type {NextResponse} from 'next/server.js';
 import {
   DomainsConfig,
   LocalePrefix,

--- a/packages/next-intl/src/routing/defineRouting.test.tsx
+++ b/packages/next-intl/src/routing/defineRouting.test.tsx
@@ -1,5 +1,5 @@
 import {describe, it} from 'vitest';
-import defineRouting from './defineRouting';
+import defineRouting from './defineRouting.tsx';
 
 describe('defaultLocale', () => {
   it('ensures the `defaultLocale` is within `locales`', () => {

--- a/packages/next-intl/src/routing/defineRouting.tsx
+++ b/packages/next-intl/src/routing/defineRouting.tsx
@@ -1,5 +1,5 @@
-import {RoutingConfig} from './config';
-import {DomainsConfig, LocalePrefixMode, Locales, Pathnames} from './types';
+import {RoutingConfig} from './config.tsx';
+import {DomainsConfig, LocalePrefixMode, Locales, Pathnames} from './types.tsx';
 
 export default function defineRouting<
   const AppLocales extends Locales,

--- a/packages/next-intl/src/routing/index.tsx
+++ b/packages/next-intl/src/routing/index.tsx
@@ -1,2 +1,2 @@
-export type {Pathnames, LocalePrefix, DomainsConfig} from './types';
-export {default as defineRouting} from './defineRouting';
+export type {Pathnames, LocalePrefix, DomainsConfig} from './types.tsx';
+export {default as defineRouting} from './defineRouting.tsx';

--- a/packages/next-intl/src/routing/types.test.tsx
+++ b/packages/next-intl/src/routing/types.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {describe, it} from 'vitest';
-import {DomainConfig, LocalePrefix} from './types';
+import {DomainConfig, LocalePrefix} from './types.tsx';
 
 describe('LocalePrefix', () => {
   it('does not require a type param for simple values', () => {

--- a/packages/next-intl/src/server.react-client.tsx
+++ b/packages/next-intl/src/server.react-client.tsx
@@ -1,1 +1,1 @@
-export * from './server/react-client/index';
+export * from './server/react-client/index.tsx';

--- a/packages/next-intl/src/server.react-server.tsx
+++ b/packages/next-intl/src/server.react-server.tsx
@@ -1,1 +1,1 @@
-export * from './server/react-server/index';
+export * from './server/react-server/index.tsx';

--- a/packages/next-intl/src/server/react-client/index.test.tsx
+++ b/packages/next-intl/src/server/react-client/index.test.tsx
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {getRequestConfig} from '../../server.react-client';
+import {getRequestConfig} from '../../server.react-client.tsx';
 
 describe('getRequestConfig', () => {
   it('can be called in the outer module closure', () => {

--- a/packages/next-intl/src/server/react-client/index.tsx
+++ b/packages/next-intl/src/server/react-client/index.tsx
@@ -7,7 +7,7 @@ import type {
   getTimeZone as getTimeZone_type,
   setRequestLocale as setRequestLocale_type,
   unstable_setRequestLocale as unstable_setRequestLocale_type
-} from '../react-server';
+} from '../react-server/index.tsx';
 
 /**
  * Allows to import `next-intl/server` in non-RSC environments.

--- a/packages/next-intl/src/server/react-server/RequestLocale.tsx
+++ b/packages/next-intl/src/server/react-server/RequestLocale.tsx
@@ -1,4 +1,4 @@
-import {headers} from 'next/headers';
+import {headers} from 'next/headers.js';
 import {cache} from 'react';
 import {HEADER_LOCALE_NAME} from '../../shared/constants.tsx';
 import {getCachedRequestLocale} from './RequestLocaleCache.tsx';

--- a/packages/next-intl/src/server/react-server/RequestLocale.tsx
+++ b/packages/next-intl/src/server/react-server/RequestLocale.tsx
@@ -1,7 +1,7 @@
 import {headers} from 'next/headers';
 import {cache} from 'react';
-import {HEADER_LOCALE_NAME} from '../../shared/constants';
-import {getCachedRequestLocale} from './RequestLocaleCache';
+import {HEADER_LOCALE_NAME} from '../../shared/constants.tsx';
+import {getCachedRequestLocale} from './RequestLocaleCache.tsx';
 
 async function getHeadersImpl(): Promise<Headers> {
   const promiseOrValue = headers();

--- a/packages/next-intl/src/server/react-server/RequestLocaleLegacy.tsx
+++ b/packages/next-intl/src/server/react-server/RequestLocaleLegacy.tsx
@@ -1,8 +1,8 @@
 import {headers} from 'next/headers';
 import {notFound} from 'next/navigation';
 import {cache} from 'react';
-import {HEADER_LOCALE_NAME} from '../../shared/constants';
-import {getCachedRequestLocale} from './RequestLocaleCache';
+import {HEADER_LOCALE_NAME} from '../../shared/constants.tsx';
+import {getCachedRequestLocale} from './RequestLocaleCache.tsx';
 
 // This was originally built for Next.js <14, where `headers()` was not async.
 // With https://github.com/vercel/next.js/pull/68812, the API became async.

--- a/packages/next-intl/src/server/react-server/RequestLocaleLegacy.tsx
+++ b/packages/next-intl/src/server/react-server/RequestLocaleLegacy.tsx
@@ -1,5 +1,5 @@
-import {headers} from 'next/headers';
-import {notFound} from 'next/navigation';
+import {headers} from 'next/headers.js';
+import {notFound} from 'next/navigation.js';
 import {cache} from 'react';
 import {HEADER_LOCALE_NAME} from '../../shared/constants.tsx';
 import {getCachedRequestLocale} from './RequestLocaleCache.tsx';

--- a/packages/next-intl/src/server/react-server/createRequestConfig.tsx
+++ b/packages/next-intl/src/server/react-server/createRequestConfig.tsx
@@ -1,5 +1,8 @@
 import getRuntimeConfig from 'next-intl/config';
-import type {GetRequestConfigParams, RequestConfig} from './getRequestConfig';
+import type {
+  GetRequestConfigParams,
+  RequestConfig
+} from './getRequestConfig.tsx';
 
 export default getRuntimeConfig as unknown as (
   params: GetRequestConfigParams

--- a/packages/next-intl/src/server/react-server/getConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getConfig.tsx
@@ -6,10 +6,10 @@ import {
   _createIntlFormatters,
   initializeConfig
 } from 'use-intl/core';
-import {getRequestLocale} from './RequestLocale';
-import {getRequestLocale as getRequestLocaleLegacy} from './RequestLocaleLegacy';
-import createRequestConfig from './createRequestConfig';
-import {GetRequestConfigParams} from './getRequestConfig';
+import {getRequestLocale} from './RequestLocale.tsx';
+import {getRequestLocale as getRequestLocaleLegacy} from './RequestLocaleLegacy.tsx';
+import createRequestConfig from './createRequestConfig.tsx';
+import {GetRequestConfigParams} from './getRequestConfig.tsx';
 
 // Make sure `now` is consistent across the request in case none was configured
 function getDefaultNowImpl() {

--- a/packages/next-intl/src/server/react-server/getConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getConfig.tsx
@@ -1,4 +1,4 @@
-import {notFound} from 'next/navigation';
+import {notFound} from 'next/navigation.js';
 import {cache} from 'react';
 import {
   IntlConfig,

--- a/packages/next-intl/src/server/react-server/getFormats.tsx
+++ b/packages/next-intl/src/server/react-server/getFormats.tsx
@@ -1,5 +1,5 @@
 import {cache} from 'react';
-import getConfig from './getConfig';
+import getConfig from './getConfig.tsx';
 
 async function getFormatsCachedImpl() {
   const config = await getConfig();

--- a/packages/next-intl/src/server/react-server/getFormatter.tsx
+++ b/packages/next-intl/src/server/react-server/getFormatter.tsx
@@ -1,6 +1,6 @@
 import {cache} from 'react';
 import {createFormatter} from 'use-intl/core';
-import getConfig from './getConfig';
+import getConfig from './getConfig.tsx';
 
 async function getFormatterCachedImpl(locale?: string) {
   const config = await getConfig(locale);

--- a/packages/next-intl/src/server/react-server/getLocale.tsx
+++ b/packages/next-intl/src/server/react-server/getLocale.tsx
@@ -1,5 +1,5 @@
 import {cache} from 'react';
-import getConfig from './getConfig';
+import getConfig from './getConfig.tsx';
 
 async function getLocaleCachedImpl() {
   const config = await getConfig();

--- a/packages/next-intl/src/server/react-server/getMessages.tsx
+++ b/packages/next-intl/src/server/react-server/getMessages.tsx
@@ -1,6 +1,6 @@
 import {cache} from 'react';
 import type {AbstractIntlMessages} from 'use-intl';
-import getConfig from './getConfig';
+import getConfig from './getConfig.tsx';
 
 export function getMessagesFromConfig(
   config: Awaited<ReturnType<typeof getConfig>>

--- a/packages/next-intl/src/server/react-server/getNow.tsx
+++ b/packages/next-intl/src/server/react-server/getNow.tsx
@@ -1,5 +1,5 @@
 import {cache} from 'react';
-import getConfig from './getConfig';
+import getConfig from './getConfig.tsx';
 
 async function getNowCachedImpl(locale?: string) {
   const config = await getConfig(locale);

--- a/packages/next-intl/src/server/react-server/getTimeZone.tsx
+++ b/packages/next-intl/src/server/react-server/getTimeZone.tsx
@@ -1,5 +1,5 @@
 import {cache} from 'react';
-import getConfig from './getConfig';
+import getConfig from './getConfig.tsx';
 
 async function getTimeZoneCachedImpl(locale?: string) {
   const config = await getConfig(locale);

--- a/packages/next-intl/src/server/react-server/getTranslations.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslations.tsx
@@ -10,7 +10,7 @@ import {
   TranslationValues,
   createTranslator
 } from 'use-intl/core';
-import getConfig from './getConfig';
+import getConfig from './getConfig.tsx';
 
 // Maintainer note: `getTranslations` has two different call signatures.
 // We need to define these with function overloads, otherwise TypeScript

--- a/packages/next-intl/src/server/react-server/index.test.tsx
+++ b/packages/next-intl/src/server/react-server/index.test.tsx
@@ -28,7 +28,7 @@ vi.mock('next-intl/config', () => ({
     })
 }));
 
-vi.mock('next/headers', () => ({
+vi.mock('next/headers.js', () => ({
   headers: () => ({
     get(name: string) {
       if (name === HEADER_LOCALE_NAME) {

--- a/packages/next-intl/src/server/react-server/index.test.tsx
+++ b/packages/next-intl/src/server/react-server/index.test.tsx
@@ -1,14 +1,14 @@
 // @vitest-environment edge-runtime
 
 import {describe, expect, it, vi} from 'vitest';
-import {HEADER_LOCALE_NAME} from '../../shared/constants';
+import {HEADER_LOCALE_NAME} from '../../shared/constants.tsx';
 import {
   getFormatter,
   getMessages,
   getNow,
   getTimeZone,
   getTranslations
-} from '.';
+} from './index.tsx';
 
 vi.mock('next-intl/config', () => ({
   default: async () =>

--- a/packages/next-intl/src/server/react-server/index.tsx
+++ b/packages/next-intl/src/server/react-server/index.tsx
@@ -2,17 +2,17 @@
  * Server-only APIs available via `next-intl/server`.
  */
 
-export {default as getRequestConfig} from './getRequestConfig';
-export {default as getFormatter} from './getFormatter';
-export {default as getNow} from './getNow';
-export {default as getTimeZone} from './getTimeZone';
-export {default as getTranslations} from './getTranslations';
-export {default as getMessages} from './getMessages';
-export {default as getLocale} from './getLocale';
+export {default as getRequestConfig} from './getRequestConfig.tsx';
+export {default as getFormatter} from './getFormatter.tsx';
+export {default as getNow} from './getNow.tsx';
+export {default as getTimeZone} from './getTimeZone.tsx';
+export {default as getTranslations} from './getTranslations.tsx';
+export {default as getMessages} from './getMessages.tsx';
+export {default as getLocale} from './getLocale.tsx';
 
-export {setCachedRequestLocale as setRequestLocale} from './RequestLocaleCache';
+export {setCachedRequestLocale as setRequestLocale} from './RequestLocaleCache.tsx';
 
 export {
   /** @deprecated Deprecated in favor of `setRequestLocale`. */
   setCachedRequestLocale as unstable_setRequestLocale
-} from './RequestLocaleCache';
+} from './RequestLocaleCache.tsx';

--- a/packages/next-intl/src/shared/NextIntlClientProvider.test.tsx
+++ b/packages/next-intl/src/shared/NextIntlClientProvider.test.tsx
@@ -1,7 +1,10 @@
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {it} from 'vitest';
-import {NextIntlClientProvider, useTranslations} from '../index.react-client';
+import {
+  NextIntlClientProvider,
+  useTranslations
+} from '../index.react-client.tsx';
 
 it('can use messages from the provider', () => {
   function Component() {

--- a/packages/next-intl/src/shared/NextIntlClientProvider.test.tsx
+++ b/packages/next-intl/src/shared/NextIntlClientProvider.test.tsx
@@ -1,5 +1,4 @@
 import {render, screen} from '@testing-library/react';
-import React from 'react';
 import {it} from 'vitest';
 import {
   NextIntlClientProvider,

--- a/packages/next-intl/src/shared/NextIntlClientProvider.tsx
+++ b/packages/next-intl/src/shared/NextIntlClientProvider.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import React, {ComponentProps} from 'react';
-// Workaround for some bundle splitting until we have ESM
-import {IntlProvider} from 'use-intl/_IntlProvider';
+import {IntlProvider} from 'use-intl/react';
 
 type Props = Omit<ComponentProps<typeof IntlProvider>, 'locale'> & {
   /** This is automatically received when being rendered from a Server Component. In all other cases, e.g. when rendered from a Client Component, a unit test or with the Pages Router, you can pass this prop explicitly. */

--- a/packages/next-intl/src/shared/NextIntlClientProvider.tsx
+++ b/packages/next-intl/src/shared/NextIntlClientProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, {ComponentProps} from 'react';
+import {ComponentProps} from 'react';
 import {IntlProvider} from 'use-intl/react';
 
 type Props = Omit<ComponentProps<typeof IntlProvider>, 'locale'> & {

--- a/packages/next-intl/src/shared/use.tsx
+++ b/packages/next-intl/src/shared/use.tsx
@@ -1,13 +1,11 @@
 import * as react from 'react';
 
-export default function use<Value>(value: Promise<Value>): Value {
-  // @ts-expect-error -- Ooof, Next.js doesn't make this easy.
-  // `use` is only available in React 19 canary, but we can
-  // use it in Next.js already as Next.js "vendors" a fixed
-  // version of React. However, if we'd simply put `use` in
-  // ESM code, then the build doesn't work since React does
-  // not export `use` officially. Therefore, we have to use
-  // something that is not statically analyzable. Once React
-  // 19 is out, we can remove this in the next major version.
-  return react['use'.trim()](value);
-}
+// @ts-expect-error -- Ooof, Next.js doesn't make this easy.
+// `use` is only available in React 19 canary, but we can
+// use it in Next.js already as Next.js "vendors" a fixed
+// version of React. However, if we'd simply put `use` in
+// ESM code, then the build doesn't work since React does
+// not export `use` officially. Therefore, we have to use
+// something that is not statically analyzable. Once React
+// 19 is out, we can remove this in the next major version.
+export default react['use'.trim()] as typeof react.use;

--- a/packages/next-intl/src/shared/use.tsx
+++ b/packages/next-intl/src/shared/use.tsx
@@ -1,0 +1,13 @@
+import * as react from 'react';
+
+export default function use<Value>(value: Promise<Value>): Value {
+  // @ts-expect-error -- Ooof, Next.js doesn't make this easy.
+  // `use` is only available in React 19 canary, but we can
+  // use it in Next.js already as Next.js "vendors" a fixed
+  // version of React. However, if we'd simply put `use` in
+  // ESM code, then the build doesn't work since React does
+  // not export `use` officially. Therefore, we have to use
+  // something that is not statically analyzable. Once React
+  // 19 is out, we can remove this in the next major version.
+  return react['use'.trim()](value);
+}

--- a/packages/next-intl/src/shared/utils.test.tsx
+++ b/packages/next-intl/src/shared/utils.test.tsx
@@ -5,7 +5,7 @@ import {
   matchesPathname,
   prefixPathname,
   unprefixPathname
-} from './utils';
+} from './utils.tsx';
 
 describe('prefixPathname', () => {
   it("doesn't add trailing slashes for the root", () => {

--- a/packages/next-intl/src/shared/utils.tsx
+++ b/packages/next-intl/src/shared/utils.tsx
@@ -5,7 +5,7 @@ import {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,
   Locales
-} from '../routing/types';
+} from '../routing/types.tsx';
 
 type Href = ComponentProps<typeof NextLink>['href'];
 

--- a/packages/next-intl/src/shared/utils.tsx
+++ b/packages/next-intl/src/shared/utils.tsx
@@ -1,13 +1,12 @@
 import {UrlObject} from 'url';
-import NextLink from 'next/link';
-import {ComponentProps} from 'react';
+import {LinkProps} from 'next/link.js';
 import {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,
   Locales
 } from '../routing/types.tsx';
 
-type Href = ComponentProps<typeof NextLink>['href'];
+type Href = LinkProps['href'];
 
 function isRelativeHref(href: Href) {
   const pathname = typeof href === 'object' ? href.pathname : href;

--- a/packages/next-intl/tsconfig.build.json
+++ b/packages/next-intl/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.tsx", "test", "__mocks__"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": false,
+    "outDir": "dist/types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/next-intl/tsconfig.json
+++ b/packages/next-intl/tsconfig.json
@@ -2,20 +2,15 @@
   "extends": "eslint-config-molindo/tsconfig.json",
   "include": ["src", "test", "__mocks__", "types", "next-env.d.ts"],
   "compilerOptions": {
-    "moduleDetection": "force",
-    "isolatedModules": true,
-    "module": "esnext",
+    "allowImportingTsExtensions": true, // For ESM
     "lib": ["dom", "esnext"],
     "target": "ES2020",
-    "importHelpers": false,
     "declaration": true,
-    "sourceMap": true,
     "rootDir": ".",
-    "moduleResolution": "Bundler",
-    "jsx": "react",
-    "esModuleInterop": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "jsx": "react-jsx",
     "skipLibCheck": true,
-    "noEmit": false,
-    "outDir": "dist"
+    "noEmit": true
   }
 }

--- a/packages/use-intl/.size-limit.ts
+++ b/packages/use-intl/.size-limit.ts
@@ -2,22 +2,23 @@ import type {SizeLimitConfig} from 'size-limit';
 
 const config: SizeLimitConfig = [
   {
-    name: "import * from 'use-intl' (ESM)",
+    name: "import * from 'use-intl' (production)",
     import: '*',
-    path: 'dist/esm/index.js',
+    path: 'dist/esm/production/index.js',
     limit: '14.195 kB'
   },
   {
-    name: "import {IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter} from 'use-intl' (ESM)",
-    path: 'dist/esm/index.js',
+    name: "import {IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter} from 'use-intl' (production)",
+    path: 'dist/esm/production/index.js',
     import:
       '{IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter}',
     limit: '2.935 kB'
   },
   {
-    name: "import * from 'use-intl' (CJS)",
-    path: 'dist/production/index.js',
-    limit: '13.695 kB'
+    name: "import * from 'use-intl' (development)",
+    import: '*',
+    path: 'dist/esm/development/index.js',
+    limit: '14.195 kB'
   }
 ];
 

--- a/packages/use-intl/.size-limit.ts
+++ b/packages/use-intl/.size-limit.ts
@@ -12,7 +12,7 @@ const config: SizeLimitConfig = [
     path: 'dist/esm/production/index.js',
     import:
       '{IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter}',
-    limit: '1.985 kB'
+    limit: '2.005 kB'
   },
   {
     name: "import * from 'use-intl' (development)",

--- a/packages/use-intl/.size-limit.ts
+++ b/packages/use-intl/.size-limit.ts
@@ -5,20 +5,20 @@ const config: SizeLimitConfig = [
     name: "import * from 'use-intl' (production)",
     import: '*',
     path: 'dist/esm/production/index.js',
-    limit: '14.195 kB'
+    limit: '13.075 kB'
   },
   {
     name: "import {IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter} from 'use-intl' (production)",
     path: 'dist/esm/production/index.js',
     import:
       '{IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter}',
-    limit: '2.935 kB'
+    limit: '1.985 kB'
   },
   {
     name: "import * from 'use-intl' (development)",
     import: '*',
     path: 'dist/esm/development/index.js',
-    limit: '14.195 kB'
+    limit: '13.955 kB'
   }
 ];
 

--- a/packages/use-intl/_IntlProvider.d.ts
+++ b/packages/use-intl/_IntlProvider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/types/src/_IntlProvider';

--- a/packages/use-intl/_useLocale.d.ts
+++ b/packages/use-intl/_useLocale.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/types/src/_useLocale';

--- a/packages/use-intl/core.d.ts
+++ b/packages/use-intl/core.d.ts
@@ -1,1 +1,2 @@
-export * from './dist/types/src/core';
+// Needed for project with `moduleResolution: 'node'`
+export * from './dist/types/core.d.ts';

--- a/packages/use-intl/core.d.ts
+++ b/packages/use-intl/core.d.ts
@@ -1,2 +1,2 @@
-// Needed for project with `moduleResolution: 'node'`
+// Needed for projects with `moduleResolution: 'node'`
 export * from './dist/types/core.d.ts';

--- a/packages/use-intl/package.json
+++ b/packages/use-intl/package.json
@@ -64,7 +64,7 @@
     "react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.15.3",
+    "@arethetypeswrong/cli": "^0.16.4",
     "@size-limit/preset-small-lib": "^11.1.4",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^20.14.5",

--- a/packages/use-intl/package.json
+++ b/packages/use-intl/package.json
@@ -35,22 +35,12 @@
     "./react": {
       "types": "./react.d.ts",
       "default": "./dist/react.js"
-    },
-    "./_useLocale": {
-      "types": "./_useLocale.d.ts",
-      "default": "./dist/_useLocale.js"
-    },
-    "./_IntlProvider": {
-      "types": "./_IntlProvider.d.ts",
-      "default": "./dist/_IntlProvider.js"
     }
   },
   "files": [
     "dist",
     "core.d.ts",
-    "react.d.ts",
-    "_useLocale.d.ts",
-    "_IntlProvider.d.ts"
+    "react.d.ts"
   ],
   "keywords": [
     "react",

--- a/packages/use-intl/package.json
+++ b/packages/use-intl/package.json
@@ -81,6 +81,7 @@
     "rollup": "^4.18.0",
     "size-limit": "^11.1.4",
     "tinyspy": "^3.0.0",
+    "tools": "workspace:^",
     "typescript": "^5.5.3",
     "vitest": "^2.0.2"
   },

--- a/packages/use-intl/package.json
+++ b/packages/use-intl/package.json
@@ -15,26 +15,29 @@
     "test": "TZ=Europe/Berlin vitest",
     "lint": "pnpm run lint:source && pnpm run lint:package",
     "lint:source": "eslint src test && tsc --noEmit && pnpm run lint:prettier",
-    "lint:package": "publint && attw --pack",
+    "lint:package": "publint && attw --pack --ignore-rules=cjs-resolves-to-esm",
     "lint:prettier": "prettier src --check",
     "prepublishOnly": "turbo build",
     "size": "size-limit"
   },
-  "main": "./dist/index.js",
-  "module": "dist/esm/index.js",
-  "typings": "./dist/types/src/index.d.ts",
+  "type": "module",
+  "main": "./dist/esm/production/index.js",
+  "typings": "./dist/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/types/src/index.d.ts",
-      "default": "./dist/index.js"
+      "types": "./dist/types/index.d.ts",
+      "development": "./dist/esm/development/index.js",
+      "default": "./dist/esm/production/index.js"
     },
     "./core": {
-      "types": "./core.d.ts",
-      "default": "./dist/core.js"
+      "types": "./dist/types/core.d.ts",
+      "development": "./dist/esm/development/core.js",
+      "default": "./dist/esm/production/core.js"
     },
     "./react": {
-      "types": "./react.d.ts",
-      "default": "./dist/react.js"
+      "types": "./dist/types/react.d.ts",
+      "development": "./dist/esm/development/react.js",
+      "default": "./dist/esm/production/react.js"
     }
   },
   "files": [
@@ -62,7 +65,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.3",
-    "@size-limit/preset-big-lib": "^11.1.4",
+    "@size-limit/preset-small-lib": "^11.1.4",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^20.14.5",
     "@types/react": "^18.3.3",

--- a/packages/use-intl/package.json
+++ b/packages/use-intl/package.json
@@ -61,7 +61,7 @@
     "intl-messageformat": "^10.5.14"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.3",

--- a/packages/use-intl/react.d.ts
+++ b/packages/use-intl/react.d.ts
@@ -1,2 +1,2 @@
-// Needed for project with `moduleResolution: 'node'`
+// Needed for projects with `moduleResolution: 'node'`
 export * from './dist/types/react.d.ts';

--- a/packages/use-intl/react.d.ts
+++ b/packages/use-intl/react.d.ts
@@ -1,1 +1,2 @@
-export * from './dist/types/src/react';
+// Needed for project with `moduleResolution: 'node'`
+export * from './dist/types/react.d.ts';

--- a/packages/use-intl/rollup.config.js
+++ b/packages/use-intl/rollup.config.js
@@ -1,4 +1,5 @@
 import getBuildConfig from '../../scripts/getBuildConfig.mjs';
+import pkg from './package.json' with {type: 'json'};
 
 export default getBuildConfig({
   input: {
@@ -7,9 +8,8 @@ export default getBuildConfig({
     react: 'src/react.tsx'
   },
   external: [
-    'intl-messageformat',
-    'react',
-    'react/jsx-runtime',
-    '@formatjs/fast-memoize'
+    ...Object.keys(pkg.dependencies),
+    ...Object.keys(pkg.peerDependencies),
+    'react/jsx-runtime'
   ]
 });

--- a/packages/use-intl/rollup.config.js
+++ b/packages/use-intl/rollup.config.js
@@ -1,4 +1,4 @@
-import getBuildConfig from '../../scripts/getBuildConfig.mjs';
+import {getBuildConfig} from 'tools';
 import pkg from './package.json' with {type: 'json'};
 
 export default getBuildConfig({

--- a/packages/use-intl/rollup.config.mjs
+++ b/packages/use-intl/rollup.config.mjs
@@ -6,5 +6,10 @@ export default getBuildConfig({
     core: 'src/core.tsx',
     react: 'src/react.tsx'
   },
-  external: ['intl-messageformat', 'react', '@formatjs/fast-memoize']
+  external: [
+    'intl-messageformat',
+    'react',
+    'react/jsx-runtime',
+    '@formatjs/fast-memoize'
+  ]
 });

--- a/packages/use-intl/rollup.config.mjs
+++ b/packages/use-intl/rollup.config.mjs
@@ -4,9 +4,7 @@ import getBuildConfig from '../../scripts/getBuildConfig.mjs';
 const input = {
   index: 'src/index.tsx',
   core: 'src/core.tsx',
-  react: 'src/react.tsx',
-  _useLocale: 'src/_useLocale.tsx',
-  _IntlProvider: 'src/_IntlProvider.tsx'
+  react: 'src/react.tsx'
 };
 
 export default [

--- a/packages/use-intl/rollup.config.mjs
+++ b/packages/use-intl/rollup.config.mjs
@@ -1,18 +1,10 @@
-/* eslint-env node */
 import getBuildConfig from '../../scripts/getBuildConfig.mjs';
 
-const input = {
-  index: 'src/index.tsx',
-  core: 'src/core.tsx',
-  react: 'src/react.tsx'
-};
-
-export default [
-  getBuildConfig({input, env: 'development'}),
-  getBuildConfig({
-    input,
-    env: 'esm',
-    output: {format: 'es'}
-  }),
-  getBuildConfig({input, env: 'production'})
-];
+export default getBuildConfig({
+  input: {
+    index: 'src/index.tsx',
+    core: 'src/core.tsx',
+    react: 'src/react.tsx'
+  },
+  external: ['intl-messageformat', 'react', '@formatjs/fast-memoize']
+});

--- a/packages/use-intl/src/_IntlProvider.tsx
+++ b/packages/use-intl/src/_IntlProvider.tsx
@@ -1,1 +1,0 @@
-export {default as IntlProvider} from './react/IntlProvider';

--- a/packages/use-intl/src/_useLocale.tsx
+++ b/packages/use-intl/src/_useLocale.tsx
@@ -1,1 +1,0 @@
-export {default as useLocale} from './react/useLocale';

--- a/packages/use-intl/src/core.tsx
+++ b/packages/use-intl/src/core.tsx
@@ -1,1 +1,1 @@
-export * from './core/index';
+export * from './core/index.tsx';

--- a/packages/use-intl/src/core/DateTimeFormatOptions.tsx
+++ b/packages/use-intl/src/core/DateTimeFormatOptions.tsx
@@ -1,6 +1,6 @@
 // https://github.com/microsoft/TypeScript/issues/35865
 
-import TimeZone from './TimeZone';
+import TimeZone from './TimeZone.tsx';
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat

--- a/packages/use-intl/src/core/Formats.tsx
+++ b/packages/use-intl/src/core/Formats.tsx
@@ -1,5 +1,5 @@
-import DateTimeFormatOptions from './DateTimeFormatOptions';
-import NumberFormatOptions from './NumberFormatOptions';
+import DateTimeFormatOptions from './DateTimeFormatOptions.tsx';
+import NumberFormatOptions from './NumberFormatOptions.tsx';
 
 type Formats = {
   number?: Record<string, NumberFormatOptions>;

--- a/packages/use-intl/src/core/IntlConfig.tsx
+++ b/packages/use-intl/src/core/IntlConfig.tsx
@@ -1,8 +1,8 @@
-import type AbstractIntlMessages from './AbstractIntlMessages';
-import type Formats from './Formats';
-import type IntlError from './IntlError';
-import type TimeZone from './TimeZone';
-import type {RichTranslationValues} from './TranslationValues';
+import type AbstractIntlMessages from './AbstractIntlMessages.tsx';
+import type Formats from './Formats.tsx';
+import type IntlError from './IntlError.tsx';
+import type TimeZone from './TimeZone.tsx';
+import type {RichTranslationValues} from './TranslationValues.tsx';
 
 /**
  * Should be used for entry points that configure the library.

--- a/packages/use-intl/src/core/IntlError.tsx
+++ b/packages/use-intl/src/core/IntlError.tsx
@@ -1,4 +1,4 @@
-export enum IntlErrorCode {
+export const enum IntlErrorCode {
   MISSING_MESSAGE = 'MISSING_MESSAGE',
   MISSING_FORMAT = 'MISSING_FORMAT',
   ENVIRONMENT_FALLBACK = 'ENVIRONMENT_FALLBACK',

--- a/packages/use-intl/src/core/convertFormatsToIntlMessageFormat.tsx
+++ b/packages/use-intl/src/core/convertFormatsToIntlMessageFormat.tsx
@@ -1,4 +1,7 @@
-import {Formats as IntlFormats, IntlMessageFormat} from 'intl-messageformat';
+import {
+  type Formats as IntlFormats,
+  IntlMessageFormat
+} from 'intl-messageformat';
 import DateTimeFormatOptions from './DateTimeFormatOptions.tsx';
 import Formats from './Formats.tsx';
 import TimeZone from './TimeZone.tsx';

--- a/packages/use-intl/src/core/convertFormatsToIntlMessageFormat.tsx
+++ b/packages/use-intl/src/core/convertFormatsToIntlMessageFormat.tsx
@@ -1,4 +1,4 @@
-import IntlMessageFormat, {Formats as IntlFormats} from 'intl-messageformat';
+import {Formats as IntlFormats, IntlMessageFormat} from 'intl-messageformat';
 import DateTimeFormatOptions from './DateTimeFormatOptions.tsx';
 import Formats from './Formats.tsx';
 import TimeZone from './TimeZone.tsx';

--- a/packages/use-intl/src/core/convertFormatsToIntlMessageFormat.tsx
+++ b/packages/use-intl/src/core/convertFormatsToIntlMessageFormat.tsx
@@ -1,7 +1,7 @@
 import IntlMessageFormat, {Formats as IntlFormats} from 'intl-messageformat';
-import DateTimeFormatOptions from './DateTimeFormatOptions';
-import Formats from './Formats';
-import TimeZone from './TimeZone';
+import DateTimeFormatOptions from './DateTimeFormatOptions.tsx';
+import Formats from './Formats.tsx';
+import TimeZone from './TimeZone.tsx';
 
 function setTimeZoneInFormats(
   formats: Record<string, DateTimeFormatOptions> | undefined,

--- a/packages/use-intl/src/core/createBaseTranslator.tsx
+++ b/packages/use-intl/src/core/createBaseTranslator.tsx
@@ -1,4 +1,4 @@
-import IntlMessageFormat from 'intl-messageformat';
+import {IntlMessageFormat} from 'intl-messageformat';
 import {ReactNode, cloneElement, isValidElement} from 'react';
 import AbstractIntlMessages from './AbstractIntlMessages.tsx';
 import Formats from './Formats.tsx';

--- a/packages/use-intl/src/core/createBaseTranslator.tsx
+++ b/packages/use-intl/src/core/createBaseTranslator.tsx
@@ -1,26 +1,26 @@
 import IntlMessageFormat from 'intl-messageformat';
 import {ReactNode, cloneElement, isValidElement} from 'react';
-import AbstractIntlMessages from './AbstractIntlMessages';
-import Formats from './Formats';
-import {InitializedIntlConfig} from './IntlConfig';
-import IntlError, {IntlErrorCode} from './IntlError';
+import AbstractIntlMessages from './AbstractIntlMessages.tsx';
+import Formats from './Formats.tsx';
+import {InitializedIntlConfig} from './IntlConfig.tsx';
+import IntlError, {IntlErrorCode} from './IntlError.tsx';
 import TranslationValues, {
   MarkupTranslationValues,
   RichTranslationValues
-} from './TranslationValues';
-import convertFormatsToIntlMessageFormat from './convertFormatsToIntlMessageFormat';
-import {defaultGetMessageFallback, defaultOnError} from './defaults';
+} from './TranslationValues.tsx';
+import convertFormatsToIntlMessageFormat from './convertFormatsToIntlMessageFormat.tsx';
+import {defaultGetMessageFallback, defaultOnError} from './defaults.tsx';
 import {
   Formatters,
   IntlCache,
   IntlFormatters,
   MessageFormatter,
   memoFn
-} from './formatters';
-import joinPath from './joinPath';
-import MessageKeys from './utils/MessageKeys';
-import NestedKeyOf from './utils/NestedKeyOf';
-import NestedValueOf from './utils/NestedValueOf';
+} from './formatters.tsx';
+import joinPath from './joinPath.tsx';
+import MessageKeys from './utils/MessageKeys.tsx';
+import NestedKeyOf from './utils/NestedKeyOf.tsx';
+import NestedValueOf from './utils/NestedValueOf.tsx';
 
 // Placed here for improved tree shaking. Somehow when this is placed in
 // `formatters.tsx`, then it can't be shaken off from `next-intl`.

--- a/packages/use-intl/src/core/createFormatter.test.tsx
+++ b/packages/use-intl/src/core/createFormatter.test.tsx
@@ -1,6 +1,6 @@
 import {parseISO} from 'date-fns';
 import {describe, expect, it} from 'vitest';
-import createFormatter from './createFormatter';
+import createFormatter from './createFormatter.tsx';
 
 describe('dateTime', () => {
   it('formats a date and time', () => {

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -1,17 +1,17 @@
 import {ReactElement} from 'react';
-import DateTimeFormatOptions from './DateTimeFormatOptions';
-import Formats from './Formats';
-import IntlError, {IntlErrorCode} from './IntlError';
-import NumberFormatOptions from './NumberFormatOptions';
-import RelativeTimeFormatOptions from './RelativeTimeFormatOptions';
-import TimeZone from './TimeZone';
-import {defaultOnError} from './defaults';
+import DateTimeFormatOptions from './DateTimeFormatOptions.tsx';
+import Formats from './Formats.tsx';
+import IntlError, {IntlErrorCode} from './IntlError.tsx';
+import NumberFormatOptions from './NumberFormatOptions.tsx';
+import RelativeTimeFormatOptions from './RelativeTimeFormatOptions.tsx';
+import TimeZone from './TimeZone.tsx';
+import {defaultOnError} from './defaults.tsx';
 import {
   Formatters,
   IntlCache,
   createCache,
   createIntlFormatters
-} from './formatters';
+} from './formatters.tsx';
 
 const SECOND = 1;
 const MINUTE = SECOND * 60;

--- a/packages/use-intl/src/core/createTranslator.test.tsx
+++ b/packages/use-intl/src/core/createTranslator.test.tsx
@@ -1,8 +1,8 @@
 import React, {isValidElement} from 'react';
 import {renderToString} from 'react-dom/server';
 import {describe, expect, it, vi} from 'vitest';
-import IntlError, {IntlErrorCode} from './IntlError';
-import createTranslator from './createTranslator';
+import IntlError, {IntlErrorCode} from './IntlError.tsx';
+import createTranslator from './createTranslator.tsx';
 
 const messages = {
   Home: {

--- a/packages/use-intl/src/core/createTranslator.test.tsx
+++ b/packages/use-intl/src/core/createTranslator.test.tsx
@@ -1,4 +1,4 @@
-import React, {isValidElement} from 'react';
+import {isValidElement} from 'react';
 import {renderToString} from 'react-dom/server';
 import {describe, expect, it, vi} from 'vitest';
 import IntlError, {IntlErrorCode} from './IntlError.tsx';

--- a/packages/use-intl/src/core/createTranslator.tsx
+++ b/packages/use-intl/src/core/createTranslator.tsx
@@ -1,22 +1,22 @@
 import {ReactNode} from 'react';
-import Formats from './Formats';
-import IntlConfig from './IntlConfig';
+import Formats from './Formats.tsx';
+import IntlConfig from './IntlConfig.tsx';
 import TranslationValues, {
   MarkupTranslationValues,
   RichTranslationValues
-} from './TranslationValues';
-import createTranslatorImpl from './createTranslatorImpl';
-import {defaultGetMessageFallback, defaultOnError} from './defaults';
+} from './TranslationValues.tsx';
+import createTranslatorImpl from './createTranslatorImpl.tsx';
+import {defaultGetMessageFallback, defaultOnError} from './defaults.tsx';
 import {
   Formatters,
   IntlCache,
   createCache,
   createIntlFormatters
-} from './formatters';
-import MessageKeys from './utils/MessageKeys';
-import NamespaceKeys from './utils/NamespaceKeys';
-import NestedKeyOf from './utils/NestedKeyOf';
-import NestedValueOf from './utils/NestedValueOf';
+} from './formatters.tsx';
+import MessageKeys from './utils/MessageKeys.tsx';
+import NamespaceKeys from './utils/NamespaceKeys.tsx';
+import NestedKeyOf from './utils/NestedKeyOf.tsx';
+import NestedValueOf from './utils/NestedValueOf.tsx';
 
 /**
  * Translates messages from the given namespace by using the ICU syntax.

--- a/packages/use-intl/src/core/createTranslatorImpl.tsx
+++ b/packages/use-intl/src/core/createTranslatorImpl.tsx
@@ -1,9 +1,9 @@
-import AbstractIntlMessages from './AbstractIntlMessages';
-import {InitializedIntlConfig} from './IntlConfig';
-import createBaseTranslator from './createBaseTranslator';
-import {Formatters, IntlCache} from './formatters';
-import resolveNamespace from './resolveNamespace';
-import NestedKeyOf from './utils/NestedKeyOf';
+import AbstractIntlMessages from './AbstractIntlMessages.tsx';
+import {InitializedIntlConfig} from './IntlConfig.tsx';
+import createBaseTranslator from './createBaseTranslator.tsx';
+import {Formatters, IntlCache} from './formatters.tsx';
+import resolveNamespace from './resolveNamespace.tsx';
+import NestedKeyOf from './utils/NestedKeyOf.tsx';
 
 export type CreateTranslatorImplProps<Messages> = Omit<
   InitializedIntlConfig,

--- a/packages/use-intl/src/core/defaults.tsx
+++ b/packages/use-intl/src/core/defaults.tsx
@@ -1,5 +1,5 @@
-import IntlError from './IntlError';
-import joinPath from './joinPath';
+import IntlError from './IntlError.tsx';
+import joinPath from './joinPath.tsx';
 
 /**
  * Contains defaults that are used for all entry points into the core.

--- a/packages/use-intl/src/core/formatters.tsx
+++ b/packages/use-intl/src/core/formatters.tsx
@@ -1,5 +1,5 @@
-import {Cache, memoize, strategies} from '@formatjs/fast-memoize';
-import {type IntlMessageFormat} from 'intl-messageformat';
+import {type Cache, memoize, strategies} from '@formatjs/fast-memoize';
+import type {IntlMessageFormat} from 'intl-messageformat';
 
 export type IntlCache = {
   dateTime: Record<string, Intl.DateTimeFormat>;

--- a/packages/use-intl/src/core/formatters.tsx
+++ b/packages/use-intl/src/core/formatters.tsx
@@ -1,5 +1,5 @@
 import {Cache, memoize, strategies} from '@formatjs/fast-memoize';
-import type IntlMessageFormat from 'intl-messageformat';
+import {type IntlMessageFormat} from 'intl-messageformat';
 
 export type IntlCache = {
   dateTime: Record<string, Intl.DateTimeFormat>;

--- a/packages/use-intl/src/core/index.tsx
+++ b/packages/use-intl/src/core/index.tsx
@@ -1,20 +1,20 @@
-export type {default as AbstractIntlMessages} from './AbstractIntlMessages';
+export type {default as AbstractIntlMessages} from './AbstractIntlMessages.tsx';
 export type {
   default as TranslationValues,
   RichTranslationValues,
   MarkupTranslationValues
-} from './TranslationValues';
-export type {default as Formats} from './Formats';
-export type {default as IntlConfig} from './IntlConfig';
-export type {default as DateTimeFormatOptions} from './DateTimeFormatOptions';
-export type {default as NumberFormatOptions} from './NumberFormatOptions';
-export {default as IntlError, IntlErrorCode} from './IntlError';
-export {default as createTranslator} from './createTranslator';
-export {default as createFormatter} from './createFormatter';
-export {default as initializeConfig} from './initializeConfig';
-export type {default as MessageKeys} from './utils/MessageKeys';
-export type {default as NamespaceKeys} from './utils/NamespaceKeys';
-export type {default as NestedKeyOf} from './utils/NestedKeyOf';
-export type {default as NestedValueOf} from './utils/NestedValueOf';
-export {createIntlFormatters as _createIntlFormatters} from './formatters';
-export {createCache as _createCache} from './formatters';
+} from './TranslationValues.tsx';
+export type {default as Formats} from './Formats.tsx';
+export type {default as IntlConfig} from './IntlConfig.tsx';
+export type {default as DateTimeFormatOptions} from './DateTimeFormatOptions.tsx';
+export type {default as NumberFormatOptions} from './NumberFormatOptions.tsx';
+export {default as IntlError, IntlErrorCode} from './IntlError.tsx';
+export {default as createTranslator} from './createTranslator.tsx';
+export {default as createFormatter} from './createFormatter.tsx';
+export {default as initializeConfig} from './initializeConfig.tsx';
+export type {default as MessageKeys} from './utils/MessageKeys.tsx';
+export type {default as NamespaceKeys} from './utils/NamespaceKeys.tsx';
+export type {default as NestedKeyOf} from './utils/NestedKeyOf.tsx';
+export type {default as NestedValueOf} from './utils/NestedValueOf.tsx';
+export {createIntlFormatters as _createIntlFormatters} from './formatters.tsx';
+export {createCache as _createCache} from './formatters.tsx';

--- a/packages/use-intl/src/core/initializeConfig.tsx
+++ b/packages/use-intl/src/core/initializeConfig.tsx
@@ -1,6 +1,6 @@
-import IntlConfig from './IntlConfig';
-import {defaultGetMessageFallback, defaultOnError} from './defaults';
-import validateMessages from './validateMessages';
+import IntlConfig from './IntlConfig.tsx';
+import {defaultGetMessageFallback, defaultOnError} from './defaults.tsx';
+import validateMessages from './validateMessages.tsx';
 
 /**
  * Enhances the incoming props with defaults.

--- a/packages/use-intl/src/core/utils/MessageKeys.tsx
+++ b/packages/use-intl/src/core/utils/MessageKeys.tsx
@@ -1,4 +1,4 @@
-import NestedValueOf from './NestedValueOf';
+import NestedValueOf from './NestedValueOf.tsx';
 
 type MessageKeys<ObjectType, Keys extends string> = {
   [Property in Keys]: NestedValueOf<ObjectType, Property> extends string

--- a/packages/use-intl/src/core/utils/NamespaceKeys.tsx
+++ b/packages/use-intl/src/core/utils/NamespaceKeys.tsx
@@ -1,4 +1,4 @@
-import NestedValueOf from './NestedValueOf';
+import NestedValueOf from './NestedValueOf.tsx';
 
 type NamespaceKeys<ObjectType, Keys extends string> = {
   [Property in Keys]: NestedValueOf<ObjectType, Property> extends string

--- a/packages/use-intl/src/core/validateMessages.tsx
+++ b/packages/use-intl/src/core/validateMessages.tsx
@@ -1,6 +1,6 @@
-import AbstractIntlMessages from './AbstractIntlMessages';
-import IntlError, {IntlErrorCode} from './IntlError';
-import joinPath from './joinPath';
+import AbstractIntlMessages from './AbstractIntlMessages.tsx';
+import IntlError, {IntlErrorCode} from './IntlError.tsx';
+import joinPath from './joinPath.tsx';
 
 function validateMessagesSegment(
   messages: AbstractIntlMessages,

--- a/packages/use-intl/src/index.tsx
+++ b/packages/use-intl/src/index.tsx
@@ -1,2 +1,2 @@
-export * from './core';
-export * from './react';
+export * from './core.tsx';
+export * from './react.tsx';

--- a/packages/use-intl/src/react.tsx
+++ b/packages/use-intl/src/react.tsx
@@ -1,1 +1,1 @@
-export * from './react/index';
+export * from './react/index.tsx';

--- a/packages/use-intl/src/react/IntlContext.tsx
+++ b/packages/use-intl/src/react/IntlContext.tsx
@@ -1,6 +1,6 @@
 import {createContext} from 'react';
-import type {InitializedIntlConfig} from '../core/IntlConfig';
-import type {Formatters, IntlCache} from '../core/formatters';
+import type {InitializedIntlConfig} from '../core/IntlConfig.tsx';
+import type {Formatters, IntlCache} from '../core/formatters.tsx';
 
 export type IntlContextValue = InitializedIntlConfig & {
   formatters: Formatters;

--- a/packages/use-intl/src/react/IntlProvider.test.tsx
+++ b/packages/use-intl/src/react/IntlProvider.test.tsx
@@ -1,9 +1,9 @@
 import {fireEvent, render, screen} from '@testing-library/react';
 import React, {memo, useState} from 'react';
 import {expect, it, vi} from 'vitest';
-import IntlProvider from './IntlProvider';
-import useNow from './useNow';
-import useTranslations from './useTranslations';
+import IntlProvider from './IntlProvider.tsx';
+import useNow from './useNow.tsx';
+import useTranslations from './useTranslations.tsx';
 
 it("doesn't re-render context consumers unnecessarily", () => {
   const messages = {StaticText: {hello: 'Hello!'}};

--- a/packages/use-intl/src/react/IntlProvider.test.tsx
+++ b/packages/use-intl/src/react/IntlProvider.test.tsx
@@ -1,5 +1,5 @@
 import {fireEvent, render, screen} from '@testing-library/react';
-import React, {memo, useState} from 'react';
+import {memo, useState} from 'react';
 import {expect, it, vi} from 'vitest';
 import IntlProvider from './IntlProvider.tsx';
 import useNow from './useNow.tsx';

--- a/packages/use-intl/src/react/IntlProvider.tsx
+++ b/packages/use-intl/src/react/IntlProvider.tsx
@@ -1,4 +1,4 @@
-import React, {ReactNode, useContext, useMemo} from 'react';
+import {ReactNode, useContext, useMemo} from 'react';
 import IntlConfig from '../core/IntlConfig.tsx';
 import {
   Formatters,

--- a/packages/use-intl/src/react/IntlProvider.tsx
+++ b/packages/use-intl/src/react/IntlProvider.tsx
@@ -1,12 +1,12 @@
 import React, {ReactNode, useContext, useMemo} from 'react';
-import IntlConfig from '../core/IntlConfig';
+import IntlConfig from '../core/IntlConfig.tsx';
 import {
   Formatters,
   createCache,
   createIntlFormatters
-} from '../core/formatters';
-import initializeConfig from '../core/initializeConfig';
-import IntlContext from './IntlContext';
+} from '../core/formatters.tsx';
+import initializeConfig from '../core/initializeConfig.tsx';
+import IntlContext from './IntlContext.tsx';
 
 type Props = IntlConfig & {
   children: ReactNode;

--- a/packages/use-intl/src/react/index.test.tsx
+++ b/packages/use-intl/src/react/index.test.tsx
@@ -1,6 +1,5 @@
 import {render, screen} from '@testing-library/react';
 import {parseISO} from 'date-fns';
-import React from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import IntlProvider from './IntlProvider.tsx';
 import useFormatter from './useFormatter.tsx';

--- a/packages/use-intl/src/react/index.test.tsx
+++ b/packages/use-intl/src/react/index.test.tsx
@@ -2,10 +2,10 @@ import {render, screen} from '@testing-library/react';
 import {parseISO} from 'date-fns';
 import React from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import IntlProvider from './IntlProvider';
-import useFormatter from './useFormatter';
-import useNow from './useNow';
-import useTranslations from './useTranslations';
+import IntlProvider from './IntlProvider.tsx';
+import useFormatter from './useFormatter.tsx';
+import useNow from './useNow.tsx';
+import useTranslations from './useTranslations.tsx';
 
 describe('performance', () => {
   beforeEach(() => {

--- a/packages/use-intl/src/react/index.tsx
+++ b/packages/use-intl/src/react/index.tsx
@@ -1,7 +1,7 @@
-export {default as IntlProvider} from './IntlProvider';
-export {default as useTranslations} from './useTranslations';
-export {default as useLocale} from './useLocale';
-export {default as useNow} from './useNow';
-export {default as useTimeZone} from './useTimeZone';
-export {default as useMessages} from './useMessages';
-export {default as useFormatter} from './useFormatter';
+export {default as IntlProvider} from './IntlProvider.tsx';
+export {default as useTranslations} from './useTranslations.tsx';
+export {default as useLocale} from './useLocale.tsx';
+export {default as useNow} from './useNow.tsx';
+export {default as useTimeZone} from './useTimeZone.tsx';
+export {default as useMessages} from './useMessages.tsx';
+export {default as useFormatter} from './useFormatter.tsx';

--- a/packages/use-intl/src/react/useFormatter.test.tsx
+++ b/packages/use-intl/src/react/useFormatter.test.tsx
@@ -3,9 +3,9 @@ import {parseISO} from 'date-fns';
 import React, {ComponentProps, ReactElement, ReactNode} from 'react';
 import {SpyImpl, spyOn} from 'tinyspy';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {IntlError, IntlErrorCode} from '../core';
-import IntlProvider from './IntlProvider';
-import useFormatter from './useFormatter';
+import {IntlError, IntlErrorCode} from '../core.tsx';
+import IntlProvider from './IntlProvider.tsx';
+import useFormatter from './useFormatter.tsx';
 
 function MockProvider(
   props: Partial<ComponentProps<typeof IntlProvider>> & {children: ReactNode}

--- a/packages/use-intl/src/react/useFormatter.test.tsx
+++ b/packages/use-intl/src/react/useFormatter.test.tsx
@@ -1,6 +1,6 @@
 import {render, screen} from '@testing-library/react';
 import {parseISO} from 'date-fns';
-import React, {ComponentProps, ReactElement, ReactNode} from 'react';
+import {ComponentProps, ReactElement, ReactNode} from 'react';
 import {SpyImpl, spyOn} from 'tinyspy';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {IntlError, IntlErrorCode} from '../core.tsx';

--- a/packages/use-intl/src/react/useFormatter.tsx
+++ b/packages/use-intl/src/react/useFormatter.tsx
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
-import createFormatter from '../core/createFormatter';
-import useIntlContext from './useIntlContext';
+import createFormatter from '../core/createFormatter.tsx';
+import useIntlContext from './useIntlContext.tsx';
 
 export default function useFormatter(): ReturnType<typeof createFormatter> {
   const {

--- a/packages/use-intl/src/react/useIntlContext.tsx
+++ b/packages/use-intl/src/react/useIntlContext.tsx
@@ -1,5 +1,5 @@
 import {useContext} from 'react';
-import IntlContext, {IntlContextValue} from './IntlContext';
+import IntlContext, {IntlContextValue} from './IntlContext.tsx';
 
 export default function useIntlContext(): IntlContextValue {
   const context = useContext(IntlContext);

--- a/packages/use-intl/src/react/useLocale.test.tsx
+++ b/packages/use-intl/src/react/useLocale.test.tsx
@@ -1,5 +1,4 @@
 import {render, screen} from '@testing-library/react';
-import React from 'react';
 import {it} from 'vitest';
 import IntlProvider from './IntlProvider.tsx';
 import useLocale from './useLocale.tsx';

--- a/packages/use-intl/src/react/useLocale.test.tsx
+++ b/packages/use-intl/src/react/useLocale.test.tsx
@@ -1,8 +1,8 @@
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {it} from 'vitest';
-import IntlProvider from './IntlProvider';
-import useLocale from './useLocale';
+import IntlProvider from './IntlProvider.tsx';
+import useLocale from './useLocale.tsx';
 
 it('returns the current locale', () => {
   function Component() {

--- a/packages/use-intl/src/react/useLocale.tsx
+++ b/packages/use-intl/src/react/useLocale.tsx
@@ -1,4 +1,4 @@
-import useIntlContext from './useIntlContext';
+import useIntlContext from './useIntlContext.tsx';
 
 export default function useLocale() {
   return useIntlContext().locale;

--- a/packages/use-intl/src/react/useMessages.test.tsx
+++ b/packages/use-intl/src/react/useMessages.test.tsx
@@ -1,8 +1,8 @@
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {expect, it} from 'vitest';
-import IntlProvider from './IntlProvider';
-import useMessages from './useMessages';
+import IntlProvider from './IntlProvider.tsx';
+import useMessages from './useMessages.tsx';
 
 function Component() {
   const messages = useMessages();

--- a/packages/use-intl/src/react/useMessages.test.tsx
+++ b/packages/use-intl/src/react/useMessages.test.tsx
@@ -1,5 +1,4 @@
 import {render, screen} from '@testing-library/react';
-import React from 'react';
 import {expect, it} from 'vitest';
 import IntlProvider from './IntlProvider.tsx';
 import useMessages from './useMessages.tsx';

--- a/packages/use-intl/src/react/useMessages.tsx
+++ b/packages/use-intl/src/react/useMessages.tsx
@@ -1,5 +1,5 @@
-import {AbstractIntlMessages} from '../core';
-import useIntlContext from './useIntlContext';
+import {AbstractIntlMessages} from '../core.tsx';
+import useIntlContext from './useIntlContext.tsx';
 
 export default function useMessages(): AbstractIntlMessages {
   const context = useIntlContext();

--- a/packages/use-intl/src/react/useNow.test.tsx
+++ b/packages/use-intl/src/react/useNow.test.tsx
@@ -1,6 +1,5 @@
 import {render, waitFor} from '@testing-library/react';
 import {parseISO} from 'date-fns';
-import React from 'react';
 import {expect, it} from 'vitest';
 import IntlProvider from './IntlProvider.tsx';
 import useNow from './useNow.tsx';

--- a/packages/use-intl/src/react/useNow.test.tsx
+++ b/packages/use-intl/src/react/useNow.test.tsx
@@ -2,8 +2,8 @@ import {render, waitFor} from '@testing-library/react';
 import {parseISO} from 'date-fns';
 import React from 'react';
 import {expect, it} from 'vitest';
-import IntlProvider from './IntlProvider';
-import useNow from './useNow';
+import IntlProvider from './IntlProvider.tsx';
+import useNow from './useNow.tsx';
 
 it('returns the current time', () => {
   function Component() {

--- a/packages/use-intl/src/react/useNow.tsx
+++ b/packages/use-intl/src/react/useNow.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useState} from 'react';
-import useIntlContext from './useIntlContext';
+import useIntlContext from './useIntlContext.tsx';
 
 type Options = {
   updateInterval?: number;

--- a/packages/use-intl/src/react/useTimeZone.test.tsx
+++ b/packages/use-intl/src/react/useTimeZone.test.tsx
@@ -1,5 +1,4 @@
 import {render, screen} from '@testing-library/react';
-import React from 'react';
 import {expect, it} from 'vitest';
 import IntlProvider from './IntlProvider.tsx';
 import useTimeZone from './useTimeZone.tsx';

--- a/packages/use-intl/src/react/useTimeZone.test.tsx
+++ b/packages/use-intl/src/react/useTimeZone.test.tsx
@@ -1,8 +1,8 @@
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {expect, it} from 'vitest';
-import IntlProvider from './IntlProvider';
-import useTimeZone from './useTimeZone';
+import IntlProvider from './IntlProvider.tsx';
+import useTimeZone from './useTimeZone.tsx';
 
 it('returns the time zone when it is configured', () => {
   function Component() {

--- a/packages/use-intl/src/react/useTimeZone.tsx
+++ b/packages/use-intl/src/react/useTimeZone.tsx
@@ -1,4 +1,4 @@
-import useIntlContext from './useIntlContext';
+import useIntlContext from './useIntlContext.tsx';
 
 export default function useTimeZone() {
   return useIntlContext().timeZone;

--- a/packages/use-intl/src/react/useTranslations.test.tsx
+++ b/packages/use-intl/src/react/useTranslations.test.tsx
@@ -1,7 +1,7 @@
 import {render, renderHook, screen} from '@testing-library/react';
 import {parseISO} from 'date-fns';
 import {IntlMessageFormat} from 'intl-messageformat';
-import React, {ComponentProps, PropsWithChildren, ReactNode} from 'react';
+import {ComponentProps, PropsWithChildren, ReactNode} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   Formats,

--- a/packages/use-intl/src/react/useTranslations.test.tsx
+++ b/packages/use-intl/src/react/useTranslations.test.tsx
@@ -9,9 +9,9 @@ import {
   IntlErrorCode,
   RichTranslationValues,
   TranslationValues
-} from '../core';
-import IntlProvider from './IntlProvider';
-import useTranslations from './useTranslations';
+} from '../core.tsx';
+import IntlProvider from './IntlProvider.tsx';
+import useTranslations from './useTranslations.tsx';
 
 // Wrap the library to include a counter for parse
 // invocations for the cache test below.

--- a/packages/use-intl/src/react/useTranslations.test.tsx
+++ b/packages/use-intl/src/react/useTranslations.test.tsx
@@ -1,6 +1,6 @@
 import {render, renderHook, screen} from '@testing-library/react';
 import {parseISO} from 'date-fns';
-import IntlMessageFormat from 'intl-messageformat';
+import {IntlMessageFormat} from 'intl-messageformat';
 import React, {ComponentProps, PropsWithChildren, ReactNode} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {

--- a/packages/use-intl/src/react/useTranslations.test.tsx
+++ b/packages/use-intl/src/react/useTranslations.test.tsx
@@ -18,10 +18,10 @@ import useTranslations from './useTranslations.tsx';
 vi.mock('intl-messageformat', async (importOriginal) => {
   const ActualIntlMessageFormat: typeof IntlMessageFormat = (
     (await importOriginal()) as any
-  ).default;
+  ).IntlMessageFormat;
 
   return {
-    default: class MockIntlMessageFormat extends ActualIntlMessageFormat {
+    IntlMessageFormat: class MockIntlMessageFormat extends ActualIntlMessageFormat {
       public static invocationsByMessage: Record<string, number> = {};
 
       constructor(
@@ -1081,10 +1081,10 @@ describe('performance', () => {
     vi.mock('intl-messageformat', async (original) => {
       const ActualIntlMessageFormat: typeof IntlMessageFormat = (
         (await original()) as any
-      ).default;
+      ).IntlMessageFormat;
 
       return {
-        default: class MockIntlMessageFormatImpl extends ActualIntlMessageFormat {
+        IntlMessageFormat: class MockIntlMessageFormatImpl extends ActualIntlMessageFormat {
           public static invocationsByMessage: Record<string, number> = {};
 
           constructor(

--- a/packages/use-intl/src/react/useTranslations.tsx
+++ b/packages/use-intl/src/react/useTranslations.tsx
@@ -1,15 +1,15 @@
 import {ReactNode} from 'react';
-import Formats from '../core/Formats';
+import Formats from '../core/Formats.tsx';
 import TranslationValues, {
   MarkupTranslationValues,
   RichTranslationValues
-} from '../core/TranslationValues';
-import MessageKeys from '../core/utils/MessageKeys';
-import NamespaceKeys from '../core/utils/NamespaceKeys';
-import NestedKeyOf from '../core/utils/NestedKeyOf';
-import NestedValueOf from '../core/utils/NestedValueOf';
-import useIntlContext from './useIntlContext';
-import useTranslationsImpl from './useTranslationsImpl';
+} from '../core/TranslationValues.tsx';
+import MessageKeys from '../core/utils/MessageKeys.tsx';
+import NamespaceKeys from '../core/utils/NamespaceKeys.tsx';
+import NestedKeyOf from '../core/utils/NestedKeyOf.tsx';
+import NestedValueOf from '../core/utils/NestedValueOf.tsx';
+import useIntlContext from './useIntlContext.tsx';
+import useTranslationsImpl from './useTranslationsImpl.tsx';
 
 /**
  * Translates messages from the given namespace by using the ICU syntax.

--- a/packages/use-intl/src/react/useTranslationsImpl.tsx
+++ b/packages/use-intl/src/react/useTranslationsImpl.tsx
@@ -1,10 +1,10 @@
 import {useMemo} from 'react';
-import {IntlError, IntlErrorCode} from '../core';
-import AbstractIntlMessages from '../core/AbstractIntlMessages';
-import createBaseTranslator from '../core/createBaseTranslator';
-import resolveNamespace from '../core/resolveNamespace';
-import NestedKeyOf from '../core/utils/NestedKeyOf';
-import useIntlContext from './useIntlContext';
+import AbstractIntlMessages from '../core/AbstractIntlMessages.tsx';
+import createBaseTranslator from '../core/createBaseTranslator.tsx';
+import resolveNamespace from '../core/resolveNamespace.tsx';
+import NestedKeyOf from '../core/utils/NestedKeyOf.tsx';
+import {IntlError, IntlErrorCode} from '../core.tsx';
+import useIntlContext from './useIntlContext.tsx';
 
 let hasWarnedForMissingTimezone = false;
 const isServer = typeof window === 'undefined';

--- a/packages/use-intl/tsconfig.build.json
+++ b/packages/use-intl/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.tsx", "test", "src/react/**/*.tsx"],
+  "exclude": ["src/**/*.test.tsx", "test"],
   "compilerOptions": {
     "rootDir": "src",
     "noEmit": false,

--- a/packages/use-intl/tsconfig.build.json
+++ b/packages/use-intl/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.tsx", "test", "src/react/**/*.tsx"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": false,
+    "outDir": "dist/types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/use-intl/tsconfig.json
+++ b/packages/use-intl/tsconfig.json
@@ -9,7 +9,7 @@
     "rootDir": ".",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "skipLibCheck": true,
     "noEmit": true
   }

--- a/packages/use-intl/tsconfig.json
+++ b/packages/use-intl/tsconfig.json
@@ -1,24 +1,15 @@
 {
+  "extends": "eslint-config-molindo/tsconfig.json",
   "include": ["src", "test", "types"],
   "compilerOptions": {
-    "module": "esnext",
     "lib": ["dom", "esnext"],
     "target": "ES2020",
-    "importHelpers": false,
     "declaration": true,
-    "sourceMap": true,
     "rootDir": ".",
-    "strict": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "jsx": "react",
-    "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": false,
-    "outDir": "dist"
+    "noEmit": true
   }
 }

--- a/packages/use-intl/tsconfig.json
+++ b/packages/use-intl/tsconfig.json
@@ -7,8 +7,8 @@
     "target": "ES2020",
     "declaration": true,
     "rootDir": ".",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "jsx": "react",
     "skipLibCheck": true,
     "noEmit": true

--- a/packages/use-intl/tsconfig.json
+++ b/packages/use-intl/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "eslint-config-molindo/tsconfig.json",
   "include": ["src", "test", "types"],
   "compilerOptions": {
+    "allowImportingTsExtensions": true, // For ESM
     "lib": ["dom", "esnext"],
     "target": "ES2020",
     "declaration": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -795,8 +795,8 @@ importers:
         version: link:../use-intl
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.3
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@edge-runtime/vm':
         specifier: ^3.2.0
         version: 3.2.0
@@ -871,8 +871,8 @@ importers:
         version: 10.7.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.3
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@size-limit/preset-small-lib':
         specifier: ^11.1.4
         version: 11.1.6(size-limit@11.1.6)
@@ -1039,13 +1039,13 @@ packages:
   '@antfu/utils@0.7.10':
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
 
-  '@arethetypeswrong/cli@0.15.4':
-    resolution: {integrity: sha512-YDbImAi1MGkouT7f2yAECpUMFhhA1J0EaXzIqoC5GGtK0xDgauLtcsZezm8tNq7d3wOFXH7OnY+IORYcG212rw==}
+  '@arethetypeswrong/cli@0.16.4':
+    resolution: {integrity: sha512-qMmdVlJon5FtA+ahn0c1oAVNxiq4xW5lqFiTZ21XHIeVwAVIQ+uRz4UEivqRMsjVV1grzRgJSKqaOrq1MvlVyQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  '@arethetypeswrong/core@0.15.1':
-    resolution: {integrity: sha512-FYp6GBAgsNz81BkfItRz8RLZO03w5+BaeiPma1uCfmxTnxbtuMrI/dbzGiOk8VghO108uFI0oJo0OkewdSHw7g==}
+  '@arethetypeswrong/core@0.16.4':
+    resolution: {integrity: sha512-RI3HXgSuKTfcBf1hSEg1P9/cOvmI0flsMm6/QL3L3wju4AlHDqd55JFPfXs4pzgEAgy5L9pul4/HPPz99x2GvA==}
     engines: {node: '>=18'}
 
   '@babel/code-frame@7.10.4':
@@ -13473,9 +13473,6 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
-  ts-expose-internals-conditionally@1.0.0-empty.0:
-    resolution: {integrity: sha512-F8m9NOF6ZhdOClDVdlM8gj3fDCav4ZIFSs/EI3ksQbAAXVSCN/Jh5OCJDDZWBuBy9psFc6jULGDlPwjMYMhJDw==}
-
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -13641,8 +13638,8 @@ packages:
       typescript:
         optional: true
 
-  typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+  typescript@5.6.1-rc:
+    resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -14771,9 +14768,9 @@ snapshots:
 
   '@antfu/utils@0.7.10': {}
 
-  '@arethetypeswrong/cli@0.15.4':
+  '@arethetypeswrong/cli@0.16.4':
     dependencies:
-      '@arethetypeswrong/core': 0.15.1
+      '@arethetypeswrong/core': 0.16.4
       chalk: 4.1.2
       cli-table3: 0.6.5
       commander: 10.0.1
@@ -14781,13 +14778,14 @@ snapshots:
       marked-terminal: 7.1.0(marked@9.1.6)
       semver: 7.6.3
 
-  '@arethetypeswrong/core@0.15.1':
+  '@arethetypeswrong/core@0.16.4':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
+      cjs-module-lexer: 1.4.1
       fflate: 0.8.2
+      lru-cache: 10.4.3
       semver: 7.6.3
-      ts-expose-internals-conditionally: 1.0.0-empty.0
-      typescript: 5.3.3
+      typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
 
   '@babel/code-frame@7.10.4':
@@ -31139,8 +31137,6 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-expose-internals-conditionally@1.0.0-empty.0: {}
-
   ts-interface-checker@0.1.13: {}
 
   ts-pnp@1.2.0(typescript@5.6.3):
@@ -31304,7 +31300,7 @@ snapshots:
       - eslint
       - supports-color
 
-  typescript@5.3.3: {}
+  typescript@5.6.1-rc: {}
 
   typescript@5.6.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@rollup/plugin-babel':
         specifier: ^6.0.3
         version: 6.0.4(@babel/core@7.25.9)(@types/babel__core@7.20.5)(rollup@4.24.0)
-      '@rollup/plugin-commonjs':
-        specifier: ^26.0.1
-        version: 26.0.3(rollup@4.24.0)
       '@rollup/plugin-node-resolve':
         specifier: ^15.2.1
         version: 15.3.0(rollup@4.24.0)
@@ -876,7 +873,7 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.15.3
         version: 0.15.4
-      '@size-limit/preset-big-lib':
+      '@size-limit/preset-small-lib':
         specifier: ^11.1.4
         version: 11.1.6(size-limit@11.1.6)
       '@testing-library/react':
@@ -2017,6 +2014,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.24.0':
+    resolution: {integrity: sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.17.6':
     resolution: {integrity: sha512-YnYSCceN/dUzUr5kdtUzB+wZprCafuD89Hs0Aqv9QSdwhYQybhXTaSTcrl6X/aWThn1a/j0eEpUBGOE7269REg==}
     engines: {node: '>=12'}
@@ -2037,6 +2040,12 @@ packages:
 
   '@esbuild/android-arm64@0.23.1':
     resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.24.0':
+    resolution: {integrity: sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -2065,6 +2074,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.24.0':
+    resolution: {integrity: sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.17.6':
     resolution: {integrity: sha512-MVcYcgSO7pfu/x34uX9u2QIZHmXAB7dEiLQC5bBl5Ryqtpj9lT2sg3gNDEsrPEmimSJW2FXIaxqSQ501YLDsZQ==}
     engines: {node: '>=12'}
@@ -2085,6 +2100,12 @@ packages:
 
   '@esbuild/android-x64@0.23.1':
     resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.24.0':
+    resolution: {integrity: sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -2113,6 +2134,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.24.0':
+    resolution: {integrity: sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.17.6':
     resolution: {integrity: sha512-xh2A5oPrYRfMFz74QXIQTQo8uA+hYzGWJFoeTE8EvoZGHb+idyV4ATaukaUvnnxJiauhs/fPx3vYhU4wiGfosg==}
     engines: {node: '>=12'}
@@ -2133,6 +2160,12 @@ packages:
 
   '@esbuild/darwin-x64@0.23.1':
     resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.0':
+    resolution: {integrity: sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -2161,6 +2194,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.24.0':
+    resolution: {integrity: sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.17.6':
     resolution: {integrity: sha512-Uh3HLWGzH6FwpviUcLMKPCbZUAFzv67Wj5MTwK6jn89b576SR2IbEp+tqUHTr8DIl0iDmBAf51MVaP7pw6PY5Q==}
     engines: {node: '>=12'}
@@ -2181,6 +2220,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.23.1':
     resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.0':
+    resolution: {integrity: sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -2209,6 +2254,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.24.0':
+    resolution: {integrity: sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.17.6':
     resolution: {integrity: sha512-7YdGiurNt7lqO0Bf/U9/arrPWPqdPqcV6JCZda4LZgEn+PTQ5SMEI4MGR52Bfn3+d6bNEGcWFzlIxiQdS48YUw==}
     engines: {node: '>=12'}
@@ -2229,6 +2280,12 @@ packages:
 
   '@esbuild/linux-arm@0.23.1':
     resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.0':
+    resolution: {integrity: sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -2257,6 +2314,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.24.0':
+    resolution: {integrity: sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.17.6':
     resolution: {integrity: sha512-y2NX1+X/Nt+izj9bLoiaYB9YXT/LoaQFYvCkVD77G/4F+/yuVXYCWz4SE9yr5CBMbOxOfBcy/xFL4LlOeNlzYQ==}
     engines: {node: '>=12'}
@@ -2277,6 +2340,12 @@ packages:
 
   '@esbuild/linux-loong64@0.23.1':
     resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.0':
+    resolution: {integrity: sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -2305,6 +2374,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.24.0':
+    resolution: {integrity: sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.17.6':
     resolution: {integrity: sha512-AmLhMzkM8JuqTIOhxnX4ubh0XWJIznEynRnZAVdA2mMKE6FAfwT2TWKTwdqMG+qEaeyDPtfNoZRpJbD4ZBv0Tg==}
     engines: {node: '>=12'}
@@ -2325,6 +2400,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.23.1':
     resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.0':
+    resolution: {integrity: sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2353,6 +2434,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.24.0':
+    resolution: {integrity: sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.17.6':
     resolution: {integrity: sha512-SPUiz4fDbnNEm3JSdUW8pBJ/vkop3M1YwZAVwvdwlFLoJwKEZ9L98l3tzeyMzq27CyepDQ3Qgoba44StgbiN5Q==}
     engines: {node: '>=12'}
@@ -2373,6 +2460,12 @@ packages:
 
   '@esbuild/linux-s390x@0.23.1':
     resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.0':
+    resolution: {integrity: sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2401,6 +2494,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.24.0':
+    resolution: {integrity: sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-x64@0.17.6':
     resolution: {integrity: sha512-EanJqcU/4uZIBreTrnbnre2DXgXSa+Gjap7ifRfllpmyAU7YMvaXmljdArptTHmjrkkKm9BK6GH5D5Yo+p6y5A==}
     engines: {node: '>=12'}
@@ -2425,8 +2524,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.24.0':
+    resolution: {integrity: sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.23.1':
     resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.24.0':
+    resolution: {integrity: sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2455,6 +2566,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.24.0':
+    resolution: {integrity: sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/sunos-x64@0.17.6':
     resolution: {integrity: sha512-gnMnMPg5pfMkZvhHee21KbKdc6W3GR8/JuE0Da1kjwpK6oiFU3nqfHuVPgUX2rsOx9N2SadSQTIYV1CIjYG+xw==}
     engines: {node: '>=12'}
@@ -2475,6 +2592,12 @@ packages:
 
   '@esbuild/sunos-x64@0.23.1':
     resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.24.0':
+    resolution: {integrity: sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -2503,6 +2626,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.24.0':
+    resolution: {integrity: sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.17.6':
     resolution: {integrity: sha512-96yEFzLhq5bv9jJo5JhTs1gI+1cKQ83cUpyxHuGqXVwQtY5Eq54ZEsKs8veKtiKwlrNimtckHEkj4mRh4pPjsg==}
     engines: {node: '>=12'}
@@ -2527,6 +2656,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.24.0':
+    resolution: {integrity: sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.17.6':
     resolution: {integrity: sha512-n6d8MOyUrNp6G4VSpRcgjs5xj4A91svJSaiwLIDWVWEsZtpN5FA9NlBbZHDmAJc2e8e6SF4tkBD3HAvPF+7igA==}
     engines: {node: '>=12'}
@@ -2547,6 +2682,12 @@ packages:
 
   '@esbuild/win32-x64@0.23.1':
     resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.0':
+    resolution: {integrity: sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2595,7 +2736,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.4.11':
     resolution: {integrity: sha512-L9Ci9RBh0aPFEDF1AjDYPk54OgeUJIKzxF3lRgITm+lQpI3IEKjAc9LaYeQeO1mlZMUQmPkHArF8iyz1eOeVoQ==}
@@ -4063,15 +4204,6 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/plugin-commonjs@26.0.3':
-    resolution: {integrity: sha512-2BJcolt43MY+y5Tz47djHkodCC3c1VKVrBDKpVqHKpQ9z9S158kCCqB8NF6/gzxLdNlYW9abB3Ibh+kOWLp8KQ==}
-    engines: {node: '>=16.0.0 || 14 >= 14.17'}
-    peerDependencies:
-      rollup: ^2.68.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@rollup/plugin-node-resolve@15.3.0':
     resolution: {integrity: sha512-9eO5McEICxMzJpDW9OnMYSv4Sta3hmt7VtBFz5zR9273suNOydOyq/FrGeGy+KsTRFm8w0SLVhzig2ILFT63Ag==}
     engines: {node: '>=14.0.0'}
@@ -4283,6 +4415,12 @@ packages:
     resolution: {integrity: sha512-dNZafjM93Y+F+sfwTO5gTpsGXlnc/0Q+c2+62ViqP3gkMWvHEMSKkaEHgVJLcLg3i/g19GSIPziiKpgyne07Bw==}
     engines: {node: '>=8'}
 
+  '@size-limit/esbuild@11.1.6':
+    resolution: {integrity: sha512-0nBKYSxeRjUVCVoCkWZbmGkGBwpm0HdwHedWgxksBGxTKU0PjOMSHc3XTjKOrXBKXQzw90Ue0mgOd4n6zct9SA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      size-limit: 11.1.6
+
   '@size-limit/file@11.1.6':
     resolution: {integrity: sha512-ojzzJMrTfcSECRnaTjGy0wNIolTCRdyqZTSWG9sG5XEoXG6PNgHXDDS6gf6YNxnqb+rWfCfVe93u6aKi3wEocQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4291,6 +4429,11 @@ packages:
 
   '@size-limit/preset-big-lib@11.1.6':
     resolution: {integrity: sha512-GE93qIW9C3+8MXOsYgV0QcLfKv6B+Q8u/Jjb5rLfetDHBKoZV7HmedM/bv0vrbdcZlT8elk5P18Jo6L6yeV/8Q==}
+    peerDependencies:
+      size-limit: 11.1.6
+
+  '@size-limit/preset-small-lib@11.1.6':
+    resolution: {integrity: sha512-hlmkBlOryJIsKlGpS61Ti7/EEZomygAzOabpo2htdxUbkCkvtVoUQpGWHUfWuxdhheDVF6rtZZ6lPGftMKlaQg==}
     peerDependencies:
       size-limit: 11.1.6
 
@@ -4545,8 +4688,8 @@ packages:
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
 
-  '@types/express-serve-static-core@5.0.0':
-    resolution: {integrity: sha512-AbXMTZGt40T+KON9/Fdxx0B2WK5hsgxcfXJLr5bFpZ7b4JCex2WyQPTEKdXqfHiY5nKKBScZ7yCoO6Pvgxfvnw==}
+  '@types/express-serve-static-core@5.0.1':
+    resolution: {integrity: sha512-CRICJIl0N5cXDONAdlTv5ShATZ4HEwk6kDDIW2/w9qOWKg+NU/5F8wYRWCrONad0/UKkloNSmmyN/wX4rtpbVA==}
 
   '@types/express@4.17.21':
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
@@ -4634,6 +4777,9 @@ packages:
 
   '@types/node@20.17.0':
     resolution: {integrity: sha512-a7zRo0f0eLo9K5X9Wp5cAqTUNGzuFLDG2R7C4HY2BhcMAsxgSPuRvAC1ZB6QkuUQXf0YZAgfOX2ZyrBa2n4nHQ==}
+
+  '@types/node@20.17.1':
+    resolution: {integrity: sha512-j2VlPv1NnwPJbaCNv69FO/1z4lId0QmGvpT41YxitRtWlg96g/j8qcv2RKsLKe2F6OJgyXhupN1Xo17b2m139Q==}
 
   '@types/node@22.7.9':
     resolution: {integrity: sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==}
@@ -7308,6 +7454,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.24.0:
+    resolution: {integrity: sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -9062,9 +9213,6 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-
-  is-reference@1.2.1:
-    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
@@ -13404,11 +13552,11 @@ packages:
     resolution: {integrity: sha512-TARUb7z1pGvlLxgPk++7wJ6aycXF3GJ0sNSBTAsTuJrQG5QuZlkUQP+zl+nbjAh4gMX9yDw9ZYklMd7vAfJKEw==}
     engines: {node: '>=0.10.0'}
 
-  tldts-core@6.1.54:
-    resolution: {integrity: sha512-5cc42+0G0EjYRDfIJHKraaT3I5kPm7j6or3Zh1T9sF+Ftj1T+isT4thicUyQQ1bwN7/xjHQIuY2fXCoXP8Haqg==}
+  tldts-core@6.1.55:
+    resolution: {integrity: sha512-BL+BuKHHaOpntE5BGI6naXjULU6aRlgaYdfDHR3T/hdbNTWkWUZ9yuc11wGnwgpvRwlyUiIK+QohYK3olaVU6Q==}
 
-  tldts@6.1.54:
-    resolution: {integrity: sha512-rDaL1t59gb/Lg0HPMUGdV1vAKLQcXwU74D26aMaYV4QW7mnMvShd1Vmkg3HYAPWx2JCTUmsrXt/Yl9eJ5UFBQw==}
+  tldts@6.1.55:
+    resolution: {integrity: sha512-HxQR/9roQ07Pwc8RyyrJMAxRz5/ssoF3qIPPUiIo3zUt6yMdmYZjM2OZIFMiZ3jHyz9jrGHEHuQZrUhoc1LkDw==}
     hasBin: true
 
   tmp@0.0.33:
@@ -14962,7 +15110,7 @@ snapshots:
       '@babel/core': 7.25.9
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -16031,6 +16179,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.23.1':
     optional: true
 
+  '@esbuild/aix-ppc64@0.24.0':
+    optional: true
+
   '@esbuild/android-arm64@0.17.6':
     optional: true
 
@@ -16041,6 +16192,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.0':
     optional: true
 
   '@esbuild/android-arm@0.17.6':
@@ -16055,6 +16209,9 @@ snapshots:
   '@esbuild/android-arm@0.23.1':
     optional: true
 
+  '@esbuild/android-arm@0.24.0':
+    optional: true
+
   '@esbuild/android-x64@0.17.6':
     optional: true
 
@@ -16065,6 +16222,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.23.1':
+    optional: true
+
+  '@esbuild/android-x64@0.24.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.17.6':
@@ -16079,6 +16239,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.23.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.24.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.17.6':
     optional: true
 
@@ -16089,6 +16252,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.17.6':
@@ -16103,6 +16269,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.23.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.24.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.17.6':
     optional: true
 
@@ -16113,6 +16282,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.0':
     optional: true
 
   '@esbuild/linux-arm64@0.17.6':
@@ -16127,6 +16299,9 @@ snapshots:
   '@esbuild/linux-arm64@0.23.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.24.0':
+    optional: true
+
   '@esbuild/linux-arm@0.17.6':
     optional: true
 
@@ -16137,6 +16312,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.0':
     optional: true
 
   '@esbuild/linux-ia32@0.17.6':
@@ -16151,6 +16329,9 @@ snapshots:
   '@esbuild/linux-ia32@0.23.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.24.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.17.6':
     optional: true
 
@@ -16161,6 +16342,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.17.6':
@@ -16175,6 +16359,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.23.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.24.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.17.6':
     optional: true
 
@@ -16185,6 +16372,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.17.6':
@@ -16199,6 +16389,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.23.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.24.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.17.6':
     optional: true
 
@@ -16209,6 +16402,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.23.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.0':
     optional: true
 
   '@esbuild/linux-x64@0.17.6':
@@ -16223,6 +16419,9 @@ snapshots:
   '@esbuild/linux-x64@0.23.1':
     optional: true
 
+  '@esbuild/linux-x64@0.24.0':
+    optional: true
+
   '@esbuild/netbsd-x64@0.17.6':
     optional: true
 
@@ -16235,7 +16434,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.23.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.24.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.24.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.17.6':
@@ -16250,6 +16455,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.24.0':
+    optional: true
+
   '@esbuild/sunos-x64@0.17.6':
     optional: true
 
@@ -16260,6 +16468,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.23.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.24.0':
     optional: true
 
   '@esbuild/win32-arm64@0.17.6':
@@ -16274,6 +16485,9 @@ snapshots:
   '@esbuild/win32-arm64@0.23.1':
     optional: true
 
+  '@esbuild/win32-arm64@0.24.0':
+    optional: true
+
   '@esbuild/win32-ia32@0.17.6':
     optional: true
 
@@ -16286,6 +16500,9 @@ snapshots:
   '@esbuild/win32-ia32@0.23.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.24.0':
+    optional: true
+
   '@esbuild/win32-x64@0.17.6':
     optional: true
 
@@ -16296,6 +16513,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@9.13.0(jiti@2.3.3))':
@@ -17695,7 +17915,7 @@ snapshots:
       lru-cache: 10.4.3
       npm-pick-manifest: 9.1.0
       proc-log: 4.2.0
-      promise-inflight: 1.0.1(bluebird@3.7.2)
+      promise-inflight: 1.0.1
       promise-retry: 2.0.1
       semver: 7.6.3
       which: 4.0.0
@@ -18562,17 +18782,6 @@ snapshots:
       '@types/babel__core': 7.20.5
       rollup: 4.24.0
 
-  '@rollup/plugin-commonjs@26.0.3(rollup@4.24.0)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.24.0)
-      commondir: 1.0.1
-      estree-walker: 2.0.2
-      glob: 10.4.5
-      is-reference: 1.2.1
-      magic-string: 0.30.12
-    optionalDependencies:
-      rollup: 4.24.0
-
   '@rollup/plugin-node-resolve@15.3.0(rollup@4.24.0)':
     dependencies:
       '@rollup/pluginutils': 5.0.5(rollup@4.24.0)
@@ -18772,6 +18981,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@size-limit/esbuild@11.1.6(size-limit@11.1.6)':
+    dependencies:
+      esbuild: 0.24.0
+      nanoid: 5.0.7
+      size-limit: 11.1.6
+
   '@size-limit/file@11.1.6(size-limit@11.1.6)':
     dependencies:
       size-limit: 11.1.6
@@ -18790,6 +19005,12 @@ snapshots:
       - uglify-js
       - utf-8-validate
       - webpack-cli
+
+  '@size-limit/preset-small-lib@11.1.6(size-limit@11.1.6)':
+    dependencies:
+      '@size-limit/esbuild': 11.1.6(size-limit@11.1.6)
+      '@size-limit/file': 11.1.6(size-limit@11.1.6)
+      size-limit: 11.1.6
 
   '@size-limit/time@11.1.6(size-limit@11.1.6)':
     dependencies:
@@ -19178,13 +19399,13 @@ snapshots:
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 20.17.0
+      '@types/node': 20.17.1
     optional: true
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
-      '@types/express-serve-static-core': 5.0.0
-      '@types/node': 20.17.0
+      '@types/express-serve-static-core': 5.0.1
+      '@types/node': 20.17.1
     optional: true
 
   '@types/connect@3.4.38':
@@ -19220,9 +19441,9 @@ snapshots:
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
 
-  '@types/express-serve-static-core@5.0.0':
+  '@types/express-serve-static-core@5.0.1':
     dependencies:
-      '@types/node': 20.17.0
+      '@types/node': 20.17.1
       '@types/qs': 6.9.16
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -19260,7 +19481,7 @@ snapshots:
 
   '@types/http-proxy@1.17.15':
     dependencies:
-      '@types/node': 20.17.0
+      '@types/node': 20.17.1
     optional: true
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -19318,12 +19539,17 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 20.17.0
+      '@types/node': 20.17.1
     optional: true
 
   '@types/node@20.17.0':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/node@20.17.1':
+    dependencies:
+      undici-types: 6.19.8
+    optional: true
 
   '@types/node@22.7.9':
     dependencies:
@@ -19377,7 +19603,7 @@ snapshots:
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 20.17.0
+      '@types/node': 20.17.1
     optional: true
 
   '@types/source-list-map@0.1.6': {}
@@ -19413,7 +19639,7 @@ snapshots:
 
   '@types/webpack@5.28.5(esbuild@0.23.1)':
     dependencies:
-      '@types/node': 20.17.0
+      '@types/node': 20.17.1
       tapable: 2.2.1
       webpack: 5.95.0(esbuild@0.23.1)
     transitivePeerDependencies:
@@ -19425,7 +19651,7 @@ snapshots:
 
   '@types/ws@8.5.12':
     dependencies:
-      '@types/node': 20.17.0
+      '@types/node': 20.17.1
     optional: true
 
   '@types/yargs-parser@21.0.3': {}
@@ -20078,7 +20304,7 @@ snapshots:
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -22101,6 +22327,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.3.7(supports-color@6.1.0):
     dependencies:
       ms: 2.1.3
@@ -22743,6 +22973,33 @@ snapshots:
       '@esbuild/win32-arm64': 0.23.1
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
+
+  esbuild@0.24.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.0
+      '@esbuild/android-arm': 0.24.0
+      '@esbuild/android-arm64': 0.24.0
+      '@esbuild/android-x64': 0.24.0
+      '@esbuild/darwin-arm64': 0.24.0
+      '@esbuild/darwin-x64': 0.24.0
+      '@esbuild/freebsd-arm64': 0.24.0
+      '@esbuild/freebsd-x64': 0.24.0
+      '@esbuild/linux-arm': 0.24.0
+      '@esbuild/linux-arm64': 0.24.0
+      '@esbuild/linux-ia32': 0.24.0
+      '@esbuild/linux-loong64': 0.24.0
+      '@esbuild/linux-mips64el': 0.24.0
+      '@esbuild/linux-ppc64': 0.24.0
+      '@esbuild/linux-riscv64': 0.24.0
+      '@esbuild/linux-s390x': 0.24.0
+      '@esbuild/linux-x64': 0.24.0
+      '@esbuild/netbsd-x64': 0.24.0
+      '@esbuild/openbsd-arm64': 0.24.0
+      '@esbuild/openbsd-x64': 0.24.0
+      '@esbuild/sunos-x64': 0.24.0
+      '@esbuild/win32-arm64': 0.24.0
+      '@esbuild/win32-ia32': 0.24.0
+      '@esbuild/win32-x64': 0.24.0
 
   escalade@3.2.0: {}
 
@@ -24685,7 +24942,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -24734,7 +24991,7 @@ snapshots:
   https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -25123,10 +25380,6 @@ snapshots:
   is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
-
-  is-reference@1.2.1:
-    dependencies:
-      '@types/estree': 1.0.6
 
   is-reference@3.0.2:
     dependencies:
@@ -29108,6 +29361,8 @@ snapshots:
 
   promise-call-limit@3.0.1: {}
 
+  promise-inflight@1.0.1: {}
+
   promise-inflight@1.0.1(bluebird@3.7.2):
     optionalDependencies:
       bluebird: 3.7.2
@@ -30549,7 +30804,7 @@ snapshots:
   socks-proxy-agent@8.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -31277,12 +31532,12 @@ snapshots:
 
   titleize@1.0.0: {}
 
-  tldts-core@6.1.54:
+  tldts-core@6.1.55:
     optional: true
 
-  tldts@6.1.54:
+  tldts@6.1.55:
     dependencies:
-      tldts-core: 6.1.54
+      tldts-core: 6.1.55
     optional: true
 
   tmp@0.0.33:
@@ -31328,7 +31583,7 @@ snapshots:
 
   tough-cookie@5.0.0:
     dependencies:
-      tldts: 6.1.54
+      tldts: 6.1.55
     optional: true
 
   tr46@0.0.3: {}
@@ -31403,7 +31658,7 @@ snapshots:
   tuf-js@2.2.1:
     dependencies:
       '@tufjs/models': 2.0.1
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
       make-fetch-happen: 13.0.1
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,45 +11,15 @@ importers:
 
   .:
     devDependencies:
-      '@babel/core':
-        specifier: ^7.24.7
-        version: 7.25.9
-      '@babel/preset-env':
-        specifier: ^7.24.7
-        version: 7.25.9(@babel/core@7.25.9)
-      '@babel/preset-react':
-        specifier: ^7.24.7
-        version: 7.25.9(@babel/core@7.25.9)
-      '@babel/preset-typescript':
-        specifier: ^7.24.7
-        version: 7.25.9(@babel/core@7.25.9)
       '@lerna-lite/cli':
         specifier: ^3.9.0
         version: 3.10.0(@lerna-lite/publish@3.10.0(@types/node@22.7.9)(typescript@5.6.3))(@lerna-lite/version@3.10.0(@lerna-lite/publish@3.10.0(@types/node@22.7.9)(typescript@5.6.3))(@types/node@22.7.9)(typescript@5.6.3))(@types/node@22.7.9)(typescript@5.6.3)
       '@lerna-lite/publish':
         specifier: ^3.9.0
         version: 3.10.0(@types/node@22.7.9)(typescript@5.6.3)
-      '@rollup/plugin-babel':
-        specifier: ^6.0.3
-        version: 6.0.4(@babel/core@7.25.9)(@types/babel__core@7.20.5)(rollup@4.24.0)
-      '@rollup/plugin-node-resolve':
-        specifier: ^15.2.1
-        version: 15.3.0(rollup@4.24.0)
-      '@rollup/plugin-replace':
-        specifier: ^5.0.7
-        version: 5.0.7(rollup@4.24.0)
-      '@rollup/plugin-terser':
-        specifier: ^0.4.3
-        version: 0.4.4(rollup@4.24.0)
       conventional-changelog-conventionalcommits:
         specifier: ^7.0.0
         version: 7.0.2
-      execa:
-        specifier: ^9.2.0
-        version: 9.4.1
-      rollup:
-        specifier: ^4.18.0
-        version: 4.24.0
       turbo:
         specifier: ^2.2.3
         version: 2.2.3
@@ -70,13 +40,13 @@ importers:
         version: 2.1.5(react@18.3.1)
       '@vercel/analytics':
         specifier: 1.3.1
-        version: 1.3.1(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 1.3.1(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@vercel/og':
         specifier: ^0.6.3
         version: 0.6.3
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.13(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 1.0.13(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -88,10 +58,10 @@ importers:
         version: 14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nextra:
         specifier: ^3.1.0
-        version: 3.1.0(@types/react@18.3.12)(acorn@8.13.0)(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        version: 3.1.0(@types/react@18.3.12)(acorn@8.13.0)(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       nextra-theme-docs:
         specifier: ^3.1.0
-        version: 3.1.0(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.1.0(@types/react@18.3.12)(acorn@8.13.0)(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.1.0(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.1.0(@types/react@18.3.12)(acorn@8.13.0)(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -128,7 +98,7 @@ importers:
         version: 15.11.0
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.2.3(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -293,7 +263,7 @@ importers:
         version: 14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.7
-        version: 4.24.8(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.8(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-intl:
         specifier: ^3.0.0
         version: link:../../packages/next-intl
@@ -641,7 +611,7 @@ importers:
     dependencies:
       next:
         specifier: ^12.0.0
-        version: 12.3.4(@babel/core@7.25.9)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 12.3.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react:
         specifier: ^17.0.0
         version: 17.0.2
@@ -854,6 +824,9 @@ importers:
       size-limit:
         specifier: ^11.1.4
         version: 11.1.6
+      tools:
+        specifier: workspace:^
+        version: link:../../tools
       typescript:
         specifier: ^5.5.3
         version: 5.6.3
@@ -921,12 +894,57 @@ importers:
       tinyspy:
         specifier: ^3.0.0
         version: 3.0.2
+      tools:
+        specifier: workspace:^
+        version: link:../../tools
       typescript:
         specifier: ^5.5.3
         version: 5.6.3
       vitest:
         specifier: ^2.0.2
         version: 2.1.3(@edge-runtime/vm@4.0.3)(@types/node@20.17.0)(jsdom@25.0.1)(terser@5.36.0)
+
+  tools:
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.24.7
+        version: 7.25.9
+      '@babel/preset-env':
+        specifier: ^7.24.7
+        version: 7.25.9(@babel/core@7.25.9)
+      '@babel/preset-react':
+        specifier: ^7.24.7
+        version: 7.25.9(@babel/core@7.25.9)
+      '@babel/preset-typescript':
+        specifier: ^7.24.7
+        version: 7.25.9(@babel/core@7.25.9)
+      '@rollup/plugin-babel':
+        specifier: ^6.0.3
+        version: 6.0.4(@babel/core@7.25.9)(@types/babel__core@7.20.5)(rollup@4.24.0)
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.2.1
+        version: 15.3.0(rollup@4.24.0)
+      '@rollup/plugin-replace':
+        specifier: ^5.0.7
+        version: 5.0.7(rollup@4.24.0)
+      '@rollup/plugin-terser':
+        specifier: ^0.4.3
+        version: 0.4.4(rollup@4.24.0)
+      eslint:
+        specifier: ^9.11.1
+        version: 9.13.0(jiti@2.3.3)
+      eslint-config-molindo:
+        specifier: ^8.0.0
+        version: 8.0.0(@typescript-eslint/eslint-plugin@8.11.0(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(jest@29.7.0(@types/node@22.7.9))(tailwindcss@3.4.14)(typescript@5.6.3)(vitest@2.1.3(@edge-runtime/vm@4.0.3)(@types/node@22.7.9)(jsdom@25.0.1)(terser@5.36.0))
+      execa:
+        specifier: ^9.2.0
+        version: 9.4.1
+      globals:
+        specifier: ^15.11.0
+        version: 15.11.0
+      rollup:
+        specifier: ^4.18.0
+        version: 4.24.0
 
 packages:
 
@@ -1075,10 +1093,6 @@ packages:
     resolution: {integrity: sha512-omlUGkr5EaoIJrhLf9CJ0TvjBRpd9+AXRG//0GEQ9THSo8wPiTlbpy1/Ow8ZTrbXpjd9FHXfbFQx32I04ht0FA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-annotate-as-pure@7.24.7':
-    resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-annotate-as-pure@7.25.9':
     resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
     engines: {node: '>=6.9.0'}
@@ -1093,12 +1107,6 @@ packages:
 
   '@babel/helper-create-class-features-plugin@7.25.9':
     resolution: {integrity: sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-create-regexp-features-plugin@7.24.7':
-    resolution: {integrity: sha512-03TCmXy2FtXJEZfbXDTSqq1fRJArk7lX9DOFC/47VthYcxyIOx+eXQmdo6DOQvrbpIix+KfXwvuXdFDZHxt+rA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1128,10 +1136,6 @@ packages:
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.22.5':
-    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.25.9':
@@ -1893,9 +1897,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-
-  '@babel/regjsgen@0.8.0':
-    resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
 
   '@babel/runtime@7.24.7':
     resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
@@ -3171,9 +3172,6 @@ packages:
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/source-map@0.3.5':
-    resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
-
   '@jridgewell/source-map@0.3.6':
     resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
 
@@ -4217,15 +4215,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
-  '@rollup/pluginutils@5.0.5':
-    resolution: {integrity: sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -8902,9 +8891,6 @@ packages:
   is-color-stop@1.1.0:
     resolution: {integrity: sha512-H1U8Vz0cfXNujrJzEcvvwMDW9Ra+biSYA3ThdQvAnMLJkEHQXn6bWzLkxHtVYJ+Sdbx0b6finn3jZiaVe7MAHA==}
 
-  is-core-module@2.12.0:
-    resolution: {integrity: sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==}
-
   is-core-module@2.13.1:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
 
@@ -12105,10 +12091,6 @@ packages:
     resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
     engines: {node: '>= 0.4'}
 
-  regenerate-unicode-properties@10.1.0:
-    resolution: {integrity: sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==}
-    engines: {node: '>=4'}
-
   regenerate-unicode-properties@10.2.0:
     resolution: {integrity: sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==}
     engines: {node: '>=4'}
@@ -12143,10 +12125,6 @@ packages:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
 
-  regexpu-core@5.3.2:
-    resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
-    engines: {node: '>=4'}
-
   regexpu-core@6.1.1:
     resolution: {integrity: sha512-k67Nb9jvwJcJmVpw0jPttR1/zVfnKf8Km0IPatrU/zJ5XeG3+Slx0xLXs9HByJSzXzrlz5EDvN6yLNMDc2qdnw==}
     engines: {node: '>=4'}
@@ -12167,10 +12145,6 @@ packages:
 
   regjsparser@0.11.1:
     resolution: {integrity: sha512-1DHODs4B8p/mQHU9kr+jv8+wIC9mtG4eBHxWxIq5mhjE3D5oORhCc6deRKzTjs9DcfRFmj9BHSDguZklqCGFWQ==}
-    hasBin: true
-
-  regjsparser@0.9.1:
-    resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
     hasBin: true
 
   rehype-katex@7.0.1:
@@ -12320,10 +12294,6 @@ packages:
   resolve.exports@2.0.2:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
     engines: {node: '>=10'}
-
-  resolve@1.22.2:
-    resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
-    hasBin: true
 
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
@@ -12589,9 +12559,6 @@ packages:
 
   serialize-javascript@4.0.0:
     resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
-
-  serialize-javascript@6.0.1:
-    resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
@@ -13288,11 +13255,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  terser@5.18.2:
-    resolution: {integrity: sha512-Ah19JS86ypbJzTzvUCX7KOsEIhDaRONungA4aYBjEP3JZRf4ocuDzTg4QWZnPn9DEMiMYGJPiSOy7aykoCc70w==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   terser@5.36.0:
     resolution: {integrity: sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==}
     engines: {node: '>=10'}
@@ -13688,10 +13650,6 @@ packages:
 
   unicode-match-property-ecmascript@2.0.0:
     resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
-    engines: {node: '>=4'}
-
-  unicode-match-property-value-ecmascript@2.1.0:
-    resolution: {integrity: sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==}
     engines: {node: '>=4'}
 
   unicode-match-property-value-ecmascript@2.2.0:
@@ -14854,10 +14812,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.0.2
 
-  '@babel/helper-annotate-as-pure@7.24.7':
-    dependencies:
-      '@babel/types': 7.25.9
-
   '@babel/helper-annotate-as-pure@7.25.9':
     dependencies:
       '@babel/types': 7.25.9
@@ -14889,13 +14843,6 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/helper-create-regexp-features-plugin@7.24.7(@babel/core@7.25.9)':
-    dependencies:
-      '@babel/core': 7.25.9
-      '@babel/helper-annotate-as-pure': 7.24.7
-      regexpu-core: 5.3.2
-      semver: 6.3.1
 
   '@babel/helper-create-regexp-features-plugin@7.25.9(@babel/core@7.25.9)':
     dependencies:
@@ -14934,10 +14881,6 @@ snapshots:
       '@babel/types': 7.25.9
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/helper-module-imports@7.22.5':
-    dependencies:
-      '@babel/types': 7.25.9
 
   '@babel/helper-module-imports@7.25.9':
     dependencies:
@@ -15291,7 +15234,7 @@ snapshots:
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.25.9)':
     dependencies:
       '@babel/core': 7.25.9
-      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.25.9)
+      '@babel/helper-create-regexp-features-plugin': 7.25.9(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-arrow-functions@7.25.9(@babel/core@7.25.9)':
@@ -15848,8 +15791,6 @@ snapshots:
       make-dir: 2.1.0
       pirates: 4.0.6
       source-map-support: 0.5.21
-
-  '@babel/regjsgen@0.8.0': {}
 
   '@babel/runtime@7.24.7':
     dependencies:
@@ -17171,11 +17112,6 @@ snapshots:
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/set-array@1.2.1': {}
-
-  '@jridgewell/source-map@0.3.5':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/source-map@0.3.6':
     dependencies:
@@ -18549,19 +18485,21 @@ snapshots:
   '@rollup/plugin-babel@6.0.4(@babel/core@7.25.9)(@types/babel__core@7.20.5)(rollup@4.24.0)':
     dependencies:
       '@babel/core': 7.25.9
-      '@babel/helper-module-imports': 7.22.5
-      '@rollup/pluginutils': 5.0.5(rollup@4.24.0)
+      '@babel/helper-module-imports': 7.25.9
+      '@rollup/pluginutils': 5.1.0(rollup@4.24.0)
     optionalDependencies:
       '@types/babel__core': 7.20.5
       rollup: 4.24.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@rollup/plugin-node-resolve@15.3.0(rollup@4.24.0)':
     dependencies:
-      '@rollup/pluginutils': 5.0.5(rollup@4.24.0)
+      '@rollup/pluginutils': 5.1.0(rollup@4.24.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
-      resolve: 1.22.2
+      resolve: 1.22.8
     optionalDependencies:
       rollup: 4.24.0
 
@@ -18574,17 +18512,9 @@ snapshots:
 
   '@rollup/plugin-terser@0.4.4(rollup@4.24.0)':
     dependencies:
-      serialize-javascript: 6.0.1
+      serialize-javascript: 6.0.2
       smob: 1.4.1
-      terser: 5.18.2
-    optionalDependencies:
-      rollup: 4.24.0
-
-  '@rollup/pluginutils@5.0.5(rollup@4.24.0)':
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
+      terser: 5.36.0
     optionalDependencies:
       rollup: 4.24.0
 
@@ -19655,7 +19585,7 @@ snapshots:
 
   '@vanilla-extract/private@1.0.3': {}
 
-  '@vercel/analytics@1.3.1(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/analytics@1.3.1(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
@@ -19668,7 +19598,7 @@ snapshots:
       satori: 0.10.9
       yoga-wasm-web: 0.3.3
 
-  '@vercel/speed-insights@1.0.13(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/speed-insights@1.0.13(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
       next: 14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -21456,7 +21386,7 @@ snapshots:
 
   core-js-compat@3.38.1:
     dependencies:
-      browserslist: 4.24.0
+      browserslist: 4.24.2
 
   core-js-pure@3.38.0: {}
 
@@ -24850,10 +24780,6 @@ snapshots:
       rgb-regex: 1.0.1
       rgba-regex: 1.0.0
 
-  is-core-module@2.12.0:
-    dependencies:
-      has: 1.0.3
-
   is-core-module@2.13.1:
     dependencies:
       hasown: 2.0.0
@@ -27534,7 +27460,7 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  next-auth@4.24.8(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-auth@4.24.8(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.24.7
       '@panva/hkdf': 1.2.0
@@ -27549,7 +27475,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       uuid: 8.3.2
 
-  next-sitemap@4.2.3(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  next-sitemap@4.2.3(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.6
@@ -27562,7 +27488,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@12.3.4(@babel/core@7.25.9)(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  next@12.3.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
     dependencies:
       '@next/env': 12.3.4
       '@swc/helpers': 0.4.11
@@ -27570,7 +27496,7 @@ snapshots:
       postcss: 8.4.14
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      styled-jsx: 5.0.7(@babel/core@7.25.9)(react@17.0.2)
+      styled-jsx: 5.0.7(react@17.0.2)
       use-sync-external-store: 1.2.0(react@17.0.2)
     optionalDependencies:
       '@next/swc-android-arm-eabi': 12.3.4
@@ -27616,7 +27542,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@3.1.0(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.1.0(@types/react@18.3.12)(acorn@8.13.0)(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  nextra-theme-docs@3.1.0(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.1.0(@types/react@18.3.12)(acorn@8.13.0)(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@headlessui/react': 2.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
@@ -27624,13 +27550,13 @@ snapshots:
       flexsearch: 0.7.43
       next: 14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      nextra: 3.1.0(@types/react@18.3.12)(acorn@8.13.0)(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      nextra: 3.1.0(@types/react@18.3.12)(acorn@8.13.0)(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       scroll-into-view-if-needed: 3.1.0
       zod: 3.23.8
 
-  nextra@3.1.0(@types/react@18.3.12)(acorn@8.13.0)(next@14.2.16(@babel/core@7.25.9)(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3):
+  nextra@3.1.0(@types/react@18.3.12)(acorn@8.13.0)(next@14.2.16(@playwright/test@1.48.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.5
       '@headlessui/react': 2.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -29482,10 +29408,6 @@ snapshots:
       globalthis: 1.0.4
       which-builtin-type: 1.1.3
 
-  regenerate-unicode-properties@10.1.0:
-    dependencies:
-      regenerate: 1.4.2
-
   regenerate-unicode-properties@10.2.0:
     dependencies:
       regenerate: 1.4.2
@@ -29518,15 +29440,6 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
-  regexpu-core@5.3.2:
-    dependencies:
-      '@babel/regjsgen': 0.8.0
-      regenerate: 1.4.2
-      regenerate-unicode-properties: 10.1.0
-      regjsparser: 0.9.1
-      unicode-match-property-ecmascript: 2.0.0
-      unicode-match-property-value-ecmascript: 2.1.0
-
   regexpu-core@6.1.1:
     dependencies:
       regenerate: 1.4.2
@@ -29554,10 +29467,6 @@ snapshots:
   regjsparser@0.11.1:
     dependencies:
       jsesc: 3.0.2
-
-  regjsparser@0.9.1:
-    dependencies:
-      jsesc: 0.5.0
 
   rehype-katex@7.0.1:
     dependencies:
@@ -29786,12 +29695,6 @@ snapshots:
   resolve-url@0.2.1: {}
 
   resolve.exports@2.0.2: {}
-
-  resolve@1.22.2:
-    dependencies:
-      is-core-module: 2.12.0
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
 
   resolve@1.22.8:
     dependencies:
@@ -30108,10 +30011,6 @@ snapshots:
       type-fest: 0.12.0
 
   serialize-javascript@4.0.0:
-    dependencies:
-      randombytes: 2.1.0
-
-  serialize-javascript@6.0.1:
     dependencies:
       randombytes: 2.1.0
 
@@ -30726,11 +30625,9 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.0.7(@babel/core@7.25.9)(react@17.0.2):
+  styled-jsx@5.0.7(react@17.0.2):
     dependencies:
       react: 17.0.2
-    optionalDependencies:
-      '@babel/core': 7.25.9
 
   styled-jsx@5.1.1(@babel/core@7.25.9)(react@18.3.1):
     dependencies:
@@ -30963,13 +30860,6 @@ snapshots:
       acorn: 8.13.0
       commander: 2.20.3
       source-map: 0.6.1
-      source-map-support: 0.5.21
-
-  terser@5.18.2:
-    dependencies:
-      '@jridgewell/source-map': 0.3.5
-      acorn: 8.12.0
-      commander: 2.20.3
       source-map-support: 0.5.21
 
   terser@5.36.0:
@@ -31337,8 +31227,6 @@ snapshots:
     dependencies:
       unicode-canonical-property-names-ecmascript: 2.0.0
       unicode-property-aliases-ecmascript: 2.1.0
-
-  unicode-match-property-value-ecmascript@2.1.0: {}
 
   unicode-match-property-value-ecmascript@2.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -800,7 +800,7 @@ importers:
       '@edge-runtime/vm':
         specifier: ^3.2.0
         version: 3.2.0
-      '@size-limit/preset-big-lib':
+      '@size-limit/preset-small-lib':
         specifier: ^11.1.4
         version: 11.1.6(size-limit@11.1.6)
       '@testing-library/react':
@@ -2736,7 +2736,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.4.11':
     resolution: {integrity: sha512-L9Ci9RBh0aPFEDF1AjDYPk54OgeUJIKzxF3lRgITm+lQpI3IEKjAc9LaYeQeO1mlZMUQmPkHArF8iyz1eOeVoQ==}
@@ -3708,16 +3708,6 @@ packages:
       webpack-plugin-serve:
         optional: true
 
-  '@puppeteer/browsers@2.2.2':
-    resolution: {integrity: sha512-hZ/JhxPIceWaGSEzUZp83/8M49CoxlkuThfTR7t4AoCu5+ZvJ3vktLm60Otww2TXeROB5igiZ8D9oPQh6ckBVg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@puppeteer/browsers@2.4.0':
-    resolution: {integrity: sha512-x8J1csfIygOwf6D6qUAZ0ASk3z63zPb7wkNeHRerCMh82qWKUrOgkuP005AJC8lDL6/evtXETGEJVcwykKT4/g==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
 
@@ -4411,10 +4401,6 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
-  '@sitespeed.io/tracium@0.3.3':
-    resolution: {integrity: sha512-dNZafjM93Y+F+sfwTO5gTpsGXlnc/0Q+c2+62ViqP3gkMWvHEMSKkaEHgVJLcLg3i/g19GSIPziiKpgyne07Bw==}
-    engines: {node: '>=8'}
-
   '@size-limit/esbuild@11.1.6':
     resolution: {integrity: sha512-0nBKYSxeRjUVCVoCkWZbmGkGBwpm0HdwHedWgxksBGxTKU0PjOMSHc3XTjKOrXBKXQzw90Ue0mgOd4n6zct9SA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4427,25 +4413,8 @@ packages:
     peerDependencies:
       size-limit: 11.1.6
 
-  '@size-limit/preset-big-lib@11.1.6':
-    resolution: {integrity: sha512-GE93qIW9C3+8MXOsYgV0QcLfKv6B+Q8u/Jjb5rLfetDHBKoZV7HmedM/bv0vrbdcZlT8elk5P18Jo6L6yeV/8Q==}
-    peerDependencies:
-      size-limit: 11.1.6
-
   '@size-limit/preset-small-lib@11.1.6':
     resolution: {integrity: sha512-hlmkBlOryJIsKlGpS61Ti7/EEZomygAzOabpo2htdxUbkCkvtVoUQpGWHUfWuxdhheDVF6rtZZ6lPGftMKlaQg==}
-    peerDependencies:
-      size-limit: 11.1.6
-
-  '@size-limit/time@11.1.6':
-    resolution: {integrity: sha512-NIlJEPvUIxw87gHjriHpPhvd9fIC94S9wq7OW25K7Ctn14FZ2NlOTezPCfVViPmdlXjBYdi8vjsbc7kLCF1EpA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    peerDependencies:
-      size-limit: 11.1.6
-
-  '@size-limit/webpack@11.1.6':
-    resolution: {integrity: sha512-PTZCgwJsgdzdEj2wPFuLm0cCge8N2WbswMcKWNwMJibxQxPAmiF+sZ2F6GYBS7G7K3Fb4ovCliuN+wnnRACPNg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       size-limit: 11.1.6
 
@@ -4616,9 +4585,6 @@ packages:
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
-
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
   '@tufjs/canonical-json@2.0.0':
     resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
@@ -4876,9 +4842,6 @@ packages:
 
   '@types/yargs@17.0.32':
     resolution: {integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==}
-
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.11.0':
     resolution: {integrity: sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==}
@@ -5596,10 +5559,6 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
-  ast-types@0.13.4:
-    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
-    engines: {node: '>=4'}
-
   ast-types@0.15.2:
     resolution: {integrity: sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==}
     engines: {node: '>=4'}
@@ -5658,9 +5617,6 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
-
-  b4a@1.6.7:
-    resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
 
   babel-core@7.0.0-bridge.0:
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
@@ -5750,21 +5706,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  bare-events@2.5.0:
-    resolution: {integrity: sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==}
-
-  bare-fs@2.3.5:
-    resolution: {integrity: sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==}
-
-  bare-os@2.4.4:
-    resolution: {integrity: sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==}
-
-  bare-path@2.1.3:
-    resolution: {integrity: sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==}
-
-  bare-stream@2.3.0:
-    resolution: {integrity: sha512-pVRWciewGUeCyKEuRxwv06M079r+fRjAQjBEK2P6OYGrO43O+Z0LrPZZEjlc4mB6C2RpZ9AxJ1s7NLEtOHO6eA==}
-
   base64-js@0.0.8:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
     engines: {node: '>= 0.4'}
@@ -5779,10 +5720,6 @@ packages:
   basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
-
-  basic-ftp@5.0.5:
-    resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
-    engines: {node: '>=10.0.0'}
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -5928,9 +5865,6 @@ packages:
 
   buffer-alloc@1.2.0:
     resolution: {integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==}
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-fill@1.0.0:
     resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
@@ -6154,11 +6088,6 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
-  chromium-bidi@0.5.17:
-    resolution: {integrity: sha512-BqOuIWUgTPj8ayuBFJUYCCuwIcwjBsb3/614P7tt1bEPJ4i1M0kCdIl0Wi9xhtswBXnfO2bTpTMkHD71H8rJMg==}
-    peerDependencies:
-      devtools-protocol: '*'
-
   ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
 
@@ -6339,10 +6268,6 @@ packages:
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
-
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
 
   commander@2.13.0:
     resolution: {integrity: sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==}
@@ -6904,10 +6829,6 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
-  data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
-
   data-urls@3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
@@ -6944,15 +6865,6 @@ packages:
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -7083,10 +6995,6 @@ packages:
     resolution: {integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==}
     engines: {node: '>=0.10.0'}
 
-  degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
-
   del@4.1.1:
     resolution: {integrity: sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==}
     engines: {node: '>=6'}
@@ -7149,9 +7057,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  devtools-protocol@0.0.1262051:
-    resolution: {integrity: sha512-YJe4CT5SA8on3Spa+UDtNhEqtuV6Epwz3OZ4HQVLhlRccpZ9/PAYk0/cy/oKxFKRrZPBUPyxympQci4yWNWZ9g==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -7664,11 +7569,6 @@ packages:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
 
-  estimo@3.0.3:
-    resolution: {integrity: sha512-qSibrDHo82yvmgeOW7onGgeOzS/nnqa8r2exQ8LyTSH8rAma10VBJE+hPSdukV1nQrqFvEz7BVe5puUK2LZJXg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   estraverse@4.3.0:
     resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
@@ -7877,16 +7777,8 @@ packages:
     resolution: {integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==}
     engines: {node: '>=0.10.0'}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-fifo@1.3.2:
-    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
@@ -7932,9 +7824,6 @@ packages:
 
   fbjs@3.0.4:
     resolution: {integrity: sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.4.0:
     resolution: {integrity: sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==}
@@ -8021,10 +7910,6 @@ packages:
   find-cache-dir@4.0.0:
     resolution: {integrity: sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==}
     engines: {node: '>=14.16'}
-
-  find-chrome-bin@2.0.2:
-    resolution: {integrity: sha512-KlggCilbbvgETk/WEq9NG894U8yu4erIW0SjMm1sMPm2xihCHeNoybpzGoxEzHRthwF3XrKOgHYtfqgJzpCH2w==}
-    engines: {node: '>=18.0.0'}
 
   find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
@@ -8282,10 +8167,6 @@ packages:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
     engines: {node: '>=6'}
 
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -8304,10 +8185,6 @@ packages:
 
   get-tsconfig@4.7.5:
     resolution: {integrity: sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==}
-
-  get-uri@6.0.3:
-    resolution: {integrity: sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==}
-    engines: {node: '>= 14'}
 
   get-value@2.0.6:
     resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
@@ -10537,9 +10414,6 @@ packages:
     resolution: {integrity: sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==}
     engines: {node: '>=4.0.0'}
 
-  mitt@3.0.1:
-    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
-
   mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
@@ -10663,10 +10537,6 @@ packages:
 
   nested-error-stacks@2.0.1:
     resolution: {integrity: sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==}
-
-  netmask@2.0.2:
-    resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
-    engines: {node: '>= 0.4.0'}
 
   new-github-release-url@2.0.0:
     resolution: {integrity: sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==}
@@ -11200,14 +11070,6 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  pac-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==}
-    engines: {node: '>= 14'}
-
-  pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
-
   package-json-from-dist@1.0.0:
     resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
 
@@ -11393,9 +11255,6 @@ packages:
 
   peek-stream@1.1.3:
     resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
-
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
@@ -11909,13 +11768,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-agent@6.4.0:
-    resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
-    engines: {node: '>= 14'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
 
@@ -11955,10 +11807,6 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  puppeteer-core@22.6.5:
-    resolution: {integrity: sha512-s0/5XkAWe0/dWISiljdrybjwDCHhgN31Nu/wznOZPKeikgcJtZtbvPKBz0t802XWqfSQnQDt3L6xiAE5JLlfuw==}
-    engines: {node: '>=18'}
-
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
@@ -11992,9 +11840,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  queue-tick@1.0.1:
-    resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
@@ -12716,11 +12561,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.6.0:
-    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.6.2:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
     engines: {node: '>=10'}
@@ -13100,9 +12940,6 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
-  streamx@2.20.1:
-    resolution: {integrity: sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==}
-
   string-hash@1.1.3:
     resolution: {integrity: sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==}
 
@@ -13378,18 +13215,9 @@ packages:
   tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
 
-  tar-fs@3.0.5:
-    resolution: {integrity: sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==}
-
-  tar-fs@3.0.6:
-    resolution: {integrity: sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==}
-
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
-
-  tar-stream@3.1.7:
-    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
@@ -13473,9 +13301,6 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
-
-  text-decoder@1.2.0:
-    resolution: {integrity: sha512-n1yg1mOj9DNpk3NeZOx7T6jchTbyJS3i3cucbNN6FcdPriMZx7NsgrGpWWdWZZGxD7ES1XB+3uoqHMgOKaN+fg==}
 
   text-extensions@2.4.0:
     resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
@@ -13849,9 +13674,6 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
-  unbzip2-stream@1.4.3:
-    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
-
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
@@ -14071,9 +13893,6 @@ packages:
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
     engines: {node: '>= 0.4'}
-
-  urlpattern-polyfill@10.0.0:
-    resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
 
   use-callback-ref@1.3.2:
     resolution: {integrity: sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==}
@@ -14651,18 +14470,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.16.0:
-    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
     engines: {node: '>=10.0.0'}
@@ -14786,9 +14593,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -14813,9 +14617,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.18.0
-
-  zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
@@ -15110,7 +14911,7 @@ snapshots:
       '@babel/core': 7.25.9
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@6.1.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -17915,7 +17716,7 @@ snapshots:
       lru-cache: 10.4.3
       npm-pick-manifest: 9.1.0
       proc-log: 4.2.0
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1(bluebird@3.7.2)
       promise-retry: 2.0.1
       semver: 7.6.3
       which: 4.0.0
@@ -18093,32 +17894,6 @@ snapshots:
       type-fest: 4.26.1
       webpack-dev-server: 5.1.0(webpack@5.95.0(esbuild@0.23.1))
       webpack-hot-middleware: 2.26.1
-
-  '@puppeteer/browsers@2.2.2':
-    dependencies:
-      debug: 4.3.4
-      extract-zip: 2.0.1
-      progress: 2.0.3
-      proxy-agent: 6.4.0
-      semver: 7.6.0
-      tar-fs: 3.0.5
-      unbzip2-stream: 1.4.3
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@puppeteer/browsers@2.4.0':
-    dependencies:
-      debug: 4.3.7(supports-color@6.1.0)
-      extract-zip: 2.0.1
-      progress: 2.0.3
-      proxy-agent: 6.4.0
-      semver: 7.6.3
-      tar-fs: 3.0.6
-      unbzip2-stream: 1.4.3
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@radix-ui/number@1.1.0': {}
 
@@ -18975,12 +18750,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@sitespeed.io/tracium@0.3.3':
-    dependencies:
-      debug: 4.3.7(supports-color@6.1.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@size-limit/esbuild@11.1.6(size-limit@11.1.6)':
     dependencies:
       esbuild: 0.24.0
@@ -18991,46 +18760,11 @@ snapshots:
     dependencies:
       size-limit: 11.1.6
 
-  '@size-limit/preset-big-lib@11.1.6(size-limit@11.1.6)':
-    dependencies:
-      '@size-limit/file': 11.1.6(size-limit@11.1.6)
-      '@size-limit/time': 11.1.6(size-limit@11.1.6)
-      '@size-limit/webpack': 11.1.6(size-limit@11.1.6)
-      size-limit: 11.1.6
-    transitivePeerDependencies:
-      - '@swc/core'
-      - bufferutil
-      - esbuild
-      - supports-color
-      - uglify-js
-      - utf-8-validate
-      - webpack-cli
-
   '@size-limit/preset-small-lib@11.1.6(size-limit@11.1.6)':
     dependencies:
       '@size-limit/esbuild': 11.1.6(size-limit@11.1.6)
       '@size-limit/file': 11.1.6(size-limit@11.1.6)
       size-limit: 11.1.6
-
-  '@size-limit/time@11.1.6(size-limit@11.1.6)':
-    dependencies:
-      estimo: 3.0.3
-      size-limit: 11.1.6
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@size-limit/webpack@11.1.6(size-limit@11.1.6)':
-    dependencies:
-      nanoid: 5.0.7
-      size-limit: 11.1.6
-      webpack: 5.95.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-      - webpack-cli
 
   '@storybook/builder-webpack5@8.3.6(esbuild@0.23.1)(storybook@8.3.6)(typescript@5.6.3)':
     dependencies:
@@ -19354,8 +19088,6 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
-
   '@tufjs/canonical-json@2.0.0': {}
 
   '@tufjs/models@2.0.1':
@@ -19667,11 +19399,6 @@ snapshots:
   '@types/yargs@17.0.32':
     dependencies:
       '@types/yargs-parser': 21.0.3
-
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 20.17.0
-    optional: true
 
   '@typescript-eslint/eslint-plugin@8.11.0(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
     dependencies:
@@ -20304,7 +20031,7 @@ snapshots:
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20591,10 +20318,6 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
-  ast-types@0.13.4:
-    dependencies:
-      tslib: 2.8.0
-
   ast-types@0.15.2:
     dependencies:
       tslib: 2.8.0
@@ -20650,8 +20373,6 @@ snapshots:
   axe-core@4.10.1: {}
 
   axobject-query@4.1.0: {}
-
-  b4a@1.6.7: {}
 
   babel-core@7.0.0-bridge.0(@babel/core@7.25.9):
     dependencies:
@@ -20831,30 +20552,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  bare-events@2.5.0:
-    optional: true
-
-  bare-fs@2.3.5:
-    dependencies:
-      bare-events: 2.5.0
-      bare-path: 2.1.3
-      bare-stream: 2.3.0
-    optional: true
-
-  bare-os@2.4.4:
-    optional: true
-
-  bare-path@2.1.3:
-    dependencies:
-      bare-os: 2.4.4
-    optional: true
-
-  bare-stream@2.3.0:
-    dependencies:
-      b4a: 1.6.7
-      streamx: 2.20.1
-    optional: true
-
   base64-js@0.0.8: {}
 
   base64-js@1.5.1: {}
@@ -20872,8 +20569,6 @@ snapshots:
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
-
-  basic-ftp@5.0.5: {}
 
   batch@0.6.1: {}
 
@@ -21082,8 +20777,6 @@ snapshots:
     dependencies:
       buffer-alloc-unsafe: 1.1.0
       buffer-fill: 1.0.0
-
-  buffer-crc32@0.2.13: {}
 
   buffer-fill@1.0.0: {}
 
@@ -21395,13 +21088,6 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
-  chromium-bidi@0.5.17(devtools-protocol@0.0.1262051):
-    dependencies:
-      devtools-protocol: 0.0.1262051
-      mitt: 3.0.1
-      urlpattern-polyfill: 10.0.0
-      zod: 3.22.4
-
   ci-info@2.0.0: {}
 
   ci-info@3.9.0: {}
@@ -21580,8 +21266,6 @@ snapshots:
   command-exists@1.2.9: {}
 
   commander@10.0.1: {}
-
-  commander@12.1.0: {}
 
   commander@2.13.0: {}
 
@@ -22271,8 +21955,6 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  data-uri-to-buffer@6.0.2: {}
-
   data-urls@3.0.2:
     dependencies:
       abab: 2.0.6
@@ -22319,17 +22001,9 @@ snapshots:
     optionalDependencies:
       supports-color: 6.1.0
 
-  debug@4.3.4:
-    dependencies:
-      ms: 2.1.2
-
   debug@4.3.5:
     dependencies:
       ms: 2.1.2
-
-  debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
 
   debug@4.3.7(supports-color@6.1.0):
     dependencies:
@@ -22448,12 +22122,6 @@ snapshots:
       is-descriptor: 1.0.3
       isobject: 3.0.1
 
-  degenerator@5.0.1:
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
-
   del@4.1.1:
     dependencies:
       '@types/glob': 7.2.0
@@ -22516,8 +22184,6 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
-
-  devtools-protocol@0.0.1262051: {}
 
   didyoumean@1.2.2: {}
 
@@ -23494,18 +23160,6 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  estimo@3.0.3:
-    dependencies:
-      '@sitespeed.io/tracium': 0.3.3
-      commander: 12.1.0
-      find-chrome-bin: 2.0.2
-      nanoid: 5.0.7
-      puppeteer-core: 22.6.5
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
@@ -23852,19 +23506,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.3.7(supports-color@6.1.0)
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fast-deep-equal@3.1.3: {}
-
-  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.2:
     dependencies:
@@ -23923,10 +23565,6 @@ snapshots:
       ua-parser-js: 0.7.35
     transitivePeerDependencies:
       - encoding
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.4.0(picomatch@4.0.2):
     optionalDependencies:
@@ -24026,12 +23664,6 @@ snapshots:
     dependencies:
       common-path-prefix: 3.0.0
       pkg-dir: 7.0.0
-
-  find-chrome-bin@2.0.2:
-    dependencies:
-      '@puppeteer/browsers': 2.4.0
-    transitivePeerDependencies:
-      - supports-color
 
   find-up@3.0.0:
     dependencies:
@@ -24303,10 +23935,6 @@ snapshots:
     dependencies:
       pump: 3.0.2
 
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.2
-
   get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
@@ -24325,15 +23953,6 @@ snapshots:
   get-tsconfig@4.7.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  get-uri@6.0.3:
-    dependencies:
-      basic-ftp: 5.0.5
-      data-uri-to-buffer: 6.0.2
-      debug: 4.3.7(supports-color@6.1.0)
-      fs-extra: 11.2.0
-    transitivePeerDependencies:
-      - supports-color
 
   get-value@2.0.6: {}
 
@@ -24942,7 +24561,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -24991,7 +24610,7 @@ snapshots:
   https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -27777,8 +27396,6 @@ snapshots:
       stream-each: 1.2.3
       through2: 2.0.5
 
-  mitt@3.0.1: {}
-
   mixin-deep@1.3.2:
     dependencies:
       for-in: 1.0.2
@@ -27914,8 +27531,6 @@ snapshots:
   neo-async@2.6.2: {}
 
   nested-error-stacks@2.0.1: {}
-
-  netmask@2.0.2: {}
 
   new-github-release-url@2.0.0:
     dependencies:
@@ -28600,24 +28215,6 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pac-proxy-agent@7.0.2:
-    dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.1
-      debug: 4.3.7(supports-color@6.1.0)
-      get-uri: 6.0.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.5
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.4
-    transitivePeerDependencies:
-      - supports-color
-
-  pac-resolver@7.0.1:
-    dependencies:
-      degenerator: 5.0.1
-      netmask: 2.0.2
-
   package-json-from-dist@1.0.0: {}
 
   package-manager-detector@0.2.2: {}
@@ -28833,8 +28430,6 @@ snapshots:
       buffer-from: 1.1.2
       duplexify: 3.7.1
       through2: 2.0.5
-
-  pend@1.2.0: {}
 
   periscopic@3.1.0:
     dependencies:
@@ -29361,8 +28956,6 @@ snapshots:
 
   promise-call-limit@3.0.1: {}
 
-  promise-inflight@1.0.1: {}
-
   promise-inflight@1.0.1(bluebird@3.7.2):
     optionalDependencies:
       bluebird: 3.7.2
@@ -29406,21 +28999,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-agent@6.4.0:
-    dependencies:
-      agent-base: 7.1.1
-      debug: 4.3.7(supports-color@6.1.0)
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.5
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.0.2
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.4
-    transitivePeerDependencies:
-      - supports-color
-
-  proxy-from-env@1.1.0: {}
 
   prr@1.0.1: {}
 
@@ -29470,18 +29048,6 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  puppeteer-core@22.6.5:
-    dependencies:
-      '@puppeteer/browsers': 2.2.2
-      chromium-bidi: 0.5.17(devtools-protocol@0.0.1262051)
-      debug: 4.3.4
-      devtools-protocol: 0.0.1262051
-      ws: 8.16.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   pure-rand@6.1.0: {}
 
   q@1.5.1: {}
@@ -29499,8 +29065,6 @@ snapshots:
   querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
-
-  queue-tick@1.0.1: {}
 
   queue@6.0.2:
     dependencies:
@@ -30499,10 +30063,6 @@ snapshots:
 
   semver@7.3.2: {}
 
-  semver@7.6.0:
-    dependencies:
-      lru-cache: 6.0.0
-
   semver@7.6.2: {}
 
   semver@7.6.3: {}
@@ -30804,7 +30364,7 @@ snapshots:
   socks-proxy-agent@8.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@6.1.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -31004,14 +30564,6 @@ snapshots:
   stream-slice@0.1.2: {}
 
   streamsearch@1.1.0: {}
-
-  streamx@2.20.1:
-    dependencies:
-      fast-fifo: 1.3.2
-      queue-tick: 1.0.1
-      text-decoder: 1.2.0
-    optionalDependencies:
-      bare-events: 2.5.0
 
   string-hash@1.1.3: {}
 
@@ -31318,22 +30870,6 @@ snapshots:
       pump: 3.0.0
       tar-stream: 2.2.0
 
-  tar-fs@3.0.5:
-    dependencies:
-      pump: 3.0.2
-      tar-stream: 3.1.7
-    optionalDependencies:
-      bare-fs: 2.3.5
-      bare-path: 2.1.3
-
-  tar-fs@3.0.6:
-    dependencies:
-      pump: 3.0.2
-      tar-stream: 3.1.7
-    optionalDependencies:
-      bare-fs: 2.3.5
-      bare-path: 2.1.3
-
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -31341,12 +30877,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-
-  tar-stream@3.1.7:
-    dependencies:
-      b4a: 1.6.7
-      fast-fifo: 1.3.2
-      streamx: 2.20.1
 
   tar@6.2.1:
     dependencies:
@@ -31430,15 +30960,6 @@ snapshots:
     optionalDependencies:
       esbuild: 0.23.1
 
-  terser-webpack-plugin@5.3.10(webpack@5.95.0):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.36.0
-      webpack: 5.95.0
-
   terser@4.8.1:
     dependencies:
       acorn: 8.13.0
@@ -31465,10 +30986,6 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
-
-  text-decoder@1.2.0:
-    dependencies:
-      b4a: 1.6.7
 
   text-extensions@2.4.0: {}
 
@@ -31658,7 +31175,7 @@ snapshots:
   tuf-js@2.2.1:
     dependencies:
       '@tufjs/models': 2.0.1
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@6.1.0)
       make-fetch-happen: 13.0.1
     transitivePeerDependencies:
       - supports-color
@@ -31811,11 +31328,6 @@ snapshots:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
-
-  unbzip2-stream@1.4.3:
-    dependencies:
-      buffer: 5.7.1
-      through: 2.3.8
 
   undici-types@6.19.8: {}
 
@@ -32068,8 +31580,6 @@ snapshots:
     dependencies:
       punycode: 1.4.1
       qs: 6.13.0
-
-  urlpattern-polyfill@10.0.0: {}
 
   use-callback-ref@1.3.2(@types/react@18.3.12)(react@18.3.1):
     dependencies:
@@ -32653,36 +32163,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  webpack@5.95.0:
-    dependencies:
-      '@types/estree': 1.0.6
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.13.0
-      acorn-import-attributes: 1.9.5(acorn@8.13.0)
-      browserslist: 4.24.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.1
-      es-module-lexer: 1.5.4
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.95.0)
-      watchpack: 2.4.2
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
   webpack@5.95.0(esbuild@0.23.1):
     dependencies:
       '@types/estree': 1.0.6
@@ -32899,8 +32379,6 @@ snapshots:
 
   ws@7.5.10: {}
 
-  ws@8.16.0: {}
-
   ws@8.17.1: {}
 
   ws@8.18.0: {}
@@ -33009,11 +32487,6 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
-
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.1.1: {}
@@ -33027,8 +32500,6 @@ snapshots:
   zod-validation-error@3.4.0(zod@3.23.8):
     dependencies:
       zod: 3.23.8
-
-  zod@3.22.4: {}
 
   zod@3.23.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
-  - "packages/*"
-  - "examples/*"
-  - "docs"
+  - 'packages/*'
+  - 'examples/*'
+  - 'docs'
+  - 'tools'

--- a/scripts/getBuildConfig.mjs
+++ b/scripts/getBuildConfig.mjs
@@ -30,6 +30,7 @@ function ignoreSideEffectImports(imports) {
   return {
     name: 'ignore-side-effect-imports',
     generateBundle(outputOptions, bundle) {
+      if (imports.length === 0) return;
       for (const fileName in bundle) {
         const file = bundle[fileName];
         if (file.type === 'chunk' && fileName.endsWith('.js')) {

--- a/scripts/getBuildConfig.mjs
+++ b/scripts/getBuildConfig.mjs
@@ -1,6 +1,5 @@
 /* eslint-env node */
 import {babel} from '@rollup/plugin-babel';
-import commonjs from '@rollup/plugin-commonjs';
 import resolve, {
   DEFAULTS as resolveDefaults
 } from '@rollup/plugin-node-resolve';
@@ -65,7 +64,6 @@ function getBundleConfig({
     },
     plugins: [
       resolve({extensions}),
-      commonjs(),
       babel({
         babelHelpers: 'bundled',
         extensions,
@@ -75,16 +73,12 @@ function getBundleConfig({
           [
             '@babel/preset-env',
             {
-              targets: {
-                // Same as https://nextjs.org/docs/architecture/supported-browsers#browserslist
-                browsers: [
-                  'chrome 64',
-                  'edge 79',
-                  'firefox 67',
-                  'opera 51',
-                  'safari 12'
-                ]
-              }
+              // > 0.5%, last 2 versions, Firefox ESR, not dead
+              targets: 'defaults',
+
+              // Maybe a bug in browserslist? This is required for
+              // ios<16.3, but MDN says available from Safari 10
+              exclude: ['transform-parameters']
             }
           ]
         ]

--- a/scripts/getBuildConfig.mjs
+++ b/scripts/getBuildConfig.mjs
@@ -71,7 +71,7 @@ function getBundleConfig({
         extensions,
         presets: [
           '@babel/preset-typescript',
-          '@babel/preset-react',
+          ['@babel/preset-react', {runtime: 'automatic'}],
           [
             '@babel/preset-env',
             {

--- a/scripts/getBuildConfig.mjs
+++ b/scripts/getBuildConfig.mjs
@@ -105,8 +105,6 @@ function getBundleConfig({
 }
 
 export default function getConfig(config) {
-  return [
-    getBundleConfig({...config, env: 'development'}),
-    getBundleConfig({...config, env: 'production'})
-  ];
+  const env = config.env || ['development', 'production'];
+  return env.map((env) => getBundleConfig({...config, env}));
 }

--- a/scripts/getBuildConfig.mjs
+++ b/scripts/getBuildConfig.mjs
@@ -77,7 +77,7 @@ function getBundleConfig({
               targets: 'defaults',
 
               // Maybe a bug in browserslist? This is required for
-              // ios<16.3, but MDN says available from Safari 10
+              // ios<16.3, but MDN says it's available from Safari 10
               exclude: ['transform-parameters']
             }
           ]

--- a/tools/eslint.config.mjs
+++ b/tools/eslint.config.mjs
@@ -1,0 +1,8 @@
+import {getPresets} from 'eslint-config-molindo';
+import globals from 'globals';
+
+export default (await getPresets('javascript')).concat({
+  languageOptions: {
+    globals: globals.node
+  }
+});

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "tools",
+  "type": "module",
+  "version": "1.0.0",
+  "description": "Shared tools for the repo",
+  "main": "src/index.js",
+  "scripts": {
+    "lint": "eslint src"
+  },
+  "keywords": [],
+  "author": "Jan Amann",
+  "license": "MIT",
+  "devDependencies": {
+    "@babel/core": "^7.24.7",
+    "@babel/preset-env": "^7.24.7",
+    "@babel/preset-react": "^7.24.7",
+    "@babel/preset-typescript": "^7.24.7",
+    "@rollup/plugin-babel": "^6.0.3",
+    "@rollup/plugin-node-resolve": "^15.2.1",
+    "@rollup/plugin-replace": "^5.0.7",
+    "@rollup/plugin-terser": "^0.4.3",
+    "eslint-config-molindo": "^8.0.0",
+    "eslint": "^9.11.1",
+    "execa": "^9.2.0",
+    "globals": "^15.11.0",
+    "rollup": "^4.18.0"
+  }
+}

--- a/tools/src/getBuildConfig.js
+++ b/tools/src/getBuildConfig.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 import {babel} from '@rollup/plugin-babel';
 import resolve, {
   DEFAULTS as resolveDefaults
@@ -14,6 +13,7 @@ const outDir = 'dist/';
 async function buildTypes() {
   await execa('tsc', '-p tsconfig.build.json'.split(' '));
 
+  // eslint-disable-next-line no-console
   console.log('\ncreated types');
 }
 
@@ -30,8 +30,8 @@ function ignoreSideEffectImports(imports) {
     name: 'ignore-side-effect-imports',
     generateBundle(outputOptions, bundle) {
       if (imports.length === 0) return;
-      for (const fileName in bundle) {
-        const file = bundle[fileName];
+
+      for (const [fileName, file] of Object.entries(bundle)) {
         if (file.type === 'chunk' && fileName.endsWith('.js')) {
           file.code = file.code.replace(regex, '');
         }
@@ -105,6 +105,6 @@ function getBundleConfig({
 }
 
 export default function getConfig(config) {
-  const env = config.env || ['development', 'production'];
-  return env.map((env) => getBundleConfig({...config, env}));
+  const envNames = config.env || ['development', 'production'];
+  return envNames.map((env) => getBundleConfig({...config, env}));
 }

--- a/tools/src/index.js
+++ b/tools/src/index.js
@@ -1,0 +1,1 @@
+export {default as getBuildConfig} from './getBuildConfig.js';


### PR DESCRIPTION
**Changes**

1. `next-intl` as well as its base library `use-intl` are now ESM-only. With this, the library is now ~7% smaller and provides full support for tree shaking. Most tools support ESM out-of-the-box, but some might require additional configuration (e.g. Jest might benefit from [`next/jest`](https://nextjs.org/docs/app/building-your-application/testing/jest#manual-setup)). The only exception is `next-intl/plugin` which is provided both as ESM as well as CommonJS due to `next.config.js` still being popular. 
2. Syntax is compiled down to the Browserslist [`defaults`](https://github.com/browserslist/browserslist/blob/065c69b0e1e6ad679263d03e22c605830bbc52e5/index.js#L460) query, which is a shortcut for `> 0.5%, last 2 versions, Firefox ESR, not dead`. The `defaults` query was thoroughly designed by the Browserslist community and is considered a reasonable default for modern apps. If you target outdated browsers, you can use [`transpilePackages`](https://nextjs.org/docs/app/api-reference/next-config-js/transpilePackages) in combination with a [`browserslist`](https://nextjs.org/docs/architecture/supported-browsers) config in Next.js to compile `next-intl` for older browsers.
3. The minimum React version is 17 now (which supports the modern JSX transform)



