### PR TITLE
feat!: Bump minimum required `typescript` version to 5 for projects using TypeScript

### DIFF
--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -115,7 +115,6 @@ declare global {
 If you're encountering problems, double check that:
 
 1. Your interface uses the correct name.
-2. You're using TypeScript version 4 or later.
-3. You're using correct paths for all modules you're importing into your global declaration file.
-4. Your type declaration file is included in `tsconfig.json`.
-5. Your editor has loaded the most recent type declarations. When in doubt, you can restart.
+2. You're using correct paths for all modules you're importing into your global declaration file.
+3. Your type declaration file is included in `tsconfig.json`.
+4. Your editor has loaded the most recent type declarations. When in doubt, you can restart.

--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -116,7 +116,13 @@
   },
   "peerDependencies": {
     "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
-    "react": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "typescript": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.16.4",

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -29,10 +29,10 @@ import {
 } from './utils.tsx';
 
 export default function createMiddleware<
-  AppLocales extends Locales,
-  AppLocalePrefixMode extends LocalePrefixMode = 'always',
-  AppPathnames extends Pathnames<AppLocales> = never,
-  AppDomains extends DomainsConfig<AppLocales> = never
+  const AppLocales extends Locales,
+  const AppLocalePrefixMode extends LocalePrefixMode = 'always',
+  const AppPathnames extends Pathnames<AppLocales> = never,
+  const AppDomains extends DomainsConfig<AppLocales> = never
 >(
   routing: RoutingConfig<
     AppLocales,


### PR DESCRIPTION
If you don't use TypeScript, this change doesn't affect you.