### PR TITLE
feat!: Remove deprecated APIs pt. 2

### DIFF
--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -3315,16 +3315,3 @@ describe('domain-based routing', () => {
     });
   });
 });
-
-describe('deprecated middleware options', () => {
-  it('still accepts them', () => {
-    createMiddleware(
-      {locales: ['en'], defaultLocale: 'en'},
-      {
-        localeDetection: false,
-        alternateLinks: false,
-        localeCookie: false
-      }
-    );
-  });
-});

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -39,38 +39,9 @@ export default function createMiddleware<
     AppLocalePrefixMode,
     AppPathnames,
     AppDomains
-  >,
-  /** @deprecated Should be passed via the first parameter `routing` instead (ideally defined with `defineRouting`) */
-  options?: {
-    /** @deprecated Should be passed via the first parameter `routing` instead (ideally defined with `defineRouting`) */
-    localeCookie?: RoutingConfig<
-      AppLocales,
-      AppLocalePrefixMode,
-      AppPathnames,
-      AppDomains
-    >['localeCookie'];
-    /** @deprecated Should be passed via the first parameter `routing` instead (ideally defined with `defineRouting`) */
-    localeDetection?: RoutingConfig<
-      AppLocales,
-      AppLocalePrefixMode,
-      AppPathnames,
-      AppDomains
-    >['localeDetection'];
-    /** @deprecated Should be passed via the first parameter `routing` instead (ideally defined with `defineRouting`) */
-    alternateLinks?: RoutingConfig<
-      AppLocales,
-      AppLocalePrefixMode,
-      AppPathnames,
-      AppDomains
-    >['alternateLinks'];
-  }
+  >
 ) {
-  const resolvedRouting = receiveRoutingConfig({
-    ...routing,
-    alternateLinks: options?.alternateLinks ?? routing.alternateLinks,
-    localeDetection: options?.localeDetection ?? routing.localeDetection,
-    localeCookie: options?.localeCookie ?? routing.localeCookie
-  });
+  const resolvedRouting = receiveRoutingConfig(routing);
 
   return function middleware(request: NextRequest) {
     let unsafeExternalPathname: string;

--- a/packages/next-intl/src/server/react-client/index.test.tsx
+++ b/packages/next-intl/src/server/react-client/index.test.tsx
@@ -4,18 +4,18 @@ import {getRequestConfig} from '../../server.react-client.tsx';
 describe('getRequestConfig', () => {
   it('can be called in the outer module closure', () => {
     expect(
-      getRequestConfig(({locale}) => ({
-        messages: {hello: 'Hello ' + locale}
+      getRequestConfig(async ({requestLocale}) => ({
+        messages: {hello: 'Hello ' + (await requestLocale)}
       }))
     );
   });
 
   it('can not call the returned function', () => {
-    const getConfig = getRequestConfig(({locale}) => ({
-      messages: {hello: 'Hello ' + locale}
+    const getConfig = getRequestConfig(async ({requestLocale}) => ({
+      messages: {hello: 'Hello ' + (await requestLocale)}
     }));
-    expect(() =>
-      getConfig({locale: 'en', requestLocale: Promise.resolve('en')})
-    ).toThrow('`getRequestConfig` is not supported in Client Components.');
+    expect(() => getConfig({requestLocale: Promise.resolve('en')})).toThrow(
+      '`getRequestConfig` is not supported in Client Components.'
+    );
   });
 });

--- a/packages/next-intl/src/server/react-client/index.tsx
+++ b/packages/next-intl/src/server/react-client/index.tsx
@@ -5,8 +5,7 @@ import type {
   getNow as getNow_type,
   getRequestConfig as getRequestConfig_type,
   getTimeZone as getTimeZone_type,
-  setRequestLocale as setRequestLocale_type,
-  unstable_setRequestLocale as unstable_setRequestLocale_type
+  setRequestLocale as setRequestLocale_type
 } from '../react-server/index.tsx';
 
 /**
@@ -45,10 +44,6 @@ export const getLocale = notSupported('getLocale') as typeof getLocale_type;
 // causes a type error. The types use the `react-server` entry
 // anyway, therefore this is irrelevant.
 export const getTranslations = notSupported('getTranslations');
-
-export const unstable_setRequestLocale = notSupported(
-  'unstable_setRequestLocale'
-) as typeof unstable_setRequestLocale_type;
 
 export const setRequestLocale = notSupported(
   'setRequestLocale'

--- a/packages/next-intl/src/server/react-server/getConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getConfig.tsx
@@ -7,7 +7,6 @@ import {
   initializeConfig
 } from 'use-intl/core';
 import {getRequestLocale} from './RequestLocale.tsx';
-import {getRequestLocale as getRequestLocaleLegacy} from './RequestLocaleLegacy.tsx';
 import createRequestConfig from './createRequestConfig.tsx';
 import {GetRequestConfigParams} from './getRequestConfig.tsx';
 
@@ -48,10 +47,6 @@ See also: https://next-intl-docs.vercel.app/docs/usage/configuration#i18n-reques
     // In case the consumer doesn't read `params.locale` and instead provides the
     // `locale` (either in a single-language workflow or because the locale is
     // read from the user settings), don't attempt to read the request locale.
-    get locale() {
-      return localeOverride || getRequestLocaleLegacy();
-    },
-
     get requestLocale() {
       return localeOverride
         ? Promise.resolve(localeOverride)

--- a/packages/next-intl/src/server/react-server/getRequestConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getRequestConfig.tsx
@@ -16,17 +16,6 @@ export type RequestConfig = Omit<IntlConfig, 'locale'> & {
 
 export type GetRequestConfigParams = {
   /**
-   * Deprecated in favor of `requestLocale` (see https://next-intl-docs.vercel.app/blog/next-intl-3-22#await-request-locale).
-   *
-   * The locale that was matched by the `[locale]` path segment. Note however
-   * that this can be overridden in async APIs when the `locale` is explicitly
-   * passed (e.g. `getTranslations({locale: 'en'})`).
-   *
-   * @deprecated
-   */
-  locale: string;
-
-  /**
    * Typically corresponds to the `[locale]` segment that was matched by the middleware.
    *
    * However, there are three special cases to consider:

--- a/packages/next-intl/src/server/react-server/index.tsx
+++ b/packages/next-intl/src/server/react-server/index.tsx
@@ -11,8 +11,3 @@ export {default as getMessages} from './getMessages.tsx';
 export {default as getLocale} from './getLocale.tsx';
 
 export {setCachedRequestLocale as setRequestLocale} from './RequestLocaleCache.tsx';
-
-export {
-  /** @deprecated Deprecated in favor of `setRequestLocale`. */
-  setCachedRequestLocale as unstable_setRequestLocale
-} from './RequestLocaleCache.tsx';


### PR DESCRIPTION
**Changes**
- Removed deprecated second argument of `createMiddleware` (use first argument instead, ideally via `defineRouting`)
- Remove deprecated `({locale})` argument in `getRequestConfig` (use `({requestLocale})` instead)
- Remove deprecated `unstable_setRequestLocale` (use `setRequestLocale` instead)
