### PR TITLE
feat!: Revamp augmented types and add support for typed `Locale`

### DIFF
--- a/docs/src/pages/docs/environments/actions-metadata-route-handlers.mdx
+++ b/docs/src/pages/docs/environments/actions-metadata-route-handlers.mdx
@@ -156,6 +156,7 @@ Next.js supports providing alternate URLs per language via the [`alternates` ent
 
 ```tsx filename="app/sitemap.ts" {4-5,8-9}
 import {MetadataRoute} from 'next';
+import {Locale} from 'next-intl';
 import {routing, getPathname} from '@/i18n/routing';
 
 // Adapt this as necessary
@@ -179,7 +180,7 @@ function getEntry(href: Href) {
   };
 }
 
-function getUrl(href: Href, locale: (typeof routing.locales)[number]) {
+function getUrl(href: Href, locale: Locale) {
   const pathname = getPathname({locale, href});
   return host + pathname;
 }

--- a/docs/src/pages/docs/environments/actions-metadata-route-handlers.mdx
+++ b/docs/src/pages/docs/environments/actions-metadata-route-handlers.mdx
@@ -207,14 +207,14 @@ You can use `next-intl` in [Route Handlers](https://nextjs.org/docs/app/building
 
 ```tsx filename="app/api/hello/route.tsx"
 import {NextResponse} from 'next/server';
-import {isValidLocale} from 'next-intl';
+import {hasLocale} from 'next-intl';
 import {getTranslations} from 'next-intl/server';
 
 export async function GET(request) {
   // Example: Receive the `locale` via a search param
   const {searchParams} = new URL(request.url);
   const locale = searchParams.get('locale');
-  if (!isValidLocale(locales, locale)) {
+  if (!hasLocale(locales, locale)) {
     return NextResponse.json({error: 'Invalid locale'}, {status: 400});
   }
 

--- a/docs/src/pages/docs/environments/actions-metadata-route-handlers.mdx
+++ b/docs/src/pages/docs/environments/actions-metadata-route-handlers.mdx
@@ -154,7 +154,7 @@ Note that by default, `next-intl` returns [the `link` response header](/docs/rou
 
 Next.js supports providing alternate URLs per language via the [`alternates` entry](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap#generate-a-localized-sitemap) as of version 14.2. You can use your default locale for the main URL and provide alternate URLs based on all locales that your app supports. Keep in mind that also the default locale should be included in the `alternates` object.
 
-```tsx filename="app/sitemap.ts" {4-5,8-9}
+```tsx filename="app/sitemap.ts" {5-6,9-10}
 import {MetadataRoute} from 'next';
 import {Locale} from 'next-intl';
 import {routing, getPathname} from '@/i18n/routing';

--- a/docs/src/pages/docs/environments/actions-metadata-route-handlers.mdx
+++ b/docs/src/pages/docs/environments/actions-metadata-route-handlers.mdx
@@ -207,12 +207,16 @@ You can use `next-intl` in [Route Handlers](https://nextjs.org/docs/app/building
 
 ```tsx filename="app/api/hello/route.tsx"
 import {NextResponse} from 'next/server';
+import {isValidLocale} from 'next-intl';
 import {getTranslations} from 'next-intl/server';
 
 export async function GET(request) {
   // Example: Receive the `locale` via a search param
   const {searchParams} = new URL(request.url);
   const locale = searchParams.get('locale');
+  if (!isValidLocale(locales, locale)) {
+    return NextResponse.json({error: 'Invalid locale'}, {status: 400});
+  }
 
   const t = await getTranslations({locale, namespace: 'Hello'});
   return NextResponse.json({title: t('title')});

--- a/docs/src/pages/docs/environments/error-files.mdx
+++ b/docs/src/pages/docs/environments/error-files.mdx
@@ -80,11 +80,12 @@ export default function RootLayout({children}) {
 For the 404 page to render, we need to call the `notFound` function in the root layout when we detect an incoming `locale` param that isn't a valid locale.
 
 ```tsx filename="app/[locale]/layout.tsx"
+import {isValidLocale} from 'next-intl';
 import {notFound} from 'next/navigation';
+import {routing} from '@/i18n/routing';
 
 export default function LocaleLayout({children, params: {locale}}) {
-  // Ensure that the incoming `locale` is valid
-  if (!routing.locales.includes(locale as any)) {
+  if (!isValidLocale(routing.locales, locale)) {
     notFound();
   }
 

--- a/docs/src/pages/docs/environments/error-files.mdx
+++ b/docs/src/pages/docs/environments/error-files.mdx
@@ -80,12 +80,12 @@ export default function RootLayout({children}) {
 For the 404 page to render, we need to call the `notFound` function in the root layout when we detect an incoming `locale` param that isn't a valid locale.
 
 ```tsx filename="app/[locale]/layout.tsx"
-import {isValidLocale} from 'next-intl';
+import {hasLocale} from 'next-intl';
 import {notFound} from 'next/navigation';
 import {routing} from '@/i18n/routing';
 
 export default function LocaleLayout({children, params: {locale}}) {
-  if (!isValidLocale(routing.locales, locale)) {
+  if (!hasLocale(routing.locales, locale)) {
     notFound();
   }
 

--- a/docs/src/pages/docs/environments/error-files.mdx
+++ b/docs/src/pages/docs/environments/error-files.mdx
@@ -77,7 +77,7 @@ export default function RootLayout({children}) {
 }
 ```
 
-For the 404 page to render, we need to call the `notFound` function in the root layout when we detect an incoming `locale` param that isn't a valid locale.
+For the 404 page to render, we need to call the `notFound` function in the root layout when we detect an incoming `locale` param that isn't valid.
 
 ```tsx filename="app/[locale]/layout.tsx"
 import {hasLocale} from 'next-intl';

--- a/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
+++ b/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
@@ -295,12 +295,12 @@ export function generateStaticParams() {
 
 ```tsx filename="app/[locale]/layout.tsx"
 import {setRequestLocale} from 'next-intl/server';
+import {isValidLocale} from 'next-intl';
 import {notFound} from 'next/navigation';
 import {routing} from '@/i18n/routing';
 
 export default async function LocaleLayout({children, params: {locale}}) {
-  // Ensure that the incoming `locale` is valid
-  if (!routing.locales.includes(locale as any)) {
+  if (!isValidLocale(routing.locales, locale)) {
     notFound();
   }
 

--- a/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
+++ b/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
@@ -147,16 +147,15 @@ When using features from `next-intl` in Server Components, the relevant configur
 
 ```tsx filename="src/i18n/request.ts"
 import {getRequestConfig} from 'next-intl/server';
+import {isValidLocale} from 'next-intl';
 import {routing} from './routing';
 
 export default getRequestConfig(async ({requestLocale}) => {
-  // This typically corresponds to the `[locale]` segment
-  let locale = await requestLocale;
-
-  // Ensure that a valid locale is used
-  if (!locale || !routing.locales.includes(locale as any)) {
-    locale = routing.defaultLocale;
-  }
+  // Typically corresponds to the `[locale]` segment
+  const requested = await requestLocale;
+  const locale = isValidLocale(routing.locales, requested)
+    ? requested
+    : routing.defaultLocale;
 
   return {
     locale,
@@ -186,7 +185,7 @@ const withNextIntl = createNextIntlPlugin(
 The `locale` that was matched by the middleware is available via the `locale` param and can be used to configure the document language. Additionally, we can use this place to pass configuration from `i18n/request.ts` to Client Components via `NextIntlClientProvider`.
 
 ```tsx filename="app/[locale]/layout.tsx"
-import {NextIntlClientProvider} from 'next-intl';
+import {NextIntlClientProvider, Locale, isValidLocale} from 'next-intl';
 import {getMessages} from 'next-intl/server';
 import {notFound} from 'next/navigation';
 import {routing} from '@/i18n/routing';
@@ -196,10 +195,9 @@ export default async function LocaleLayout({
   params: {locale}
 }: {
   children: React.ReactNode;
-  params: {locale: string};
+  params: {locale: Locale};
 }) {
-  // Ensure that the incoming `locale` is valid
-  if (!routing.locales.includes(locale as any)) {
+  if (!isValidLocale(routing.locales, locale)) {
     notFound();
   }
 

--- a/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
+++ b/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
@@ -147,13 +147,13 @@ When using features from `next-intl` in Server Components, the relevant configur
 
 ```tsx filename="src/i18n/request.ts"
 import {getRequestConfig} from 'next-intl/server';
-import {isValidLocale} from 'next-intl';
+import {hasLocale} from 'next-intl';
 import {routing} from './routing';
 
 export default getRequestConfig(async ({requestLocale}) => {
   // Typically corresponds to the `[locale]` segment
   const requested = await requestLocale;
-  const locale = isValidLocale(routing.locales, requested)
+  const locale = hasLocale(routing.locales, requested)
     ? requested
     : routing.defaultLocale;
 
@@ -185,7 +185,7 @@ const withNextIntl = createNextIntlPlugin(
 The `locale` that was matched by the middleware is available via the `locale` param and can be used to configure the document language. Additionally, we can use this place to pass configuration from `i18n/request.ts` to Client Components via `NextIntlClientProvider`.
 
 ```tsx filename="app/[locale]/layout.tsx"
-import {NextIntlClientProvider, Locale, isValidLocale} from 'next-intl';
+import {NextIntlClientProvider, Locale, hasLocale} from 'next-intl';
 import {getMessages} from 'next-intl/server';
 import {notFound} from 'next/navigation';
 import {routing} from '@/i18n/routing';
@@ -197,7 +197,7 @@ export default async function LocaleLayout({
   children: React.ReactNode;
   params: {locale: Locale};
 }) {
-  if (!isValidLocale(routing.locales, locale)) {
+  if (!hasLocale(routing.locales, locale)) {
     notFound();
   }
 
@@ -295,12 +295,12 @@ export function generateStaticParams() {
 
 ```tsx filename="app/[locale]/layout.tsx"
 import {setRequestLocale} from 'next-intl/server';
-import {isValidLocale} from 'next-intl';
+import {hasLocale} from 'next-intl';
 import {notFound} from 'next/navigation';
 import {routing} from '@/i18n/routing';
 
 export default async function LocaleLayout({children, params: {locale}}) {
-  if (!isValidLocale(routing.locales, locale)) {
+  if (!hasLocale(routing.locales, locale)) {
     notFound();
   }
 

--- a/docs/src/pages/docs/routing.mdx
+++ b/docs/src/pages/docs/routing.mdx
@@ -297,11 +297,12 @@ In case you're using a system like a CMS to configure localized pathnames, you'l
 
 ```tsx filename="page.tsx"
 import {notFound} from 'next';
+import {Locale} from 'next-intl';
 import {fetchContent} from './cms';
 
 type Props = {
   params: {
-    locale: string;
+    locale: Locale;
     slug: Array<string>;
   };
 };

--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -155,7 +155,7 @@ Depending on if you're using [i18n routing](/docs/getting-started/app-router), y
 export default getRequestConfig(async ({requestLocale}) => {
   // Typically corresponds to the `[locale]` segment
   const requested = await requestLocale;
-  const locale = isValidLocale(routing.locales, requested)
+  const locale = hasLocale(routing.locales, requested)
     ? requested
     : routing.defaultLocale;
 

--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -15,50 +15,20 @@ Depending on if you handle [internationalization in Server- or Client Components
 
 `i18n/request.ts` can be used to provide configuration for **server-only** code, i.e. Server Components, Server Actions & friends. The configuration is provided via the `getRequestConfig` function and needs to be set up based on whether you're using [i18n routing](/docs/getting-started/app-router) or not.
 
-<Tabs items={['With i18n routing', 'Without i18n routing']}>
-
-<Tabs.Tab>
-
 ```tsx filename="i18n/request.ts"
 import {getRequestConfig} from 'next-intl/server';
 import {routing} from '@/i18n/routing';
 
 export default getRequestConfig(async ({requestLocale}) => {
-  // This typically corresponds to the `[locale]` segment.
-  let locale = await requestLocale;
-
-  // Ensure that a valid locale is used
-  if (!locale || !routing.locales.includes(locale as any)) {
-    locale = routing.defaultLocale;
-  }
+  // ...
 
   return {
     locale,
-    messages: (await import(`../../messages/${locale}.json`)).default
+    messages
+    // ...
   };
 });
 ```
-
-</Tabs.Tab>
-<Tabs.Tab>
-
-```tsx filename="i18n/request.ts"
-import {getRequestConfig} from 'next-intl/server';
-
-export default getRequestConfig(async () => {
-  // Provide a static locale, fetch a user setting,
-  // read from `cookies()`, `headers()`, etc.
-  const locale = 'en';
-
-  return {
-    locale,
-    messages: (await import(`../../messages/${locale}.json`)).default
-  };
-});
-```
-
-</Tabs.Tab>
-</Tabs>
 
 The configuration object is created once for each request by internally using React's [`cache`](https://react.dev/reference/react/cache). The first component to use internationalization will call the function defined with `getRequestConfig`.
 
@@ -80,17 +50,6 @@ const withNextIntl = createNextIntlPlugin(
 
 </Details>
 
-<Details id="server-request-locale">
-<summary>Which values can the `requestLocale` parameter hold?</summary>
-
-While the `requestLocale` parameter typically corresponds to the `[locale]` segment that was matched by the middleware, there are three special cases to consider:
-
-1. **Overrides**: When an explicit `locale` is passed to [awaitable functions](/docs/environments/actions-metadata-route-handlers) like `getTranslations({locale: 'en'})`, then this value will be used instead of the segment.
-1. **`undefined`**: The value can be `undefined` when a page outside of the `[locale]` segment renders (e.g. a language selection page at `app/page.tsx`).
-1. **Invalid values**: Since the `[locale]` segment effectively acts like a catch-all for unknown routes (e.g. `/unknown.txt`), invalid values should be replaced with a valid locale. In addition to this, you might want to call `notFound()` in [the root layout](/docs/getting-started/app-router/with-i18n-routing#layout) to abort the render in this case.
-
-</Details>
-
 ### `NextIntlClientProvider`
 
 `NextIntlClientProvider` can be used to provide configuration for **Client Components**.
@@ -100,9 +59,7 @@ import {NextIntlClientProvider} from 'next-intl';
 import {getMessages} from 'next-intl/server';
 
 export default async function RootLayout(/* ... */) {
-  // Providing all messages to the client
-  // side is the easiest way to get started
-  const messages = await getMessages();
+  // ...
 
   return (
     <html lang={locale}>
@@ -183,6 +140,137 @@ Note that the inner `NextIntlClientProvider` inherits the configuration from the
 
 </Details>
 
+## Locale
+
+The `locale` represents an identifier that contains the language and formatting preferences of users, optionally including regional information (e.g. `en-US`). Locales are specified as [IETF BCP 47 language tags](https://en.wikipedia.org/wiki/IETF_language_tag).
+
+<Tabs items={['i18n/request.ts', 'Provider']}>
+<Tabs.Tab>
+
+Depending on if you're using [i18n routing](/docs/getting-started/app-router), you can read the locale from the `requestLocale` parameter or provide a value on your own:
+
+**With i18n routing:**
+
+```tsx filename="i18n/request.ts"
+export default getRequestConfig(async ({requestLocale}) => {
+  // Typically corresponds to the `[locale]` segment
+  const requested = await requestLocale;
+  const locale = isValidLocale(routing.locales, requested)
+    ? requested
+    : routing.defaultLocale;
+
+  return {
+    locale
+    // ...
+  };
+});
+```
+
+**Without i18n routing:**
+
+```tsx filename="i18n/request.ts"
+export default getRequestConfig(async () => {
+  return {
+    locale: 'en'
+    // ...
+  };
+});
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+```tsx
+<NextIntlClientProvider locale="en">...</NextIntlClientProvider>
+```
+
+</Tabs.Tab>
+</Tabs>
+
+<Details id="server-request-locale">
+<summary>Which values can the `requestLocale` parameter hold?</summary>
+
+While the `requestLocale` parameter typically corresponds to the `[locale]` segment that was matched by the middleware, there are three special cases to consider:
+
+1. **Overrides**: When an explicit `locale` is passed to [awaitable functions](/docs/environments/actions-metadata-route-handlers) like `getTranslations({locale: 'en'})`, then this value will be used instead of the segment.
+1. **`undefined`**: The value can be `undefined` when a page outside of the `[locale]` segment renders (e.g. a language selection page at `app/page.tsx`).
+1. **Invalid values**: Since the `[locale]` segment effectively acts like a catch-all for unknown routes (e.g. `/unknown.txt`), invalid values should be replaced with a valid locale. In addition to this, you might want to call `notFound()` in [the root layout](/docs/getting-started/app-router/with-i18n-routing#layout) to abort the render in this case.
+
+</Details>
+
+### `useLocale` & `getLocale` [#use-locale]
+
+The current locale of your app is automatically incorporated into hooks like `useTranslations` & `useFormatter` and will affect the rendered output.
+
+In case you need to use this value in other places of your app, e.g. to implement a locale switcher or to pass it to API calls, you can read it via `useLocale` or `getLocale`:
+
+```tsx
+// Regular components
+import {useLocale} from 'next-intl';
+const locale = useLocale();
+
+// Async Server Components
+import {getLocale} from 'next-intl/server';
+const locale = await getLocale();
+```
+
+When passing a `locale` to another function, you can use the `Locale` type for the receiving parameter:
+
+```tsx
+import {Locale} from 'next-intl';
+
+async function getPosts(locale: Locale) {
+  // ...
+}
+```
+
+<Callout>
+  By default, `Locale` is typed as `string`. However, you can optionally provide
+  a strict union based on your supported locales for this type by [augmenting
+  the `Locale` type](/docs/workflows/typescript#locale).
+</Callout>
+
+<Details id="locale-change">
+<summary>How can I change the locale?</summary>
+
+Depending on if you're using [i18n routing](/docs/getting-started/app-router), the locale can be changed as follows:
+
+1. **With i18n routing**: The locale is managed by the router and can be changed by using navigation APIs from `next-intl` like [`Link`](/docs/routing/navigation#link) or [`useRouter`](/docs/routing/navigation#userouter).
+2. **Without i18n routing**: You can change the locale by updating the value where the locale is read from (e.g. a cookie, a user setting, etc.). If you're looking for inspiration, you can have a look at the [App Router without i18n routing example](/examples#app-router-without-i18n-routing) that manages the locale via a cookie.
+
+</Details>
+
+<Details id="locale-return-value">
+<summary>Which value is returned from `useLocale`?</summary>
+
+The returned value is resolved based on these priorities:
+
+1. **Server Components**: If you're using [i18n routing](/docs/getting-started/app-router), the returned locale is the one that you've either provided via [`setRequestLocale`](/docs/getting-started/app-router/with-i18n-routing#static-rendering) or alternatively the one in the `[locale]` segment that was matched by the middleware. If you're not using i18n routing, the returned locale is the one that you've provided via `getRequestConfig`.
+2. **Client Components**: In this case, the locale is received from `NextIntlClientProvider` or alternatively `useParams().locale`. Note that `NextIntlClientProvider` automatically inherits the locale if the component is rendered by a Server Component.
+
+</Details>
+
+<Details id="locale-pages-router">
+<summary>I'm using the Pages Router, how can I access the locale?</summary>
+
+If you use [internationalized routing with the Pages Router](https://nextjs.org/docs/pages/building-your-application/routing/internationalization), you can receive the locale from the router in order to pass it to `NextIntlClientProvider`:
+
+```tsx filename="_app.tsx"
+import {useRouter} from 'next/router';
+
+// ...
+
+const router = useRouter();
+
+return (
+  <NextIntlClientProvider locale={router.locale}>
+    ...
+  </NextIntlClientProvider>;
+);
+```
+
+</Details>
+
 ## Messages
 
 The most crucial aspect of internationalization is providing labels based on the user's language. The recommended workflow is to store your messages in your repository along with the code.
@@ -214,40 +302,6 @@ export default getRequestConfig(async () => {
 ```
 
 After messages are configured, they can be used via [`useTranslations`](/docs/usage/messages#rendering-messages-with-usetranslations).
-
-In case you require access to messages in a component, you can read them via `useMessages()` or `getMessages()` from your configuration:
-
-```tsx
-// Regular components
-import {useMessages} from 'next-intl';
-const messages = useMessages();
-
-// Async Server Components
-import {getMessages} from 'next-intl/server';
-const messages = await getMessages();
-```
-
-</Tabs.Tab>
-<Tabs.Tab>
-
-```tsx
-import {NextIntlClientProvider} from 'next-intl';
-import {getMessages} from 'next-intl/server';
-
-async function Component({children}) {
-  // Read messages configured via `i18n/request.ts`
-  const messages = await getMessages();
-
-  return (
-    <NextIntlClientProvider messages={messages}>
-      {children}
-    </NextIntlClientProvider>
-  );
-}
-```
-
-</Tabs.Tab>
-</Tabs>
 
 <Details id="messages-remote-sources">
 <summary>How can I load messages from remote sources?</summary>
@@ -298,6 +352,42 @@ Note that [the VSCode integration for `next-intl`](/docs/workflows/vscode-integr
 
 </Details>
 
+### `useMessages` & `getMessages` [#use-messages]
+
+In case you require access to messages in a component, you can read them via `useMessages()` or `getMessages()` from your configuration:
+
+```tsx
+// Regular components
+import {useMessages} from 'next-intl';
+const messages = useMessages();
+
+// Async Server Components
+import {getMessages} from 'next-intl/server';
+const messages = await getMessages();
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+```tsx
+import {NextIntlClientProvider} from 'next-intl';
+import {getMessages} from 'next-intl/server';
+
+async function Component({children}) {
+  // Read messages configured via `i18n/request.ts`
+  const messages = await getMessages();
+
+  return (
+    <NextIntlClientProvider messages={messages}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}
+```
+
+</Tabs.Tab>
+</Tabs>
+
 ## Time zone
 
 Specifying a time zone affects the rendering of dates and times. By default, the time zone of the server runtime will be used, but can be customized as necessary.
@@ -337,6 +427,10 @@ const timeZone = 'Europe/Vienna';
 
 The available time zone names can be looked up in [the tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
+The time zone in Client Components is automatically inherited from the server side if you wrap the relevant components in a `NextIntlClientProvider` that is rendered by a Server Component. For all other cases, you can specify the value explicitly on a wrapping `NextIntlClientProvider`.
+
+### `useTimeZone` & `getTimeZone` [#use-time-zone]
+
 The configured time zone can be read via `useTimeZone` or `getTimeZone` in components:
 
 ```tsx
@@ -348,11 +442,6 @@ const messages = useTimeZone();
 import {getTimeZone} from 'next-intl/server';
 const timeZone = await getTimeZone();
 ```
-
-The time zone in Client Components is automatically inherited from the server
-side if you wrap the relevant components in a `NextIntlClientProvider` that is
-rendered by a Server Component. For all other cases, you can specify the value
-explicitly on a wrapping `NextIntlClientProvider`.
 
 ## Now value [#now]
 
@@ -391,6 +480,10 @@ const now = new Date('2020-11-20T10:36:01.516Z');
 </Tabs.Tab>
 </Tabs>
 
+Similarly to the `timeZone`, the `now` value in Client Components is automatically inherited from the server side if you wrap the relevant components in a `NextIntlClientProvider` that is rendered by a Server Component.
+
+### `useNow` & `getNow` [#use-now]
+
 The configured `now` value can be read in components via `useNow` or `getNow`:
 
 ```tsx
@@ -402,11 +495,6 @@ const now = useNow();
 import {getNow} from 'next-intl/server';
 const now = await getNow();
 ```
-
-Similarly to the `timeZone`, the `now` value in Client Components is
-automatically inherited from the server side if you wrap the relevant
-components in a `NextIntlClientProvider` that is rendered by a Server
-Component.
 
 ## Formats
 
@@ -445,8 +533,6 @@ export default getRequestConfig(async () => {
   };
 });
 ```
-
-Note that `formats` are not automatically inherited by Client Components. If you want to make this available in Client Components, you should provide the same configuration to [`NextIntlClientProvider`](#nextintlclientprovider).
 
 </Tabs.Tab>
 <Tabs.Tab>
@@ -496,9 +582,9 @@ function Component() {
 ```
 
 <Callout>
-  You can optionally [specify a global type for
-  `formats`](/docs/workflows/typescript#formats) to get autocompletion and type
-  safety.
+  By default, format names are loosely typed as `string`. However, you can
+  optionally use strict types by [augmenting the `Formats`
+  type](/docs/workflows/typescript#formats).
 </Callout>
 
 Global formats for numbers, dates and times can be referenced in messages too:
@@ -601,61 +687,3 @@ function getMessageFallback({namespace, key, error}) {
 
 </Tabs.Tab>
 </Tabs>
-
-## Locale
-
-The current locale of your app is automatically incorporated into hooks like `useTranslations` & `useFormatter` and will affect the rendered output.
-
-In case you need to use this value in other places of your app, e.g. to implement a locale switcher or to pass it to API calls, you can read it via `useLocale` or `getLocale`:
-
-```tsx
-// Regular components
-import {useLocale} from 'next-intl';
-const locale = useLocale();
-
-// Async Server Components
-import {getLocale} from 'next-intl/server';
-const locale = await getLocale();
-```
-
-<Details id="locale-change">
-<summary>How can I change the locale?</summary>
-
-Depending on if you're using [i18n routing](/docs/getting-started/app-router), the locale can be changed as follows:
-
-1. **With i18n routing**: The locale is managed by the router and can be changed by using navigation APIs from `next-intl` like [`Link`](/docs/routing/navigation#link) or [`useRouter`](/docs/routing/navigation#userouter).
-2. **Without i18n routing**: You can change the locale by updating the value where the locale is read from (e.g. a cookie, a user setting, etc.). If you're looking for inspiration, you can have a look at the [App Router without i18n routing example](/examples#app-router-without-i18n-routing) that manages the locale via a cookie.
-
-</Details>
-
-<Details id="locale-return-value">
-<summary>Which value is returned from `useLocale`?</summary>
-
-The returned value is resolved based on these priorities:
-
-1. **Server Components**: If you're using [i18n routing](/docs/getting-started/app-router), the returned locale is the one that you've either provided via [`setRequestLocale`](/docs/getting-started/app-router/with-i18n-routing#static-rendering) or alternatively the one in the `[locale]` segment that was matched by the middleware. If you're not using i18n routing, the returned locale is the one that you've provided via `getRequestConfig`.
-2. **Client Components**: In this case, the locale is received from `NextIntlClientProvider` or alternatively `useParams().locale`. Note that `NextIntlClientProvider` automatically inherits the locale if the component is rendered by a Server Component. For all other cases, you can specify the value
-   explicitly.
-
-</Details>
-
-<Details id="locale-pages-router">
-<summary>I'm using the Pages Router, how can I access the locale?</summary>
-
-If you use [internationalized routing with the Pages Router](https://nextjs.org/docs/pages/building-your-application/routing/internationalization), you can receive the locale from the router in order to pass it to `NextIntlClientProvider`:
-
-```tsx filename="_app.tsx"
-import {useRouter} from 'next/router';
-
-// ...
-
-const router = useRouter();
-
-return (
-  <NextIntlClientProvider locale={router.locale}>
-    ...
-  </NextIntlClientProvider>;
-);
-```
-
-</Details>

--- a/docs/src/pages/docs/usage/messages.mdx
+++ b/docs/src/pages/docs/usage/messages.mdx
@@ -8,7 +8,7 @@ The main part of handling internationalization (typically referred to as _i18n_)
 
 ## Terminology
 
-- **Locale**: We use this term to describe an identifier that contains the language and formatting preferences of users. Apart from the language, a locale can include optional regional information (e.g. `en-US`). Locales are specified as [IETF BCP 47 language tags](https://en.wikipedia.org/wiki/IETF_language_tag).
+- **Locale**: We use this term to describe an identifier that contains the language and formatting preferences of users. Apart from the language, a locale can include optional regional information (e.g. `en-US`).
 - **Messages**: These are collections of namespace-label pairs that are grouped by locale (e.g. `en-US.json`).
 
 ## Structuring messages

--- a/docs/src/pages/docs/workflows.mdx
+++ b/docs/src/pages/docs/workflows.mdx
@@ -3,7 +3,7 @@ import Cards from '@/components/Cards';
 
 # Workflows & integrations
 
-To get the most out of `next-intl`, you can choose from these integrations to improve your workflow when developing and collaborating with translators.
+To get the most out of `next-intl`, you can choose from these integrations to improve your workflow.
 
 <Cards className="mt-8 lg:w-1/2">
   <Card title="TypeScript integration" href="/docs/workflows/typescript" />

--- a/docs/src/pages/docs/workflows.mdx
+++ b/docs/src/pages/docs/workflows.mdx
@@ -6,7 +6,7 @@ import Cards from '@/components/Cards';
 To get the most out of `next-intl`, you can choose from these integrations to improve your workflow.
 
 <Cards className="mt-8 lg:w-1/2">
-  <Card title="TypeScript integration" href="/docs/workflows/typescript" />
+  <Card title="TypeScript augmentation" href="/docs/workflows/typescript" />
   <Card
     title="Localization management with Crowdin"
     href="/docs/workflows/localization-management"

--- a/docs/src/pages/docs/workflows/_meta.tsx
+++ b/docs/src/pages/docs/workflows/_meta.tsx
@@ -1,5 +1,5 @@
 export default {
-  typescript: 'TypeScript',
+  typescript: 'TypeScript augmentation',
   'localization-management': 'Localization management with Crowdin',
   'vscode-integration': 'VSCode integration',
   linting: 'ESLint',

--- a/docs/src/pages/docs/workflows/localization-management.mdx
+++ b/docs/src/pages/docs/workflows/localization-management.mdx
@@ -74,7 +74,7 @@ As a developer-focused localization service, Crowdin helps you to decouple the l
 </figure>
 
 <Callout>
-  The [TypeScript integration of `next-intl`](/docs/workflows/typescript) can
+  The [TypeScript augmentation of `next-intl`](/docs/workflows/typescript) can
   help you to validate at compile time that your app is in sync with your
   translation bundles.
 </Callout>

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -235,7 +235,7 @@ export default async function LocaleLayout({params: {locale}}: Props) {
 
 If you're encountering problems, double check that:
 
-1. Your interface uses the correct name.
+1. The interface uses the correct name `AppConfig`.
 2. You're using correct paths for all modules you're importing into your global declaration file.
 3. Your type declaration file is included in `tsconfig.json`.
 4. Your editor has loaded the most recent type declarations. When in doubt, you can restart.

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -1,12 +1,117 @@
+import Details from '@/components/Details';
+import {Tabs} from 'nextra/components';
 import Callout from '@/components/Callout';
 
 # TypeScript integration
 
 `next-intl` integrates seamlessly with TypeScript right out of the box, requiring no additional setup.
 
-However, you can optionally provide supplemental type definitions for your messages and formats to enable autocompletion and improve type safety.
+However, you can optionally provide supplemental definitions to augment the types that `next-intl` works with, enabling improved autocompletion and type safety across your app.
 
-## Messages
+```tsx filename="global.d.ts"
+import 'next-intl';
+
+declare module 'next-intl' {
+  interface AppConfig {
+    // ...
+  }
+}
+```
+
+Type augmentation is available for:
+
+- [`Locale`](#locale)
+- [`Messages`](#messages)
+- [`Formats`](#formats)
+
+## `Locale`
+
+Augmenting the `Locale` type will affect the return type of [`useLocale`](/docs/usage/configuration#locale), as well as all `locale` arguments that are received by `next-intl` (e.g. the `locale` prop of [`<Link />`](/docs/routing/navigation#link)).
+
+```tsx
+// ✅ 'en' | 'de'
+const locale = useLocale();
+```
+
+To enable this validation, you can adapt `AppConfig` as follows:
+
+<Tabs items={['With i18n routing', 'Without i18n routing']}>
+<Tabs.Tab>
+
+```tsx filename="global.d.ts"
+import 'next-intl';
+import {routing} from '@/i18n/routing';
+
+declare module 'next-intl' {
+  interface AppConfig {
+    // ...
+    Locale: (typeof routing.locales)[number];
+  }
+}
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+```tsx filename="global.d.ts"
+import 'next-intl';
+
+// Potentially imported from a shared config
+const locales = ['en', 'de'] as const;
+
+declare module 'next-intl' {
+  interface AppConfig {
+    // ...
+    Locale: (typeof locales)[number];
+  }
+}
+```
+
+</Tabs.Tab>
+</Tabs>
+
+### Using the `Locale` type for layout and page params [#locale-params]
+
+You can use the `Locale` type across your codebase, for example when reading from the `[locale]` parameter in a layout or page:
+
+```tsx filename="app/[locale]/page.tsx"
+import {Locale} from 'next-intl';
+
+type Props = {
+  params: {
+    locale: Locale;
+  };
+};
+
+export default function Page(props: Props) {
+  // ...
+}
+```
+
+However, keep in mind that this _assumes_ the locale to be valid in this place—Next.js doesn't validate the `[locale]` parameter automatically for you. Due to this, you can add your own validation logic in a central place like the root layout:
+
+```tsx filename="app/[locale]/layout.tsx"
+import {isValidLocale} from 'next-intl';
+import {routing} from '@/i18n/routing';
+
+type Props = {
+  params: {
+    children: React.ReactNode;
+    locale: Locale;
+  };
+};
+
+export default async function LocaleLayout({params: {locale}}: Props) {
+  if (!isValidLocale(routing.locales, locale)) {
+    notFound();
+  }
+
+  // ✅ 'en' | 'de'
+  console.log(locale);
+}
+```
+
+## `Messages`
 
 Messages can be strictly typed to ensure you're using valid keys.
 
@@ -31,22 +136,23 @@ function About() {
 }
 ```
 
-To enable this validation, add a global type definition file in your project root (e.g. `global.d.ts`):
+To enable this validation, you can adapt `AppConfig` as follows:
 
 ```ts filename="global.d.ts"
+import 'next-intl';
 import en from './messages/en.json';
 
-type Messages = typeof en;
-
-declare global {
-  // Use type safe message keys with `next-intl`
-  interface IntlMessages extends Messages {}
+declare module 'next-intl' {
+  interface AppConfig {
+    // ...
+    Messages: typeof en;
+  }
 }
 ```
 
-You can freely define the interface, but if you have your messages available locally, it can be helpful to automatically create the interface based on the messages from your default locale by importing it.
+You can freely define the interface, but if you have your messages available locally, it can be helpful to automatically create the type based on the messages from your default locale.
 
-## Formats
+## `Formats`
 
 [Global formats](/docs/usage/configuration#formats) that are referenced in calls like `format.dateTime` can be strictly typed to ensure you're using valid format names across your app.
 
@@ -97,16 +203,16 @@ export const formats = {
 // ...
 ```
 
-Now, a global type definition file in the root of your project can pick up the shape of your formats and use them for declaring the `IntlFormats` interface:
+Now, you can include the `formats` in your `AppConfig`:
 
 ```ts filename="global.d.ts"
 import {formats} from './src/i18n/request';
 
-type Formats = typeof formats;
-
-declare global {
-  // Use type safe formats with `next-intl`
-  interface IntlFormats extends Formats {}
+declare module 'next-intl' {
+  interface AppConfig {
+    // ...
+    Formats: typeof formats;
+  }
 }
 ```
 

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -209,18 +209,20 @@ export default function Page(props: Props) {
 However, keep in mind that this _assumes_ the locale to be valid in this place—Next.js doesn't validate the `[locale]` parameter automatically for you. Due to this, you can add your own validation logic in a central place like the root layout:
 
 ```tsx filename="app/[locale]/layout.tsx"
-import {Locale, isValidLocale} from 'next-intl';
-import {routing} from '@/i18n/routing';
+import {isValidLocale} from 'next-intl';
+
+// Can be imported e.g. from `@/i18n/routing`
+const locales = ['en', 'de'] as const;
 
 type Props = {
   params: {
     children: React.ReactNode;
-    locale: Locale;
+    locale: string;
   };
 };
 
 export default async function LocaleLayout({params: {locale}}: Props) {
-  if (!isValidLocale(routing.locales, locale)) {
+  if (!isValidLocale(locales, locale)) {
     notFound();
   }
 

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -2,7 +2,7 @@ import Details from '@/components/Details';
 import {Tabs} from 'nextra/components';
 import Callout from '@/components/Callout';
 
-# TypeScript integration
+# TypeScript augmentation
 
 `next-intl` integrates seamlessly with TypeScript right out of the box, requiring no additional setup.
 
@@ -20,9 +20,114 @@ declare module 'next-intl' {
 
 Type augmentation is available for:
 
-- [`Locale`](#locale)
 - [`Messages`](#messages)
 - [`Formats`](#formats)
+- [`Locale`](#locale)
+
+## `Messages`
+
+Messages can be strictly typed to ensure you're using valid keys.
+
+```json filename="messages.json"
+{
+  "About": {
+    "title": "Hello"
+  }
+}
+```
+
+```tsx
+function About() {
+  // ✅ Valid namespace
+  const t = useTranslations('About');
+
+  // ✖️ Unknown message key
+  t('description');
+
+  // ✅ Valid message key
+  t('title');
+}
+```
+
+To enable this validation, you can adapt `AppConfig` as follows:
+
+```ts filename="global.d.ts"
+import 'next-intl';
+import en from './messages/en.json';
+
+declare module 'next-intl' {
+  interface AppConfig {
+    // ...
+    Messages: typeof en;
+  }
+}
+```
+
+You can freely define the interface, but if you have your messages available locally, it can be helpful to automatically create the type based on the messages from your default locale.
+
+## `Formats`
+
+If you're using [global formats](/docs/usage/configuration#formats), you can strictly type the format names that are referenced in calls to `format.dateTime`, `format.number` and `format.list`.
+
+```tsx
+function Component() {
+  const format = useFormatter();
+
+  // ✖️ Unknown format string
+  format.dateTime(new Date(), 'unknown');
+
+  // ✅ Valid format
+  format.dateTime(new Date(), 'short');
+
+  // ✅ Valid format
+  format.number(2, 'precise');
+
+  // ✅ Valid format
+  format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
+}
+```
+
+To enable this validation, export the formats that you're using in your request configuration:
+
+```ts filename="i18n/request.ts"
+import {Formats} from 'next-intl';
+
+export const formats = {
+  dateTime: {
+    short: {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric'
+    }
+  },
+  number: {
+    precise: {
+      maximumFractionDigits: 5
+    }
+  },
+  list: {
+    enumeration: {
+      style: 'long',
+      type: 'conjunction'
+    }
+  }
+} satisfies Formats;
+
+// ...
+```
+
+Now, you can include the `formats` in your `AppConfig`:
+
+```ts filename="global.d.ts"
+import {formats} from '@/i18n/request';
+
+declare module 'next-intl' {
+  interface AppConfig {
+    // ...
+    Formats: typeof formats;
+  }
+}
+```
 
 ## `Locale`
 
@@ -70,9 +175,28 @@ declare module 'next-intl' {
 </Tabs.Tab>
 </Tabs>
 
-### Using the `Locale` type for layout and page params [#locale-params]
+### Using the `Locale` type for arguments
 
-You can use the `Locale` type across your codebase, for example when reading from the `[locale]` parameter in a layout or page:
+Once the `Locale` type is augmented, it can be used across your codebase if you need to pass the locale to functions outside of your components:
+
+```tsx {2,10}
+import {getLocale} from 'next-intl/server';
+import {Locale} from 'next-intl';
+
+async function BlogPosts() {
+  const locale = await getLocale();
+  const posts = await getPosts(locale);
+  // ...
+}
+
+async function getPosts(locale: Locale) {
+  // ...
+}
+```
+
+### Using the `Locale` type for layout and page params [#locale-segment-params]
+
+You can also use the `Locale` type when working with the `[locale]` parameter in layouts and pages:
 
 ```tsx filename="app/[locale]/page.tsx"
 import {Locale} from 'next-intl';
@@ -91,7 +215,7 @@ export default function Page(props: Props) {
 However, keep in mind that this _assumes_ the locale to be valid in this place—Next.js doesn't validate the `[locale]` parameter automatically for you. Due to this, you can add your own validation logic in a central place like the root layout:
 
 ```tsx filename="app/[locale]/layout.tsx"
-import {isValidLocale} from 'next-intl';
+import {Locale, isValidLocale} from 'next-intl';
 import {routing} from '@/i18n/routing';
 
 type Props = {
@@ -108,111 +232,6 @@ export default async function LocaleLayout({params: {locale}}: Props) {
 
   // ✅ 'en' | 'de'
   console.log(locale);
-}
-```
-
-## `Messages`
-
-Messages can be strictly typed to ensure you're using valid keys.
-
-```json filename="messages.json"
-{
-  "About": {
-    "title": "Hello"
-  }
-}
-```
-
-```tsx
-function About() {
-  // ✅ Valid namespace
-  const t = useTranslations('About');
-
-  // ✖️ Unknown message key
-  t('description');
-
-  // ✅ Valid message key
-  t('title');
-}
-```
-
-To enable this validation, you can adapt `AppConfig` as follows:
-
-```ts filename="global.d.ts"
-import 'next-intl';
-import en from './messages/en.json';
-
-declare module 'next-intl' {
-  interface AppConfig {
-    // ...
-    Messages: typeof en;
-  }
-}
-```
-
-You can freely define the interface, but if you have your messages available locally, it can be helpful to automatically create the type based on the messages from your default locale.
-
-## `Formats`
-
-[Global formats](/docs/usage/configuration#formats) that are referenced in calls like `format.dateTime` can be strictly typed to ensure you're using valid format names across your app.
-
-```tsx
-function Component() {
-  const format = useFormatter();
-
-  // ✅ Valid format
-  format.number(2, 'precise');
-
-  // ✅ Valid format
-  format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
-
-  // ✖️ Unknown format string
-  format.dateTime(new Date(), 'unknown');
-
-  // ✅ Valid format
-  format.dateTime(new Date(), 'short');
-}
-```
-
-To enable this validation, export the formats that you're using in your request configuration:
-
-```ts filename="i18n/request.ts"
-import {Formats} from 'next-intl';
-
-export const formats = {
-  dateTime: {
-    short: {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric'
-    }
-  },
-  number: {
-    precise: {
-      maximumFractionDigits: 5
-    }
-  },
-  list: {
-    enumeration: {
-      style: 'long',
-      type: 'conjunction'
-    }
-  }
-} satisfies Formats;
-
-// ...
-```
-
-Now, you can include the `formats` in your `AppConfig`:
-
-```ts filename="global.d.ts"
-import {formats} from '@/i18n/request';
-
-declare module 'next-intl' {
-  interface AppConfig {
-    // ...
-    Formats: typeof formats;
-  }
 }
 ```
 

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -209,7 +209,7 @@ export default function Page(props: Props) {
 However, keep in mind that this _assumes_ the locale to be valid in this place—Next.js doesn't validate the `[locale]` parameter automatically for you. Due to this, you can add your own validation logic in a central place like the root layout:
 
 ```tsx filename="app/[locale]/layout.tsx"
-import {isValidLocale} from 'next-intl';
+import {hasLocale} from 'next-intl';
 
 // Can be imported e.g. from `@/i18n/routing`
 const locales = ['en', 'de'] as const;
@@ -222,7 +222,7 @@ type Props = {
 };
 
 export default async function LocaleLayout({params: {locale}}: Props) {
-  if (!isValidLocale(locales, locale)) {
+  if (!hasLocale(locales, locale)) {
     notFound();
   }
 

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -206,7 +206,7 @@ export const formats = {
 Now, you can include the `formats` in your `AppConfig`:
 
 ```ts filename="global.d.ts"
-import {formats} from './src/i18n/request';
+import {formats} from '@/i18n/request';
 
 declare module 'next-intl' {
   interface AppConfig {

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -9,8 +9,6 @@ import Callout from '@/components/Callout';
 However, you can optionally provide supplemental definitions to augment the types that `next-intl` works with, enabling improved autocompletion and type safety across your app.
 
 ```tsx filename="global.d.ts"
-import 'next-intl';
-
 declare module 'next-intl' {
   interface AppConfig {
     // ...
@@ -52,7 +50,6 @@ function About() {
 To enable this validation, you can adapt `AppConfig` as follows:
 
 ```ts filename="global.d.ts"
-import 'next-intl';
 import en from './messages/en.json';
 
 declare module 'next-intl' {
@@ -144,7 +141,6 @@ To enable this validation, you can adapt `AppConfig` as follows:
 <Tabs.Tab>
 
 ```tsx filename="global.d.ts"
-import 'next-intl';
 import {routing} from '@/i18n/routing';
 
 declare module 'next-intl' {
@@ -159,8 +155,6 @@ declare module 'next-intl' {
 <Tabs.Tab>
 
 ```tsx filename="global.d.ts"
-import 'next-intl';
-
 // Potentially imported from a shared config
 const locales = ['en', 'de'] as const;
 

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -84,7 +84,7 @@ function Component() {
 }
 ```
 
-To enable this validation, export the formats that you're using in your request configuration:
+To enable this validation, export the formats that you're using e.g. from your request configuration:
 
 ```ts filename="i18n/request.ts"
 import {Formats} from 'next-intl';
@@ -128,7 +128,7 @@ declare module 'next-intl' {
 
 ## `Locale`
 
-Augmenting the `Locale` type will affect the return type of [`useLocale`](/docs/usage/configuration#locale), as well as all `locale` arguments that are received by `next-intl` (e.g. the `locale` prop of [`<Link />`](/docs/routing/navigation#link)).
+Augmenting the `Locale` type will affect the return type of [`useLocale`](/docs/usage/configuration#locale), as well as all `locale` arguments that are accepted by APIs from `next-intl` (e.g. the `locale` prop of [`<Link />`](/docs/routing/navigation#link)).
 
 ```tsx
 // ✅ 'en' | 'de'
@@ -173,9 +173,9 @@ declare module 'next-intl' {
 
 Once the `Locale` type is augmented, it can be used across your codebase if you need to pass the locale to functions outside of your components:
 
-```tsx {2,10}
-import {getLocale} from 'next-intl/server';
+```tsx {1,10}
 import {Locale} from 'next-intl';
+import {getLocale} from 'next-intl/server';
 
 async function BlogPosts() {
   const locale = await getLocale();
@@ -238,4 +238,4 @@ If you're encountering problems, double check that:
 1. The interface uses the correct name `AppConfig`.
 2. You're using correct paths for all modules you're importing into your global declaration file.
 3. Your type declaration file is included in `tsconfig.json`.
-4. Your editor has loaded the most recent type declarations. When in doubt, you can restart.
+4. Your editor has loaded the latest types. When in doubt, restart your editor.

--- a/examples/example-app-router-migration/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router-migration/src/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import {notFound} from 'next/navigation';
-import {NextIntlClientProvider} from 'next-intl';
+import {NextIntlClientProvider, isValidLocale} from 'next-intl';
 import {getMessages} from 'next-intl/server';
 import {ReactNode} from 'react';
 import {routing} from '@/i18n/routing';
@@ -10,8 +10,7 @@ type Props = {
 };
 
 export default async function LocaleLayout({children, params}: Props) {
-  // Ensure that the incoming `locale` is valid
-  if (!routing.locales.includes(params.locale as any)) {
+  if (!isValidLocale(routing.locales, params.locale)) {
     notFound();
   }
 

--- a/examples/example-app-router-migration/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router-migration/src/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import {notFound} from 'next/navigation';
-import {NextIntlClientProvider, isValidLocale} from 'next-intl';
+import {NextIntlClientProvider, hasLocale} from 'next-intl';
 import {getMessages} from 'next-intl/server';
 import {ReactNode} from 'react';
 import {routing} from '@/i18n/routing';
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export default async function LocaleLayout({children, params}: Props) {
-  if (!isValidLocale(routing.locales, params.locale)) {
+  if (!hasLocale(routing.locales, params.locale)) {
     notFound();
   }
 

--- a/examples/example-app-router-migration/src/i18n/request.ts
+++ b/examples/example-app-router-migration/src/i18n/request.ts
@@ -1,11 +1,11 @@
-import {isValidLocale} from 'next-intl';
+import {hasLocale} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 import {routing} from './routing';
 
 export default getRequestConfig(async ({requestLocale}) => {
   // Typically corresponds to the `[locale]` segment
   const requested = await requestLocale;
-  const locale = isValidLocale(routing.locales, requested)
+  const locale = hasLocale(routing.locales, requested)
     ? requested
     : routing.defaultLocale;
 

--- a/examples/example-app-router-migration/src/i18n/request.ts
+++ b/examples/example-app-router-migration/src/i18n/request.ts
@@ -1,14 +1,13 @@
+import {isValidLocale} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 import {routing} from './routing';
 
 export default getRequestConfig(async ({requestLocale}) => {
-  // This typically corresponds to the `[locale]` segment
-  let locale = await requestLocale;
-
-  // Ensure that the incoming locale is valid
-  if (!locale || !routing.locales.includes(locale as any)) {
-    locale = routing.defaultLocale;
-  }
+  // Typically corresponds to the `[locale]` segment
+  const requested = await requestLocale;
+  const locale = isValidLocale(routing.locales, requested)
+    ? requested
+    : routing.defaultLocale;
 
   return {
     locale,

--- a/examples/example-app-router-mixed-routing/global.d.ts
+++ b/examples/example-app-router-mixed-routing/global.d.ts
@@ -1,4 +1,3 @@
-import 'next-intl';
 import {locales} from '@/config';
 import en from './messages/en.json';
 

--- a/examples/example-app-router-mixed-routing/src/app/(public)/[locale]/PublicNavigationLocaleSwitcher.tsx
+++ b/examples/example-app-router-mixed-routing/src/app/(public)/[locale]/PublicNavigationLocaleSwitcher.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import {useLocale} from 'next-intl';
-import {Locale} from '@/config';
+import {Locale, useLocale} from 'next-intl';
 import {Link, usePathname} from '@/i18n/routing.public';
 
 export default function PublicNavigationLocaleSwitcher() {

--- a/examples/example-app-router-mixed-routing/src/app/(public)/[locale]/about/page.tsx
+++ b/examples/example-app-router-mixed-routing/src/app/(public)/[locale]/about/page.tsx
@@ -1,9 +1,9 @@
-import {useTranslations} from 'next-intl';
+import {Locale, useTranslations} from 'next-intl';
 import {setRequestLocale} from 'next-intl/server';
 import PageTitle from '@/components/PageTitle';
 
 type Props = {
-  params: {locale: string};
+  params: {locale: Locale};
 };
 
 export default function About({params: {locale}}: Props) {

--- a/examples/example-app-router-mixed-routing/src/app/(public)/[locale]/layout.tsx
+++ b/examples/example-app-router-mixed-routing/src/app/(public)/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import {Metadata} from 'next';
 import {notFound} from 'next/navigation';
-import {Locale, NextIntlClientProvider, isValidLocale} from 'next-intl';
+import {Locale, NextIntlClientProvider, hasLocale} from 'next-intl';
 import {getMessages, setRequestLocale} from 'next-intl/server';
 import {ReactNode} from 'react';
 import Document from '@/components/Document';
@@ -26,7 +26,7 @@ export default async function LocaleLayout({
   params: {locale}
 }: Props) {
   // Ensure that the incoming locale is valid
-  if (!isValidLocale(locales, locale)) {
+  if (!hasLocale(locales, locale)) {
     notFound();
   }
 

--- a/examples/example-app-router-mixed-routing/src/app/(public)/[locale]/layout.tsx
+++ b/examples/example-app-router-mixed-routing/src/app/(public)/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import {Metadata} from 'next';
 import {notFound} from 'next/navigation';
-import {NextIntlClientProvider} from 'next-intl';
+import {Locale, NextIntlClientProvider, isValidLocale} from 'next-intl';
 import {getMessages, setRequestLocale} from 'next-intl/server';
 import {ReactNode} from 'react';
 import Document from '@/components/Document';
@@ -10,7 +10,7 @@ import PublicNavigationLocaleSwitcher from './PublicNavigationLocaleSwitcher';
 
 type Props = {
   children: ReactNode;
-  params: {locale: string};
+  params: {locale: Locale};
 };
 
 export function generateStaticParams() {
@@ -25,13 +25,13 @@ export default async function LocaleLayout({
   children,
   params: {locale}
 }: Props) {
-  // Enable static rendering
-  setRequestLocale(locale);
-
   // Ensure that the incoming locale is valid
-  if (!locales.includes(locale as any)) {
+  if (!isValidLocale(locales, locale)) {
     notFound();
   }
+
+  // Enable static rendering
+  setRequestLocale(locale);
 
   // Providing all messages to the client
   // side is the easiest way to get started

--- a/examples/example-app-router-mixed-routing/src/app/(public)/[locale]/page.tsx
+++ b/examples/example-app-router-mixed-routing/src/app/(public)/[locale]/page.tsx
@@ -1,9 +1,9 @@
-import {useTranslations} from 'next-intl';
+import {Locale, useTranslations} from 'next-intl';
 import {setRequestLocale} from 'next-intl/server';
 import PageTitle from '@/components/PageTitle';
 
 type Props = {
-  params: {locale: string};
+  params: {locale: Locale};
 };
 
 export default function Index({params: {locale}}: Props) {

--- a/examples/example-app-router-mixed-routing/src/app/app/AppNavigationLocaleSwitcher.tsx
+++ b/examples/example-app-router-mixed-routing/src/app/app/AppNavigationLocaleSwitcher.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import {useRouter} from 'next/navigation';
-import {useLocale} from 'next-intl';
-import {Locale} from '@/config';
+import {Locale, useLocale} from 'next-intl';
 import updateLocale from './updateLocale';
 
 export default function AppNavigationLocaleSwitcher() {

--- a/examples/example-app-router-mixed-routing/src/config.ts
+++ b/examples/example-app-router-mixed-routing/src/config.ts
@@ -1,5 +1,5 @@
+import {Locale} from 'next-intl';
+
 export const locales = ['en', 'de'] as const;
 
 export const defaultLocale: Locale = 'en';
-
-export type Locale = (typeof locales)[number];

--- a/examples/example-app-router-mixed-routing/src/db.ts
+++ b/examples/example-app-router-mixed-routing/src/db.ts
@@ -1,5 +1,6 @@
 import {cookies} from 'next/headers';
-import {defaultLocale} from './config';
+import {Locale, isValidLocale} from 'next-intl';
+import {defaultLocale, locales} from './config';
 
 // This cookie name is used by `next-intl` on the public pages too. By
 // reading/writing to this locale, we can ensure that the user's locale
@@ -8,8 +9,9 @@ import {defaultLocale} from './config';
 // that instead when the user is logged in.
 const COOKIE_NAME = 'NEXT_LOCALE';
 
-export async function getUserLocale() {
-  return cookies().get(COOKIE_NAME)?.value || defaultLocale;
+export async function getUserLocale(): Promise<Locale> {
+  const candidate = cookies().get(COOKIE_NAME)?.value;
+  return isValidLocale(locales, candidate) ? candidate : defaultLocale;
 }
 
 export async function setUserLocale(locale: string) {

--- a/examples/example-app-router-mixed-routing/src/db.ts
+++ b/examples/example-app-router-mixed-routing/src/db.ts
@@ -1,5 +1,5 @@
 import {cookies} from 'next/headers';
-import {Locale, isValidLocale} from 'next-intl';
+import {Locale, hasLocale} from 'next-intl';
 import {defaultLocale, locales} from './config';
 
 // This cookie name is used by `next-intl` on the public pages too. By
@@ -11,7 +11,7 @@ const COOKIE_NAME = 'NEXT_LOCALE';
 
 export async function getUserLocale(): Promise<Locale> {
   const candidate = cookies().get(COOKIE_NAME)?.value;
-  return isValidLocale(locales, candidate) ? candidate : defaultLocale;
+  return hasLocale(locales, candidate) ? candidate : defaultLocale;
 }
 
 export async function setUserLocale(locale: string) {

--- a/examples/example-app-router-mixed-routing/src/i18n/request.ts
+++ b/examples/example-app-router-mixed-routing/src/i18n/request.ts
@@ -1,20 +1,17 @@
+import {isValidLocale} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 import {defaultLocale, locales} from '../config';
 import {getUserLocale} from '../db';
 
 export default getRequestConfig(async ({requestLocale}) => {
   // Read from potential `[locale]` segment
-  let locale = await requestLocale;
+  let candidate = await requestLocale;
 
-  if (!locale) {
+  if (!candidate) {
     // The user is logged in
-    locale = await getUserLocale();
+    candidate = await getUserLocale();
   }
-
-  // Ensure that the incoming locale is valid
-  if (!locales.includes(locale as any)) {
-    locale = defaultLocale;
-  }
+  const locale = isValidLocale(locales, candidate) ? candidate : defaultLocale;
 
   return {
     locale,

--- a/examples/example-app-router-mixed-routing/src/i18n/request.ts
+++ b/examples/example-app-router-mixed-routing/src/i18n/request.ts
@@ -1,4 +1,4 @@
-import {isValidLocale} from 'next-intl';
+import {hasLocale} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 import {defaultLocale, locales} from '../config';
 import {getUserLocale} from '../db';
@@ -11,7 +11,7 @@ export default getRequestConfig(async ({requestLocale}) => {
     // The user is logged in
     candidate = await getUserLocale();
   }
-  const locale = isValidLocale(locales, candidate) ? candidate : defaultLocale;
+  const locale = hasLocale(locales, candidate) ? candidate : defaultLocale;
 
   return {
     locale,

--- a/examples/example-app-router-next-auth/global.d.ts
+++ b/examples/example-app-router-next-auth/global.d.ts
@@ -1,4 +1,3 @@
-import 'next-intl';
 import {routing} from '@/i18n/routing';
 import en from './messages/en.json';
 

--- a/examples/example-app-router-next-auth/global.d.ts
+++ b/examples/example-app-router-next-auth/global.d.ts
@@ -1,8 +1,10 @@
+import 'next-intl';
+import {routing} from '@/i18n/routing';
 import en from './messages/en.json';
 
-type Messages = typeof en;
-
-declare global {
-  // Use type safe message keys with `next-intl`
-  interface IntlMessages extends Messages {}
+declare module 'next-intl' {
+  interface AppConfig {
+    Locale: (typeof routing.locales)[number];
+    Messages: typeof en;
+  }
 }

--- a/examples/example-app-router-next-auth/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router-next-auth/src/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import {notFound} from 'next/navigation';
-import {Locale, NextIntlClientProvider, isValidLocale} from 'next-intl';
+import {Locale, NextIntlClientProvider, hasLocale} from 'next-intl';
 import {getMessages} from 'next-intl/server';
 import {ReactNode} from 'react';
 import {routing} from '@/i18n/routing';
@@ -13,7 +13,7 @@ export default async function LocaleLayout({
   children,
   params: {locale}
 }: Props) {
-  if (!isValidLocale(routing.locales, locale)) {
+  if (!hasLocale(routing.locales, locale)) {
     notFound();
   }
 

--- a/examples/example-app-router-next-auth/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router-next-auth/src/app/[locale]/layout.tsx
@@ -1,20 +1,19 @@
 import {notFound} from 'next/navigation';
-import {NextIntlClientProvider} from 'next-intl';
+import {Locale, NextIntlClientProvider, isValidLocale} from 'next-intl';
 import {getMessages} from 'next-intl/server';
 import {ReactNode} from 'react';
 import {routing} from '@/i18n/routing';
 
 type Props = {
   children: ReactNode;
-  params: {locale: string};
+  params: {locale: Locale};
 };
 
 export default async function LocaleLayout({
   children,
   params: {locale}
 }: Props) {
-  // Ensure that the incoming `locale` is valid
-  if (!routing.locales.includes(locale as any)) {
+  if (!isValidLocale(routing.locales, locale)) {
     notFound();
   }
 

--- a/examples/example-app-router-next-auth/src/i18n/request.ts
+++ b/examples/example-app-router-next-auth/src/i18n/request.ts
@@ -1,11 +1,11 @@
-import {isValidLocale} from 'next-intl';
+import {hasLocale} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 import {routing} from './routing';
 
 export default getRequestConfig(async ({requestLocale}) => {
   // Typically corresponds to the `[locale]` segment
   const requested = await requestLocale;
-  const locale = isValidLocale(routing.locales, requested)
+  const locale = hasLocale(routing.locales, requested)
     ? requested
     : routing.defaultLocale;
 

--- a/examples/example-app-router-next-auth/src/i18n/request.ts
+++ b/examples/example-app-router-next-auth/src/i18n/request.ts
@@ -1,14 +1,13 @@
+import {isValidLocale} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 import {routing} from './routing';
 
 export default getRequestConfig(async ({requestLocale}) => {
-  // This typically corresponds to the `[locale]` segment
-  let locale = await requestLocale;
-
-  // Ensure that the incoming locale is valid
-  if (!locale || !routing.locales.includes(locale as any)) {
-    locale = routing.defaultLocale;
-  }
+  // Typically corresponds to the `[locale]` segment
+  const requested = await requestLocale;
+  const locale = isValidLocale(routing.locales, requested)
+    ? requested
+    : routing.defaultLocale;
 
   return {
     locale,

--- a/examples/example-app-router-playground/global.d.ts
+++ b/examples/example-app-router-playground/global.d.ts
@@ -6,16 +6,13 @@ import en from './messages/en.json';
 declare module 'next-intl' {
   interface AppConfig {
     Locale: (typeof routing.locales)[number];
+    Formats: typeof formats;
   }
 }
 
 type Messages = typeof en;
-type Formats = typeof formats;
 
 declare global {
   // Use type safe message keys with `next-intl`
   interface IntlMessages extends Messages {}
-
-  // Use type safe formats with `next-intl`
-  interface IntlFormats extends Formats {}
 }

--- a/examples/example-app-router-playground/global.d.ts
+++ b/examples/example-app-router-playground/global.d.ts
@@ -7,12 +7,6 @@ declare module 'next-intl' {
   interface AppConfig {
     Locale: (typeof routing.locales)[number];
     Formats: typeof formats;
+    Messages: typeof en;
   }
-}
-
-type Messages = typeof en;
-
-declare global {
-  // Use type safe message keys with `next-intl`
-  interface IntlMessages extends Messages {}
 }

--- a/examples/example-app-router-playground/global.d.ts
+++ b/examples/example-app-router-playground/global.d.ts
@@ -1,4 +1,3 @@
-import 'next-intl';
 import {formats} from '@/i18n/request';
 import {routing} from '@/i18n/routing';
 import en from './messages/en.json';

--- a/examples/example-app-router-playground/global.d.ts
+++ b/examples/example-app-router-playground/global.d.ts
@@ -1,5 +1,13 @@
+import 'next-intl';
+import {formats} from '@/i18n/request';
+import {routing} from '@/i18n/routing';
 import en from './messages/en.json';
-import {formats} from './src/i18n/request';
+
+declare module 'next-intl' {
+  interface AppConfig {
+    Locale: (typeof routing.locales)[number];
+  }
+}
 
 type Messages = typeof en;
 type Formats = typeof formats;

--- a/examples/example-app-router-playground/src/app/[locale]/about/page.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/about/page.tsx
@@ -1,6 +1,8 @@
+import {Locale} from 'next-intl';
+
 type Props = {
   params: {
-    locale: string;
+    locale: Locale;
   };
 };
 

--- a/examples/example-app-router-playground/src/app/[locale]/api/route.ts
+++ b/examples/example-app-router-playground/src/app/[locale]/api/route.ts
@@ -1,9 +1,10 @@
 import {NextRequest, NextResponse} from 'next/server';
+import {Locale} from 'next-intl';
 import {getTranslations} from 'next-intl/server';
 
 type Props = {
   params: {
-    locale: string;
+    locale: Locale;
   };
 };
 

--- a/examples/example-app-router-playground/src/app/[locale]/client/ClientContent.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/client/ClientContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useFormatter, useLocale, useNow, useTimeZone} from 'next-intl';
+import {useLocale, useNow, useTimeZone} from 'next-intl';
 import {Link, usePathname} from '@/i18n/routing';
 
 export default function ClientContent() {
@@ -17,24 +17,4 @@ export default function ClientContent() {
       <p data-testid="Locale">{locale}</p>
     </>
   );
-}
-
-export function TypeTest() {
-  const format = useFormatter();
-
-  format.dateTime(new Date(), 'medium');
-  // @ts-expect-error
-  format.dateTime(new Date(), 'unknown');
-
-  format.dateTimeRange(new Date(), new Date(), 'medium');
-  // @ts-expect-error
-  format.dateTimeRange(new Date(), new Date(), 'unknown');
-
-  format.number(420, 'precise');
-  // @ts-expect-error
-  format.number(420, 'unknown');
-
-  format.list(['this', 'is', 'a', 'list'], 'enumeration');
-  // @ts-expect-error
-  format.list(['this', 'is', 'a', 'list'], 'unknown');
 }

--- a/examples/example-app-router-playground/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import {Metadata} from 'next';
 import {notFound} from 'next/navigation';
-import {Locale, isValidLocale} from 'next-intl';
+import {Locale, hasLocale} from 'next-intl';
 import {
   getFormatter,
   getNow,
@@ -36,7 +36,7 @@ export async function generateMetadata({
 }
 
 export default function LocaleLayout({children, params: {locale}}: Props) {
-  if (!isValidLocale(routing.locales, locale)) {
+  if (!hasLocale(routing.locales, locale)) {
     notFound();
   }
 

--- a/examples/example-app-router-playground/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import {Metadata} from 'next';
 import {notFound} from 'next/navigation';
-import {Locale} from 'next-intl';
+import {Locale, isValidLocale} from 'next-intl';
 import {
   getFormatter,
   getNow,
@@ -36,8 +36,7 @@ export async function generateMetadata({
 }
 
 export default function LocaleLayout({children, params: {locale}}: Props) {
-  // Ensure that the incoming `locale` is valid
-  if (!routing.locales.includes(locale as any)) {
+  if (!isValidLocale(routing.locales, locale)) {
     notFound();
   }
 

--- a/examples/example-app-router-playground/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import {Metadata} from 'next';
 import {notFound} from 'next/navigation';
+import {Locale} from 'next-intl';
 import {
   getFormatter,
   getNow,
@@ -12,7 +13,7 @@ import Navigation from '../../components/Navigation';
 
 type Props = {
   children: ReactNode;
-  params: {locale: string};
+  params: {locale: Locale};
 };
 
 export async function generateMetadata({
@@ -29,7 +30,7 @@ export async function generateMetadata({
     description: t('description'),
     other: {
       currentYear: formatter.dateTime(now, {year: 'numeric'}),
-      timeZone: timeZone || 'N/A'
+      timeZone
     }
   };
 }

--- a/examples/example-app-router-playground/src/app/[locale]/news/[articleId]/page.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/news/[articleId]/page.tsx
@@ -1,6 +1,6 @@
 import {Metadata} from 'next';
-import {useTranslations} from 'next-intl';
-import {Locale, getPathname} from '@/i18n/routing';
+import {Locale, useTranslations} from 'next-intl';
+import {getPathname} from '@/i18n/routing';
 
 type Props = {
   params: {

--- a/examples/example-app-router-playground/src/app/[locale]/opengraph-image.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/opengraph-image.tsx
@@ -1,9 +1,10 @@
 import {ImageResponse} from 'next/og';
 import {getTranslations} from 'next-intl/server';
+import {Locale} from '@/i18n/routing';
 
 type Props = {
   params: {
-    locale: string;
+    locale: Locale;
   };
 };
 

--- a/examples/example-app-router-playground/src/app/[locale]/opengraph-image.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import {ImageResponse} from 'next/og';
+import {Locale} from 'next-intl';
 import {getTranslations} from 'next-intl/server';
-import {Locale} from '@/i18n/routing';
 
 type Props = {
   params: {

--- a/examples/example-app-router-playground/src/components/AsyncComponent.tsx
+++ b/examples/example-app-router-playground/src/components/AsyncComponent.tsx
@@ -1,4 +1,4 @@
-import {getFormatter, getTranslations} from 'next-intl/server';
+import {getTranslations} from 'next-intl/server';
 
 export default async function AsyncComponent() {
   const t = await getTranslations('AsyncComponent');
@@ -20,8 +20,6 @@ export default async function AsyncComponent() {
 export async function TypeTest() {
   const t = await getTranslations('AsyncComponent');
 
-  const format = await getFormatter();
-
   // @ts-expect-error
   await getTranslations('Unknown');
 
@@ -36,20 +34,4 @@ export async function TypeTest() {
 
   // @ts-expect-error
   t.has('unknown');
-
-  format.dateTime(new Date(), 'medium');
-  // @ts-expect-error
-  format.dateTime(new Date(), 'unknown');
-
-  format.dateTimeRange(new Date(), new Date(), 'medium');
-  // @ts-expect-error
-  format.dateTimeRange(new Date(), new Date(), 'unknown');
-
-  format.number(420, 'precise');
-  // @ts-expect-error
-  format.number(420, 'unknown');
-
-  format.list(['this', 'is', 'a', 'list'], 'enumeration');
-  // @ts-expect-error
-  format.list(['this', 'is', 'a', 'list'], 'unknown');
 }

--- a/examples/example-app-router-playground/src/components/UseFormatterTypeTests.tsx
+++ b/examples/example-app-router-playground/src/components/UseFormatterTypeTests.tsx
@@ -1,0 +1,44 @@
+import {useFormatter} from 'next-intl';
+import {getFormatter} from 'next-intl/server';
+
+export function RegularComponent() {
+  const format = useFormatter();
+
+  format.dateTime(new Date(), 'medium');
+  format.dateTime(new Date(), 'long');
+  // @ts-expect-error
+  format.dateTime(new Date(), 'unknown');
+
+  format.dateTimeRange(new Date(), new Date(), 'medium');
+  // @ts-expect-error
+  format.dateTimeRange(new Date(), new Date(), 'unknown');
+
+  format.number(420, 'precise');
+  // @ts-expect-error
+  format.number(420, 'unknown');
+
+  format.list(['this', 'is', 'a', 'list'], 'enumeration');
+  // @ts-expect-error
+  format.list(['this', 'is', 'a', 'list'], 'unknown');
+}
+
+export async function AsyncComponent() {
+  const format = await getFormatter();
+
+  format.dateTime(new Date(), 'medium');
+  format.dateTime(new Date(), 'long');
+  // @ts-expect-error
+  format.dateTime(new Date(), 'unknown');
+
+  format.dateTimeRange(new Date(), new Date(), 'medium');
+  // @ts-expect-error
+  format.dateTimeRange(new Date(), new Date(), 'unknown');
+
+  format.number(420, 'precise');
+  // @ts-expect-error
+  format.number(420, 'unknown');
+
+  format.list(['this', 'is', 'a', 'list'], 'enumeration');
+  // @ts-expect-error
+  format.list(['this', 'is', 'a', 'list'], 'unknown');
+}

--- a/examples/example-app-router-playground/src/components/UseLocaleTypeTests.tsx
+++ b/examples/example-app-router-playground/src/components/UseLocaleTypeTests.tsx
@@ -1,0 +1,62 @@
+import {Locale, useLocale} from 'next-intl';
+import {getLocale} from 'next-intl/server';
+import {Link, getPathname, redirect, useRouter} from '@/i18n/routing';
+
+export function RegularComponent() {
+  const locale = useLocale();
+
+  locale satisfies Locale;
+  'en' satisfies typeof locale;
+
+  // @ts-expect-error
+  'fr' satisfies typeof locale;
+  // @ts-expect-error
+  2 satisfies typeof locale;
+
+  const router = useRouter();
+  router.push('/', {locale});
+
+  return (
+    <>
+      <Link href="/" locale={locale}>
+        Home
+      </Link>
+      {getPathname({
+        href: '/',
+        locale
+      })}
+      {redirect({
+        href: '/',
+        locale
+      })}
+    </>
+  );
+}
+
+export async function AsyncComponent() {
+  const locale = await getLocale();
+
+  locale satisfies Locale;
+  'en' satisfies typeof locale;
+
+  // @ts-expect-error
+  'fr' satisfies typeof locale;
+  // @ts-expect-error
+  2 satisfies typeof locale;
+
+  return (
+    <>
+      <Link href="/" locale={locale}>
+        Home
+      </Link>
+      {getPathname({
+        href: '/',
+        locale
+      })}
+      {redirect({
+        href: '/',
+        locale
+      })}
+    </>
+  );
+}

--- a/examples/example-app-router-playground/src/components/UseMessagesTypeTests.tsx
+++ b/examples/example-app-router-playground/src/components/UseMessagesTypeTests.tsx
@@ -2,7 +2,7 @@
 import {useMessages} from 'next-intl';
 import {getMessages} from 'next-intl/server';
 
-export async function GetMessages() {
+export async function AsyncComponent() {
   const messages = await getMessages();
 
   // Valid
@@ -16,7 +16,7 @@ export async function GetMessages() {
   messages.Index.unknown;
 }
 
-export function UseMessages() {
+export function RegularComponent() {
   const messages = useMessages();
 
   // Valid

--- a/examples/example-app-router-playground/src/i18n/request.tsx
+++ b/examples/example-app-router-playground/src/i18n/request.tsx
@@ -10,6 +10,11 @@ export const formats = {
       dateStyle: 'medium',
       timeStyle: 'short',
       hour12: false
+    },
+    long: {
+      dateStyle: 'full',
+      timeStyle: 'long',
+      hour12: false
     }
   },
   number: {

--- a/examples/example-app-router-playground/src/i18n/request.tsx
+++ b/examples/example-app-router-playground/src/i18n/request.tsx
@@ -1,5 +1,5 @@
 import {headers} from 'next/headers';
-import {Formats, isValidLocale} from 'next-intl';
+import {Formats, hasLocale} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 import defaultMessages from '../../messages/en.json';
 import {routing} from './routing';
@@ -33,7 +33,7 @@ export const formats = {
 export default getRequestConfig(async ({requestLocale}) => {
   // Typically corresponds to the `[locale]` segment
   const requested = await requestLocale;
-  const locale = isValidLocale(routing.locales, requested)
+  const locale = hasLocale(routing.locales, requested)
     ? requested
     : routing.defaultLocale;
 

--- a/examples/example-app-router-playground/src/i18n/request.tsx
+++ b/examples/example-app-router-playground/src/i18n/request.tsx
@@ -1,5 +1,5 @@
 import {headers} from 'next/headers';
-import {Formats} from 'next-intl';
+import {Formats, isValidLocale} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 import defaultMessages from '../../messages/en.json';
 import {routing} from './routing';
@@ -26,13 +26,11 @@ export const formats = {
 } satisfies Formats;
 
 export default getRequestConfig(async ({requestLocale}) => {
-  // This typically corresponds to the `[locale]` segment
-  let locale = await requestLocale;
-
-  // Ensure that the incoming locale is valid
-  if (!locale || !routing.locales.includes(locale as any)) {
-    locale = routing.defaultLocale;
-  }
+  // Typically corresponds to the `[locale]` segment
+  const requested = await requestLocale;
+  const locale = isValidLocale(routing.locales, requested)
+    ? requested
+    : routing.defaultLocale;
 
   const now = headers().get('x-now');
   const timeZone = headers().get('x-time-zone') ?? 'Europe/Vienna';

--- a/examples/example-app-router-playground/src/i18n/routing.ts
+++ b/examples/example-app-router-playground/src/i18n/routing.ts
@@ -60,8 +60,5 @@ export const routing = defineRouting({
         }
 });
 
-export type Pathnames = keyof typeof routing.pathnames;
-export type Locale = (typeof routing.locales)[number];
-
 export const {Link, getPathname, redirect, usePathname, useRouter} =
   createNavigation(routing);

--- a/examples/example-app-router/global.d.ts
+++ b/examples/example-app-router/global.d.ts
@@ -5,12 +5,7 @@ import en from './messages/en.json';
 declare module 'next-intl' {
   interface AppConfig {
     Locale: (typeof routing.locales)[number];
+    Messages: typeof en;
   }
 }
 
-type Messages = typeof en;
-
-declare global {
-  // Use type safe message keys with `next-intl`
-  interface IntlMessages extends Messages {}
-}

--- a/examples/example-app-router/global.d.ts
+++ b/examples/example-app-router/global.d.ts
@@ -1,4 +1,3 @@
-import 'next-intl';
 import {routing} from '@/i18n/routing';
 import en from './messages/en.json';
 
@@ -8,4 +7,3 @@ declare module 'next-intl' {
     Messages: typeof en;
   }
 }
-

--- a/examples/example-app-router/global.d.ts
+++ b/examples/example-app-router/global.d.ts
@@ -1,4 +1,12 @@
+import 'next-intl';
+import {routing} from '@/i18n/routing';
 import en from './messages/en.json';
+
+declare module 'next-intl' {
+  interface AppConfig {
+    Locale: (typeof routing.locales)[number];
+  }
+}
 
 type Messages = typeof en;
 

--- a/examples/example-app-router/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router/src/app/[locale]/layout.tsx
@@ -1,4 +1,5 @@
 import {notFound} from 'next/navigation';
+import {Locale, isValidLocale} from 'next-intl';
 import {getTranslations, setRequestLocale} from 'next-intl/server';
 import {ReactNode} from 'react';
 import BaseLayout from '@/components/BaseLayout';
@@ -6,7 +7,7 @@ import {routing} from '@/i18n/routing';
 
 type Props = {
   children: ReactNode;
-  params: {locale: string};
+  params: {locale: Locale};
 };
 
 export function generateStaticParams() {
@@ -27,8 +28,7 @@ export default async function LocaleLayout({
   children,
   params: {locale}
 }: Props) {
-  // Ensure that the incoming `locale` is valid
-  if (!routing.locales.includes(locale as any)) {
+  if (!isValidLocale(routing.locales, locale)) {
     notFound();
   }
 

--- a/examples/example-app-router/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router/src/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import {notFound} from 'next/navigation';
-import {Locale, isValidLocale} from 'next-intl';
+import {Locale, hasLocale} from 'next-intl';
 import {getTranslations, setRequestLocale} from 'next-intl/server';
 import {ReactNode} from 'react';
 import BaseLayout from '@/components/BaseLayout';
@@ -28,7 +28,7 @@ export default async function LocaleLayout({
   children,
   params: {locale}
 }: Props) {
-  if (!isValidLocale(routing.locales, locale)) {
+  if (!hasLocale(routing.locales, locale)) {
     notFound();
   }
 

--- a/examples/example-app-router/src/app/[locale]/page.tsx
+++ b/examples/example-app-router/src/app/[locale]/page.tsx
@@ -1,9 +1,9 @@
-import {useTranslations} from 'next-intl';
+import {Locale, useTranslations} from 'next-intl';
 import {setRequestLocale} from 'next-intl/server';
 import PageLayout from '@/components/PageLayout';
 
 type Props = {
-  params: {locale: string};
+  params: {locale: Locale};
 };
 
 export default function IndexPage({params: {locale}}: Props) {

--- a/examples/example-app-router/src/app/[locale]/pathnames/page.tsx
+++ b/examples/example-app-router/src/app/[locale]/pathnames/page.tsx
@@ -1,9 +1,9 @@
-import {useTranslations} from 'next-intl';
+import {Locale, useTranslations} from 'next-intl';
 import {setRequestLocale} from 'next-intl/server';
 import PageLayout from '@/components/PageLayout';
 
 type Props = {
-  params: {locale: string};
+  params: {locale: Locale};
 };
 
 export default function PathnamesPage({params: {locale}}: Props) {

--- a/examples/example-app-router/src/app/sitemap.ts
+++ b/examples/example-app-router/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import {MetadataRoute} from 'next';
+import {Locale} from 'next-intl';
 import {host} from '@/config';
-import {Locale, getPathname, routing} from '@/i18n/routing';
+import {getPathname, routing} from '@/i18n/routing';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [getEntry('/'), getEntry('/pathnames')];

--- a/examples/example-app-router/src/components/LocaleSwitcherSelect.tsx
+++ b/examples/example-app-router/src/components/LocaleSwitcherSelect.tsx
@@ -2,8 +2,9 @@
 
 import clsx from 'clsx';
 import {useParams} from 'next/navigation';
+import {Locale} from 'next-intl';
 import {ChangeEvent, ReactNode, useTransition} from 'react';
-import {Locale, usePathname, useRouter} from '@/i18n/routing';
+import {usePathname, useRouter} from '@/i18n/routing';
 
 type Props = {
   children: ReactNode;

--- a/examples/example-app-router/src/i18n/request.ts
+++ b/examples/example-app-router/src/i18n/request.ts
@@ -1,14 +1,13 @@
+import {isValidLocale} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 import {routing} from './routing';
 
 export default getRequestConfig(async ({requestLocale}) => {
-  // This typically corresponds to the `[locale]` segment
-  let locale = await requestLocale;
-
-  // Ensure that the incoming `locale` is valid
-  if (!locale || !routing.locales.includes(locale as any)) {
-    locale = routing.defaultLocale;
-  }
+  // Typically corresponds to the `[locale]` segment
+  const requested = await requestLocale;
+  const locale = isValidLocale(routing.locales, requested)
+    ? requested
+    : routing.defaultLocale;
 
   return {
     locale,

--- a/examples/example-app-router/src/i18n/request.ts
+++ b/examples/example-app-router/src/i18n/request.ts
@@ -1,11 +1,11 @@
-import {isValidLocale} from 'next-intl';
+import {hasLocale} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 import {routing} from './routing';
 
 export default getRequestConfig(async ({requestLocale}) => {
   // Typically corresponds to the `[locale]` segment
   const requested = await requestLocale;
-  const locale = isValidLocale(routing.locales, requested)
+  const locale = hasLocale(routing.locales, requested)
     ? requested
     : routing.defaultLocale;
 

--- a/examples/example-app-router/src/i18n/routing.ts
+++ b/examples/example-app-router/src/i18n/routing.ts
@@ -13,8 +13,5 @@ export const routing = defineRouting({
   }
 });
 
-export type Pathnames = keyof typeof routing.pathnames;
-export type Locale = (typeof routing.locales)[number];
-
 export const {Link, getPathname, redirect, usePathname, useRouter} =
   createNavigation(routing);

--- a/examples/example-pages-router-advanced/global.d.ts
+++ b/examples/example-pages-router-advanced/global.d.ts
@@ -1,8 +1,8 @@
+import 'next-intl';
 import en from './messages/en.json';
 
-type Messages = typeof en;
-
-declare global {
-  // Use type safe message keys with `next-intl`
-  interface IntlMessages extends Messages {}
+declare module 'next-intl' {
+  interface AppConfig {
+    Messages: typeof en;
+  }
 }

--- a/examples/example-pages-router-advanced/global.d.ts
+++ b/examples/example-pages-router-advanced/global.d.ts
@@ -1,4 +1,3 @@
-import 'next-intl';
 import en from './messages/en.json';
 
 declare module 'next-intl' {

--- a/examples/example-pages-router-advanced/src/pages/_app.tsx
+++ b/examples/example-pages-router-advanced/src/pages/_app.tsx
@@ -1,9 +1,9 @@
 import {AppProps} from 'next/app';
 import {useRouter} from 'next/router';
-import {NextIntlClientProvider} from 'next-intl';
+import {Messages, NextIntlClientProvider} from 'next-intl';
 
 type PageProps = {
-  messages: IntlMessages;
+  messages: Messages;
   now: number;
 };
 

--- a/examples/example-pages-router/global.d.ts
+++ b/examples/example-pages-router/global.d.ts
@@ -1,8 +1,8 @@
+import 'next-intl';
 import en from './messages/en.json';
 
-type Messages = typeof en;
-
-declare global {
-  // Use type safe message keys with `next-intl`
-  interface IntlMessages extends Messages {}
+declare module 'next-intl' {
+  interface AppConfig {
+    Messages: typeof en;
+  }
 }

--- a/examples/example-pages-router/global.d.ts
+++ b/examples/example-pages-router/global.d.ts
@@ -1,4 +1,3 @@
-import 'next-intl';
 import en from './messages/en.json';
 
 declare module 'next-intl' {

--- a/examples/example-use-intl/global.d.ts
+++ b/examples/example-use-intl/global.d.ts
@@ -1,8 +1,8 @@
-import 'next-intl';
-import {locales} from '@/config';
+import 'use-intl';
 import en from './messages/en.json';
+import {locales} from './src/config';
 
-declare module 'next-intl' {
+declare module 'use-intl' {
   interface AppConfig {
     Locale: (typeof locales)[number];
     Messages: typeof en;

--- a/examples/example-use-intl/messages/en.json
+++ b/examples/example-use-intl/messages/en.json
@@ -1,0 +1,5 @@
+{
+  "App": {
+    "hello": "Hello {username}!"
+  }
+}

--- a/examples/example-use-intl/src/config.tsx
+++ b/examples/example-use-intl/src/config.tsx
@@ -1,0 +1,1 @@
+export const locales = ['en'] as const;

--- a/examples/example-use-intl/src/main.tsx
+++ b/examples/example-use-intl/src/main.tsx
@@ -1,16 +1,13 @@
 import {StrictMode} from 'react';
 import ReactDOM from 'react-dom/client';
 import {IntlProvider} from 'use-intl';
+import en from '../messages/en.json';
 import App from './App.tsx';
 
 // You can get the messages from anywhere you like. You can also
 // fetch them from within a component and then render the provider
 // along with your app once you have the messages.
-const messages = {
-  App: {
-    hello: 'Hello {username}!'
-  }
-};
+const messages = en;
 
 const node = document.getElementById('root');
 

--- a/examples/example-use-intl/tsconfig.json
+++ b/examples/example-use-intl/tsconfig.json
@@ -13,6 +13,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["**/*.ts", "**/*.tsx"],
+  "include": ["src", "global.d.ts"],
   "references": [{"path": "./tsconfig.node.json"}]
 }

--- a/examples/example-use-intl/tsconfig.json
+++ b/examples/example-use-intl/tsconfig.json
@@ -13,6 +13,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"],
+  "include": ["**/*.ts", "**/*.tsx"],
   "references": [{"path": "./tsconfig.node.json"}]
 }

--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -4,7 +4,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-client, production)",
     path: 'dist/esm/production/index.react-client.js',
-    limit: '13.11 KB'
+    limit: '13.175 KB'
   },
   {
     name: "import {NextIntlClientProvider} from 'next-intl' (react-client, production)",

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -59,7 +59,7 @@ export default function getAlternateLinksHeaderValue<
     routing.localePrefix
   );
 
-  function getAlternateEntry(url: URL, locale: string) {
+  function getAlternateEntry(url: URL, locale: AppLocales[number]) {
     url.pathname = normalizeTrailingSlash(url.pathname);
 
     if (request.nextUrl.basePath) {

--- a/packages/next-intl/src/middleware/resolveLocale.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.tsx
@@ -1,6 +1,7 @@
 import {match} from '@formatjs/intl-localematcher';
 import Negotiator from 'negotiator';
 import {RequestCookies} from 'next/dist/server/web/spec-extension/cookies.js';
+import type {Locale} from 'use-intl';
 import {ResolvedRoutingConfig} from '../routing/config.tsx';
 import {
   DomainConfig,
@@ -36,7 +37,7 @@ function orderLocales<AppLocales extends Locales>(locales: AppLocales) {
 export function getAcceptLanguageLocale<AppLocales extends Locales>(
   requestHeaders: Headers,
   locales: AppLocales,
-  defaultLocale: string
+  defaultLocale: Locale
 ) {
   let locale;
 
@@ -47,12 +48,7 @@ export function getAcceptLanguageLocale<AppLocales extends Locales>(
   }).languages();
   try {
     const orderedLocales = orderLocales(locales);
-
-    locale = match(
-      languages,
-      orderedLocales as unknown as Array<string>,
-      defaultLocale
-    );
+    locale = match(languages, orderedLocales, defaultLocale);
   } catch {
     // Invalid language
   }

--- a/packages/next-intl/src/middleware/syncCookie.tsx
+++ b/packages/next-intl/src/middleware/syncCookie.tsx
@@ -1,4 +1,5 @@
 import {NextRequest, NextResponse} from 'next/server.js';
+import type {Locale} from 'use-intl';
 import {
   InitializedLocaleCookieConfig,
   ResolvedRoutingConfig
@@ -20,7 +21,7 @@ export default function syncCookie<
 >(
   request: NextRequest,
   response: NextResponse,
-  locale: string,
+  locale: Locale,
   routing: Pick<
     ResolvedRoutingConfig<
       AppLocales,

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -1,3 +1,4 @@
+import type {Locale} from 'use-intl';
 import {
   DomainConfig,
   DomainsConfig,
@@ -254,7 +255,7 @@ export function getHost(requestHeaders: Headers) {
 }
 
 export function isLocaleSupportedOnDomain<AppLocales extends Locales>(
-  locale: string,
+  locale: Locale,
   domain: DomainConfig<AppLocales>
 ) {
   return (
@@ -266,7 +267,7 @@ export function isLocaleSupportedOnDomain<AppLocales extends Locales>(
 
 export function getBestMatchingDomain<AppLocales extends Locales>(
   curHostDomain: DomainConfig<AppLocales> | undefined,
-  locale: string,
+  locale: Locale,
   domainsConfig: DomainsConfig<AppLocales>
 ) {
   let domainConfig;

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -6,7 +6,9 @@ import {
   useParams as nextUseParams
 } from 'next/navigation.js';
 import {renderToString} from 'react-dom/server';
+import {Locale} from 'use-intl';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {useLocale} from '../index.react-server.tsx';
 import {DomainsConfig, Pathnames, defineRouting} from '../routing.tsx';
 import createNavigationClient from './react-client/createNavigation.tsx';
 import createNavigationServer from './react-server/createNavigation.tsx';
@@ -24,7 +26,7 @@ vi.mock('next/navigation.js', async () => {
 });
 vi.mock('./react-server/getServerLocale');
 
-function mockCurrentLocale(locale: string) {
+function mockCurrentLocale(locale: Locale) {
   // Enable synchronous rendering without having to suspend
   const value = locale;
   const promise = Promise.resolve(value);
@@ -33,7 +35,7 @@ function mockCurrentLocale(locale: string) {
 
   vi.mocked(getServerLocale).mockImplementation(() => promise);
 
-  vi.mocked(nextUseParams<{locale: string}>).mockImplementation(() => ({
+  vi.mocked(nextUseParams<{locale: Locale}>).mockImplementation(() => ({
     locale
   }));
 }
@@ -214,6 +216,14 @@ describe.each([
         expect(markup).toContain('href="/en/about"');
         expect(consoleSpy).not.toHaveBeenCalled();
       });
+
+      it('can use a locale from `useLocale`', () => {
+        function Component() {
+          const locale = useLocale();
+          return <Link href="/about" locale={locale} />;
+        }
+        render(<Component />);
+      });
     });
 
     describe('getPathname', () => {
@@ -305,6 +315,17 @@ describe.each([
           true
         );
       });
+
+      it('can use a locale from `useLocale`', () => {
+        function Component() {
+          const locale = useLocale();
+          return getPathname({
+            locale,
+            href: '/about'
+          });
+        }
+        render(<Component />);
+      });
     });
 
     describe.each([
@@ -352,6 +373,14 @@ describe.each([
         redirectFn('/');
         // @ts-expect-error -- Missing locale
         redirectFn({pathname: '/about'});
+      });
+
+      it('can use a locale from `useLocale`', () => {
+        function Component() {
+          const locale = useLocale();
+          return redirectFn({href: '/about', locale});
+        }
+        render(<Component />);
       });
     });
   });

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -111,6 +111,19 @@ describe.each([
       localePrefix: 'always'
     });
 
+    describe('createNavigation', () => {
+      it('ensures `defaultLocale` is in `locales`', () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        () =>
+          createNavigation({
+            locales,
+            // @ts-expect-error
+            defaultLocale: 'zh',
+            localePrefix: 'always'
+          });
+      });
+    });
+
     describe('Link', () => {
       it('renders a prefix when currently on the default locale', () => {
         const markup = renderToString(<Link href="/about">About</Link>);

--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -4,15 +4,16 @@ import {
   useRouter as useNextRouter,
   useParams
 } from 'next/navigation.js';
+import type {Locale} from 'use-intl';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {NextIntlClientProvider} from '../../index.react-client.tsx';
+import {NextIntlClientProvider, useLocale} from '../../index.react-client.tsx';
 import {DomainsConfig, Pathnames} from '../../routing.tsx';
 import createNavigation from './createNavigation.tsx';
 
 vi.mock('next/navigation.js');
 
-function mockCurrentLocale(locale: string) {
-  vi.mocked(useParams<{locale: string}>).mockImplementation(() => ({
+function mockCurrentLocale(locale: Locale) {
+  vi.mocked(useParams<{locale: Locale}>).mockImplementation(() => ({
     locale
   }));
 }
@@ -169,14 +170,18 @@ describe("localePrefix: 'always'", () => {
       });
 
       it('prefixes with a secondary locale', () => {
-        // Being able to accept a string and not only a strictly typed locale is
-        // important in order to be able to use a result from `useLocale()`.
-        // This is less relevant for `Link`, but this should be in sync across
-        // al navigation APIs (see https://github.com/amannn/next-intl/issues/1377)
-        const locale = 'de' as string;
-
-        invokeRouter((router) => router[method]('/about', {locale}));
+        invokeRouter((router) => router[method]('/about', {locale: 'de'}));
         expect(useNextRouter()[method]).toHaveBeenCalledWith('/de/about');
+      });
+
+      it('can use a locale from `useLocale`', () => {
+        function Component() {
+          const locale = useLocale();
+          const router = useRouter();
+          router.push('/about', {locale});
+          return null;
+        }
+        render(<Component />);
       });
 
       it('passes through unknown options to the Next.js router', () => {

--- a/packages/next-intl/src/navigation/react-client/createNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.tsx
@@ -3,6 +3,7 @@ import {
   useRouter as useNextRouter
 } from 'next/navigation.js';
 import {useMemo} from 'react';
+import type {Locale} from 'use-intl';
 import useLocale from '../../react-client/useLocale.tsx';
 import {
   RoutingConfigLocalizedNavigation,
@@ -40,14 +41,8 @@ export default function createNavigation<
         AppDomains
       >
 ) {
-  type Locale = AppLocales extends never ? string : AppLocales[number];
-
-  function useTypedLocale() {
-    return useLocale() as Locale;
-  }
-
   const {Link, config, getPathname, ...redirects} = createSharedNavigationFns(
-    useTypedLocale,
+    useLocale,
     routing
   );
 
@@ -56,7 +51,7 @@ export default function createNavigation<
     ? string
     : keyof AppPathnames {
     const pathname = useBasePathname(config.localePrefix);
-    const locale = useTypedLocale();
+    const locale = useLocale();
 
     // @ts-expect-error -- Mirror the behavior from Next.js, where `null` is returned when `usePathname` is used outside of Next, but the types indicate that a string is always returned.
     return useMemo(
@@ -77,7 +72,7 @@ export default function createNavigation<
 
   function useRouter() {
     const router = useNextRouter();
-    const curLocale = useTypedLocale();
+    const curLocale = useLocale();
     const nextPathname = useNextPathname();
 
     return useMemo(() => {
@@ -87,7 +82,7 @@ export default function createNavigation<
       >(fn: Fn) {
         return function handler(
           href: Parameters<typeof getPathname>[0]['href'],
-          options?: Partial<Options> & {locale?: string}
+          options?: Partial<Options> & {locale?: Locale}
         ): void {
           const {locale: nextLocale, ...rest} = options || {};
 

--- a/packages/next-intl/src/navigation/react-server/createNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-server/createNavigation.tsx
@@ -32,14 +32,8 @@ export default function createNavigation<
         AppDomains
       >
 ) {
-  type Locale = AppLocales extends never ? string : AppLocales[number];
-
-  function getLocale() {
-    return getServerLocale() as Promise<Locale>;
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const {config, ...fns} = createSharedNavigationFns(getLocale, routing);
+  const {config, ...fns} = createSharedNavigationFns(getServerLocale, routing);
 
   function notSupported(hookName: string) {
     return () => {

--- a/packages/next-intl/src/navigation/shared/BaseLink.tsx
+++ b/packages/next-intl/src/navigation/shared/BaseLink.tsx
@@ -10,6 +10,7 @@ import {
   useEffect,
   useState
 } from 'react';
+import type {Locale} from 'use-intl';
 import useLocale from '../../react-client/useLocale.tsx';
 import {InitializedLocaleCookieConfig} from '../../routing/config.tsx';
 import syncLocaleCookie from './syncLocaleCookie.tsx';
@@ -18,12 +19,12 @@ type NextLinkProps = Omit<ComponentProps<'a'>, keyof LinkProps> &
   Omit<LinkProps, 'locale'>;
 
 type Props = NextLinkProps & {
-  locale?: string;
-  defaultLocale?: string;
+  locale?: Locale;
+  defaultLocale?: Locale;
   localeCookie: InitializedLocaleCookieConfig;
   /** Special case for `localePrefix: 'as-needed'` and `domains`. */
   unprefixed?: {
-    domains: {[domain: string]: string};
+    domains: {[domain: string]: Locale};
     pathname: string;
   };
 };

--- a/packages/next-intl/src/navigation/shared/syncLocaleCookie.tsx
+++ b/packages/next-intl/src/navigation/shared/syncLocaleCookie.tsx
@@ -1,3 +1,4 @@
+import type {Locale} from 'use-intl';
 import {InitializedLocaleCookieConfig} from '../../routing/config.tsx';
 import {getBasePath} from './utils.tsx';
 
@@ -9,8 +10,8 @@ import {getBasePath} from './utils.tsx';
 export default function syncLocaleCookie(
   localeCookie: InitializedLocaleCookieConfig,
   pathname: string | null,
-  locale: string,
-  nextLocale?: string
+  locale: Locale,
+  nextLocale?: Locale
 ) {
   const isSwitchingLocale = nextLocale !== locale && nextLocale != null;
 

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -1,5 +1,6 @@
 import type {ParsedUrlQueryInput} from 'node:querystring';
 import type {UrlObject} from 'url';
+import type {Locale} from 'use-intl';
 import {ResolvedRoutingConfig} from '../../routing/config.tsx';
 import {
   DomainsConfig,
@@ -49,7 +50,7 @@ export function normalizeNameOrNameWithParams<Pathname>(
   href:
     | HrefOrHrefWithParams<Pathname>
     | {
-        locale: string;
+        locale: Locale;
         href: HrefOrHrefWithParams<Pathname>;
       }
 ): {

--- a/packages/next-intl/src/react-client/useLocale.tsx
+++ b/packages/next-intl/src/react-client/useLocale.tsx
@@ -2,7 +2,7 @@ import {useLocale as useBaseLocale} from 'use-intl/react';
 import {LOCALE_SEGMENT_NAME} from '../shared/constants.tsx';
 import useParams from '../shared/useParams.tsx';
 
-export default function useLocale(): string {
+export default function useLocale(): ReturnType<typeof useBaseLocale> {
   const params = useParams();
 
   let locale;

--- a/packages/next-intl/src/react-server/getTranslator.tsx
+++ b/packages/next-intl/src/react-server/getTranslator.tsx
@@ -3,6 +3,7 @@ import {
   Formats,
   MarkupTranslationValues,
   MessageKeys,
+  Messages,
   NamespaceKeys,
   NestedKeyOf,
   NestedValueOf,
@@ -12,10 +13,7 @@ import {
 } from 'use-intl/core';
 
 function getTranslatorImpl<
-  NestedKey extends NamespaceKeys<
-    IntlMessages,
-    NestedKeyOf<IntlMessages>
-  > = never
+  NestedKey extends NamespaceKeys<Messages, NestedKeyOf<Messages>> = never
 >(
   config: Parameters<typeof createTranslator>[0],
   namespace?: NestedKey
@@ -25,12 +23,12 @@ function getTranslatorImpl<
   <
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -45,12 +43,12 @@ function getTranslatorImpl<
   rich<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -65,12 +63,12 @@ function getTranslatorImpl<
   markup<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -85,12 +83,12 @@ function getTranslatorImpl<
   raw<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -103,12 +101,12 @@ function getTranslatorImpl<
   has<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >

--- a/packages/next-intl/src/routing/types.tsx
+++ b/packages/next-intl/src/routing/types.tsx
@@ -1,3 +1,5 @@
+// We intentionally don't use `Locale` here to avoid a circular reference
+// when `routing` is used to initialize the `Locale` type.
 export type Locales = ReadonlyArray<string>;
 
 export type LocalePrefixMode = 'always' | 'as-needed' | 'never';

--- a/packages/next-intl/src/server/react-server/RequestLocale.tsx
+++ b/packages/next-intl/src/server/react-server/RequestLocale.tsx
@@ -1,5 +1,6 @@
 import {headers} from 'next/headers.js';
 import {cache} from 'react';
+import {Locale} from 'use-intl';
 import {HEADER_LOCALE_NAME} from '../../shared/constants.tsx';
 import {getCachedRequestLocale} from './RequestLocaleCache.tsx';
 
@@ -13,7 +14,7 @@ async function getHeadersImpl(): Promise<Headers> {
 }
 const getHeaders = cache(getHeadersImpl);
 
-async function getLocaleFromHeaderImpl(): Promise<string | undefined> {
+async function getLocaleFromHeaderImpl(): Promise<Locale | undefined> {
   let locale;
 
   try {

--- a/packages/next-intl/src/server/react-server/RequestLocaleCache.tsx
+++ b/packages/next-intl/src/server/react-server/RequestLocaleCache.tsx
@@ -1,8 +1,9 @@
 import {cache} from 'react';
+import type {Locale} from 'use-intl';
 
 // See https://github.com/vercel/next.js/discussions/58862
 function getCacheImpl() {
-  const value: {locale?: string} = {locale: undefined};
+  const value: {locale?: Locale} = {locale: undefined};
   return value;
 }
 
@@ -12,6 +13,6 @@ export function getCachedRequestLocale() {
   return getCache().locale;
 }
 
-export function setCachedRequestLocale(locale: string) {
+export function setCachedRequestLocale(locale: Locale) {
   getCache().locale = locale;
 }

--- a/packages/next-intl/src/server/react-server/getConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getConfig.tsx
@@ -1,6 +1,7 @@
 import {cache} from 'react';
 import {
   IntlConfig,
+  type Locale,
   _createCache,
   _createIntlFormatters,
   initializeConfig
@@ -24,7 +25,7 @@ const getDefaultTimeZone = cache(getDefaultTimeZoneImpl);
 
 async function receiveRuntimeConfigImpl(
   getConfig: typeof createRequestConfig,
-  localeOverride?: string
+  localeOverride?: Locale
 ) {
   if (
     process.env.NODE_ENV !== 'production' &&
@@ -76,7 +77,7 @@ const receiveRuntimeConfig = cache(receiveRuntimeConfigImpl);
 const getFormatters = cache(_createIntlFormatters);
 const getCache = cache(_createCache);
 
-async function getConfigImpl(localeOverride?: string): Promise<
+async function getConfigImpl(localeOverride?: Locale): Promise<
   IntlConfig & {
     getMessageFallback: NonNullable<IntlConfig['getMessageFallback']>;
     now: NonNullable<IntlConfig['now']>;

--- a/packages/next-intl/src/server/react-server/getFormatter.tsx
+++ b/packages/next-intl/src/server/react-server/getFormatter.tsx
@@ -1,8 +1,8 @@
 import {cache} from 'react';
-import {createFormatter} from 'use-intl/core';
+import {type Locale, createFormatter} from 'use-intl/core';
 import getConfig from './getConfig.tsx';
 
-async function getFormatterCachedImpl(locale?: string) {
+async function getFormatterCachedImpl(locale?: Locale) {
   const config = await getConfig(locale);
   return createFormatter(config);
 }
@@ -15,7 +15,7 @@ const getFormatterCached = cache(getFormatterCachedImpl);
  * you can override it by passing in additional options.
  */
 export default async function getFormatter(opts?: {
-  locale?: string;
+  locale?: Locale;
 }): Promise<ReturnType<typeof createFormatter>> {
   return getFormatterCached(opts?.locale);
 }

--- a/packages/next-intl/src/server/react-server/getLocale.tsx
+++ b/packages/next-intl/src/server/react-server/getLocale.tsx
@@ -1,7 +1,8 @@
 import {cache} from 'react';
+import {Locale} from 'use-intl';
 import getConfig from './getConfig.tsx';
 
-async function getLocaleCachedImpl() {
+async function getLocaleCachedImpl(): Promise<Locale> {
   const config = await getConfig();
   return config.locale;
 }

--- a/packages/next-intl/src/server/react-server/getMessages.tsx
+++ b/packages/next-intl/src/server/react-server/getMessages.tsx
@@ -1,5 +1,5 @@
 import {cache} from 'react';
-import type {useMessages as useMessagesType} from 'use-intl';
+import type {Locale, useMessages as useMessagesType} from 'use-intl';
 import getConfig from './getConfig.tsx';
 
 export function getMessagesFromConfig(
@@ -13,12 +13,12 @@ export function getMessagesFromConfig(
   return config.messages;
 }
 
-async function getMessagesCachedImpl(locale?: string) {
+async function getMessagesCachedImpl(locale?: Locale) {
   const config = await getConfig(locale);
   return getMessagesFromConfig(config);
 }
 const getMessagesCached = cache(getMessagesCachedImpl);
 
-export default async function getMessages(opts?: {locale?: string}) {
+export default async function getMessages(opts?: {locale?: Locale}) {
   return getMessagesCached(opts?.locale);
 }

--- a/packages/next-intl/src/server/react-server/getMessages.tsx
+++ b/packages/next-intl/src/server/react-server/getMessages.tsx
@@ -19,6 +19,8 @@ async function getMessagesCachedImpl(locale?: Locale) {
 }
 const getMessagesCached = cache(getMessagesCachedImpl);
 
-export default async function getMessages(opts?: {locale?: Locale}) {
+export default async function getMessages(opts?: {
+  locale?: Locale;
+}): Promise<ReturnType<typeof useMessagesType>> {
   return getMessagesCached(opts?.locale);
 }

--- a/packages/next-intl/src/server/react-server/getNow.tsx
+++ b/packages/next-intl/src/server/react-server/getNow.tsx
@@ -1,12 +1,13 @@
 import {cache} from 'react';
+import type {Locale} from 'use-intl';
 import getConfig from './getConfig.tsx';
 
-async function getNowCachedImpl(locale?: string) {
+async function getNowCachedImpl(locale?: Locale) {
   const config = await getConfig(locale);
   return config.now;
 }
 const getNowCached = cache(getNowCachedImpl);
 
-export default async function getNow(opts?: {locale?: string}): Promise<Date> {
+export default async function getNow(opts?: {locale?: Locale}): Promise<Date> {
   return getNowCached(opts?.locale);
 }

--- a/packages/next-intl/src/server/react-server/getTimeZone.tsx
+++ b/packages/next-intl/src/server/react-server/getTimeZone.tsx
@@ -1,14 +1,15 @@
 import {cache} from 'react';
+import type {Locale} from 'use-intl';
 import getConfig from './getConfig.tsx';
 
-async function getTimeZoneCachedImpl(locale?: string) {
+async function getTimeZoneCachedImpl(locale?: Locale) {
   const config = await getConfig(locale);
   return config.timeZone;
 }
 const getTimeZoneCached = cache(getTimeZoneCachedImpl);
 
 export default async function getTimeZone(opts?: {
-  locale?: string;
-}): Promise<string> {
+  locale?: Locale;
+}): Promise<Locale> {
   return getTimeZoneCached(opts?.locale);
 }

--- a/packages/next-intl/src/server/react-server/getTranslations.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslations.tsx
@@ -1,6 +1,7 @@
 import {ReactNode, cache} from 'react';
 import {
   Formats,
+  Locale,
   MarkupTranslationValues,
   MessageKeys,
   NamespaceKeys,
@@ -129,7 +130,7 @@ function getTranslations<
     NestedKeyOf<IntlMessages>
   > = never
 >(opts?: {
-  locale: string;
+  locale: Locale;
   namespace?: NestedKey;
 }): // Explicitly defining the return type is necessary as TypeScript would get it wrong
 Promise<{
@@ -217,9 +218,9 @@ async function getTranslations<
     IntlMessages,
     NestedKeyOf<IntlMessages>
   > = never
->(namespaceOrOpts?: NestedKey | {locale: string; namespace?: NestedKey}) {
+>(namespaceOrOpts?: NestedKey | {locale: Locale; namespace?: NestedKey}) {
   let namespace: NestedKey | undefined;
-  let locale: string | undefined;
+  let locale: Locale | undefined;
 
   if (typeof namespaceOrOpts === 'string') {
     namespace = namespaceOrOpts;

--- a/packages/next-intl/src/server/react-server/getTranslations.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslations.tsx
@@ -4,6 +4,7 @@ import {
   Locale,
   MarkupTranslationValues,
   MessageKeys,
+  Messages,
   NamespaceKeys,
   NestedKeyOf,
   NestedValueOf,
@@ -19,10 +20,7 @@ import getConfig from './getConfig.tsx';
 
 // CALL SIGNATURE 1: `getTranslations(namespace)`
 function getTranslations<
-  NestedKey extends NamespaceKeys<
-    IntlMessages,
-    NestedKeyOf<IntlMessages>
-  > = never
+  NestedKey extends NamespaceKeys<Messages, NestedKeyOf<Messages>> = never
 >(
   namespace?: NestedKey
 ): // Explicitly defining the return type is necessary as TypeScript would get it wrong
@@ -31,12 +29,12 @@ Promise<{
   <
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -51,12 +49,12 @@ Promise<{
   rich<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -71,12 +69,12 @@ Promise<{
   markup<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -91,12 +89,12 @@ Promise<{
   raw<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -109,12 +107,12 @@ Promise<{
   has<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -125,10 +123,7 @@ Promise<{
 }>;
 // CALL SIGNATURE 2: `getTranslations({locale, namespace})`
 function getTranslations<
-  NestedKey extends NamespaceKeys<
-    IntlMessages,
-    NestedKeyOf<IntlMessages>
-  > = never
+  NestedKey extends NamespaceKeys<Messages, NestedKeyOf<Messages>> = never
 >(opts?: {
   locale: Locale;
   namespace?: NestedKey;
@@ -138,12 +133,12 @@ Promise<{
   <
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -158,12 +153,12 @@ Promise<{
   rich<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -178,12 +173,12 @@ Promise<{
   markup<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -198,12 +193,12 @@ Promise<{
   raw<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -214,10 +209,7 @@ Promise<{
 }>;
 // IMPLEMENTATION
 async function getTranslations<
-  NestedKey extends NamespaceKeys<
-    IntlMessages,
-    NestedKeyOf<IntlMessages>
-  > = never
+  NestedKey extends NamespaceKeys<Messages, NestedKeyOf<Messages>> = never
 >(namespaceOrOpts?: NestedKey | {locale: Locale; namespace?: NestedKey}) {
   let namespace: NestedKey | undefined;
   let locale: Locale | undefined;

--- a/packages/next-intl/src/shared/NextIntlClientProvider.test.tsx
+++ b/packages/next-intl/src/shared/NextIntlClientProvider.test.tsx
@@ -1,4 +1,5 @@
 import {render, screen} from '@testing-library/react';
+import type {Locale} from 'use-intl';
 import {it, vi} from 'vitest';
 import {
   NextIntlClientProvider,
@@ -16,7 +17,7 @@ function Component() {
   return <>{t('message', {price: 29000.5})}</>;
 }
 
-function TestProvider({locale}: {locale?: string}) {
+function TestProvider({locale}: {locale?: Locale}) {
   return (
     <NextIntlClientProvider
       locale={locale}

--- a/packages/next-intl/src/shared/NextIntlClientProvider.tsx
+++ b/packages/next-intl/src/shared/NextIntlClientProvider.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import {ComponentProps} from 'react';
+import type {Locale} from 'use-intl';
 import {IntlProvider} from 'use-intl/react';
 import {LOCALE_SEGMENT_NAME} from './constants.tsx';
 import useParams from './useParams.tsx';
 
 type Props = Omit<ComponentProps<typeof IntlProvider>, 'locale'> & {
   /** This is automatically received when being rendered from a Server Component. In all other cases, e.g. when rendered from a Client Component, a unit test or with the Pages Router, you can pass this prop explicitly. */
-  locale?: string;
+  locale?: Locale;
 };
 
 export default function NextIntlClientProvider({locale, ...rest}: Props) {

--- a/packages/next-intl/types/index.d.ts
+++ b/packages/next-intl/types/index.d.ts
@@ -4,8 +4,6 @@ declare namespace NodeJS {
   }
 }
 
-declare interface IntlMessages extends Record<string, any> {}
-
 // Temporarly copied here until the "es2020.intl" lib is published.
 declare namespace Intl {
   /**

--- a/packages/use-intl/.size-limit.ts
+++ b/packages/use-intl/.size-limit.ts
@@ -5,7 +5,7 @@ const config: SizeLimitConfig = [
     name: "import * from 'use-intl' (production)",
     import: '*',
     path: 'dist/esm/production/index.js',
-    limit: '12.975 kB'
+    limit: '12.985 kB'
   },
   {
     name: "import {IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter} from 'use-intl' (production)",

--- a/packages/use-intl/.size-limit.ts
+++ b/packages/use-intl/.size-limit.ts
@@ -5,7 +5,7 @@ const config: SizeLimitConfig = [
     name: "import * from 'use-intl' (production)",
     import: '*',
     path: 'dist/esm/production/index.js',
-    limit: '12.965 kB'
+    limit: '12.975 kB'
   },
   {
     name: "import {IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter} from 'use-intl' (production)",

--- a/packages/use-intl/.size-limit.ts
+++ b/packages/use-intl/.size-limit.ts
@@ -13,12 +13,6 @@ const config: SizeLimitConfig = [
     import:
       '{IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter}',
     limit: '1.975 kB'
-  },
-  {
-    name: "import * from 'use-intl' (development)",
-    import: '*',
-    path: 'dist/esm/development/index.js',
-    limit: '13.905 kB'
   }
 ];
 

--- a/packages/use-intl/src/core/AbstractIntlMessages.tsx
+++ b/packages/use-intl/src/core/AbstractIntlMessages.tsx
@@ -1,7 +1,7 @@
 /**
  * A generic type that describes the shape of messages.
  *
- * Optionally, `IntlMessages` can be provided to get type safety for message
+ * Optionally, messages can be strictly-typed in order to get type safety for message
  * namespaces and keys. See https://next-intl-docs.vercel.app/docs/usage/typescript
  */
 type AbstractIntlMessages = {

--- a/packages/use-intl/src/core/AppConfig.tsx
+++ b/packages/use-intl/src/core/AppConfig.tsx
@@ -29,3 +29,9 @@ export type FormatNames = AppConfig extends {
       number: string;
       list: string;
     };
+
+export type Messages = AppConfig extends {
+  Messages: infer AppMessages;
+}
+  ? AppMessages
+  : Record<string, any>;

--- a/packages/use-intl/src/core/AppConfig.tsx
+++ b/packages/use-intl/src/core/AppConfig.tsx
@@ -1,7 +1,7 @@
 export default interface AppConfig {
   // Locale
   // Formats
-  // Messages (todo)
+  // Messages
 }
 
 export type Locale = AppConfig extends {

--- a/packages/use-intl/src/core/AppConfig.tsx
+++ b/packages/use-intl/src/core/AppConfig.tsx
@@ -1,11 +1,31 @@
 export default interface AppConfig {
   // Locale
-  // Formats (todo)
+  // Formats
   // Messages (todo)
 }
 
 export type Locale = AppConfig extends {
-  Locale: infer UserLocale;
+  Locale: infer AppLocale;
 }
-  ? UserLocale
+  ? AppLocale
   : string;
+
+export type FormatNames = AppConfig extends {
+  Formats: infer AppFormats;
+}
+  ? {
+      dateTime: AppFormats extends {dateTime: infer AppDateTimeFormats}
+        ? keyof AppDateTimeFormats
+        : string;
+      number: AppFormats extends {number: infer AppNumberFormats}
+        ? keyof AppNumberFormats
+        : string;
+      list: AppFormats extends {list: infer AppListFormats}
+        ? keyof AppListFormats
+        : string;
+    }
+  : {
+      dateTime: string;
+      number: string;
+      list: string;
+    };

--- a/packages/use-intl/src/core/AppConfig.tsx
+++ b/packages/use-intl/src/core/AppConfig.tsx
@@ -1,0 +1,11 @@
+export default interface AppConfig {
+  // Locale
+  // Formats (todo)
+  // Messages (todo)
+}
+
+export type Locale = AppConfig extends {
+  Locale: infer UserLocale;
+}
+  ? UserLocale
+  : string;

--- a/packages/use-intl/src/core/IntlConfig.tsx
+++ b/packages/use-intl/src/core/IntlConfig.tsx
@@ -1,4 +1,5 @@
 import type AbstractIntlMessages from './AbstractIntlMessages.tsx';
+import type {Locale} from './AppConfig.tsx';
 import type Formats from './Formats.tsx';
 import type IntlError from './IntlError.tsx';
 import type TimeZone from './TimeZone.tsx';
@@ -9,7 +10,7 @@ import type TimeZone from './TimeZone.tsx';
 
 type IntlConfig<Messages = AbstractIntlMessages> = {
   /** A valid Unicode locale tag (e.g. "en" or "en-GB"). */
-  locale: string;
+  locale: Locale;
   /** Global formats can be provided to achieve consistent
    * formatting across components. */
   formats?: Formats;

--- a/packages/use-intl/src/core/createBaseTranslator.tsx
+++ b/packages/use-intl/src/core/createBaseTranslator.tsx
@@ -1,6 +1,7 @@
 import {IntlMessageFormat} from 'intl-messageformat';
 import {ReactNode, cloneElement, isValidElement} from 'react';
 import AbstractIntlMessages from './AbstractIntlMessages.tsx';
+import {Locale} from './AppConfig.tsx';
 import Formats from './Formats.tsx';
 import {InitializedIntlConfig} from './IntlConfig.tsx';
 import IntlError, {IntlErrorCode} from './IntlError.tsx';
@@ -41,7 +42,7 @@ function createMessageFormatter(
 }
 
 function resolvePath(
-  locale: string,
+  locale: Locale,
   messages: AbstractIntlMessages | undefined,
   key: string,
   namespace?: string
@@ -103,7 +104,7 @@ function prepareTranslationValues(values: RichTranslationValues) {
 }
 
 function getMessagesOrError<Messages extends AbstractIntlMessages>(
-  locale: string,
+  locale: Locale,
   messages?: Messages,
   namespace?: string,
   onError: (error: IntlError) => void = defaultOnError

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -1,5 +1,5 @@
 import {ReactElement} from 'react';
-import {Locale} from './AppConfig.tsx';
+import {FormatNames, Locale} from './AppConfig.tsx';
 import DateTimeFormatOptions from './DateTimeFormatOptions.tsx';
 import Formats from './Formats.tsx';
 import IntlError, {IntlErrorCode} from './IntlError.tsx';
@@ -164,9 +164,7 @@ export default function createFormatter({
     value: Date | number,
     /** If a time zone is supplied, the `value` is converted to that time zone.
      * Otherwise the user time zone will be used. */
-    formatOrOptions?:
-      | Extract<keyof IntlFormats['dateTime'], string>
-      | DateTimeFormatOptions
+    formatOrOptions?: FormatNames['dateTime'] | DateTimeFormatOptions
   ) {
     return getFormattedValue(
       formatOrOptions,
@@ -186,9 +184,7 @@ export default function createFormatter({
     end: Date | number,
     /** If a time zone is supplied, the values are converted to that time zone.
      * Otherwise the user time zone will be used. */
-    formatOrOptions?:
-      | Extract<keyof IntlFormats['dateTime'], string>
-      | DateTimeFormatOptions
+    formatOrOptions?: FormatNames['dateTime'] | DateTimeFormatOptions
   ) {
     return getFormattedValue(
       formatOrOptions,
@@ -205,9 +201,7 @@ export default function createFormatter({
 
   function number(
     value: number | bigint,
-    formatOrOptions?:
-      | Extract<keyof IntlFormats['number'], string>
-      | NumberFormatOptions
+    formatOrOptions?: FormatNames['number'] | NumberFormatOptions
   ) {
     return getFormattedValue(
       formatOrOptions,
@@ -291,9 +285,7 @@ export default function createFormatter({
   type FormattableListValue = string | ReactElement;
   function list<Value extends FormattableListValue>(
     value: Iterable<Value>,
-    formatOrOptions?:
-      | Extract<keyof IntlFormats['list'], string>
-      | Intl.ListFormatOptions
+    formatOrOptions?: FormatNames['list'] | Intl.ListFormatOptions
   ): Value extends string ? string : Iterable<ReactElement> {
     const serializedValue: Array<string> = [];
     const richValues = new Map<string, Value>();

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -1,4 +1,5 @@
 import {ReactElement} from 'react';
+import {Locale} from './AppConfig.tsx';
 import DateTimeFormatOptions from './DateTimeFormatOptions.tsx';
 import Formats from './Formats.tsx';
 import IntlError, {IntlErrorCode} from './IntlError.tsx';
@@ -70,7 +71,7 @@ function calculateRelativeTimeValue(
 }
 
 type Props = {
-  locale: string;
+  locale: Locale;
   timeZone?: TimeZone;
   onError?(error: IntlError): void;
   formats?: Formats;

--- a/packages/use-intl/src/core/createTranslator.tsx
+++ b/packages/use-intl/src/core/createTranslator.tsx
@@ -1,4 +1,5 @@
 import {ReactNode} from 'react';
+import {Messages} from './AppConfig.tsx';
 import Formats from './Formats.tsx';
 import IntlConfig from './IntlConfig.tsx';
 import TranslationValues, {
@@ -27,10 +28,7 @@ import NestedValueOf from './utils/NestedValueOf.tsx';
  * (e.g. `namespace.Component`).
  */
 export default function createTranslator<
-  NestedKey extends NamespaceKeys<
-    IntlMessages,
-    NestedKeyOf<IntlMessages>
-  > = never
+  NestedKey extends NamespaceKeys<Messages, NestedKeyOf<Messages>> = never
 >({
   _cache = createCache(),
   _formatters = createIntlFormatters(_cache),
@@ -39,8 +37,8 @@ export default function createTranslator<
   namespace,
   onError = defaultOnError,
   ...rest
-}: Omit<IntlConfig<IntlMessages>, 'messages'> & {
-  messages?: IntlConfig<IntlMessages>['messages'];
+}: Omit<IntlConfig<Messages>, 'messages'> & {
+  messages?: IntlConfig<Messages>['messages'];
   namespace?: NestedKey;
   /** @private */
   _formatters?: Formatters;
@@ -52,12 +50,12 @@ export default function createTranslator<
   <
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -72,12 +70,12 @@ export default function createTranslator<
   rich<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -92,12 +90,12 @@ export default function createTranslator<
   markup<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -112,12 +110,12 @@ export default function createTranslator<
   raw<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -130,12 +128,12 @@ export default function createTranslator<
   has<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -148,7 +146,7 @@ export default function createTranslator<
   // namespace works correctly. See https://stackoverflow.com/a/71529575/343045
   // The prefix ("!") is arbitrary.
   return createTranslatorImpl<
-    {'!': IntlMessages},
+    {'!': Messages},
     [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
   >(
     {

--- a/packages/use-intl/src/core/hasLocale.test.tsx
+++ b/packages/use-intl/src/core/hasLocale.test.tsx
@@ -1,4 +1,4 @@
-import {describe, expect, it} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import hasLocale from './hasLocale.tsx';
 
 it('narrows down the type', () => {
@@ -26,6 +26,16 @@ it('can be called with a non-matching narrow candidate', () => {
 });
 
 describe('accepts valid formats', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   it.each([
     'en',
     'en-US',
@@ -49,10 +59,21 @@ describe('accepts valid formats', () => {
     'english'
   ])('accepts: %s', (locale) => {
     expect(hasLocale([locale] as const, locale)).toBe(true);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });
 
-describe('rejects invalid formats', () => {
+describe('warns for invalid formats', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   it.each([
     'en_US',
     'en-',
@@ -68,6 +89,7 @@ describe('rejects invalid formats', () => {
     'en US',
     'en.US'
   ])('rejects: %s', (locale) => {
-    expect(() => hasLocale([locale] as const, locale)).toThrow();
+    hasLocale([locale] as const, locale);
+    expect(consoleErrorSpy).toHaveBeenCalled();
   });
 });

--- a/packages/use-intl/src/core/hasLocale.test.tsx
+++ b/packages/use-intl/src/core/hasLocale.test.tsx
@@ -1,11 +1,27 @@
 import {describe, expect, it} from 'vitest';
-import isValidLocale from './isValidLocale.tsx';
+import hasLocale from './hasLocale.tsx';
 
 it('narrows down the type', () => {
   const locales = ['en-US', 'en-GB'] as const;
   const candidate = 'en-US' as string;
-  if (isValidLocale(locales, candidate)) {
+  if (hasLocale(locales, candidate)) {
     candidate satisfies (typeof locales)[number];
+  }
+});
+
+it('can be called with a matching narrow candidate', () => {
+  const locales = ['en-US', 'en-GB'] as const;
+  const candidate = 'en-US' as const;
+  if (hasLocale(locales, candidate)) {
+    candidate satisfies (typeof locales)[number];
+  }
+});
+
+it('can be called with a non-matching narrow candidate', () => {
+  const locales = ['en-US', 'en-GB'] as const;
+  const candidate = 'de' as const;
+  if (hasLocale(locales, candidate)) {
+    candidate satisfies never;
   }
 });
 
@@ -32,7 +48,7 @@ describe('accepts valid formats', () => {
     // Somehow tolerated by Intl.Locale
     'english'
   ])('accepts: %s', (locale) => {
-    expect(isValidLocale([locale] as const, locale)).toBe(true);
+    expect(hasLocale([locale] as const, locale)).toBe(true);
   });
 });
 
@@ -52,6 +68,6 @@ describe('rejects invalid formats', () => {
     'en US',
     'en.US'
   ])('rejects: %s', (locale) => {
-    expect(() => isValidLocale([locale] as const, locale)).toThrow();
+    expect(() => hasLocale([locale] as const, locale)).toThrow();
   });
 });

--- a/packages/use-intl/src/core/hasLocale.tsx
+++ b/packages/use-intl/src/core/hasLocale.tsx
@@ -1,14 +1,14 @@
 import type {Locale} from './AppConfig.tsx';
 
 /**
- * Validates a locale against a list of valid locales.
+ * Checks if a locale exists in a list of locales.
  *
- * Additionally, the provided locales are validated to
- * ensure they follow the IETF language tag standard.
+ * Additionally, in development, the provided locales are validated to
+ * ensure they follow the Unicode language identifier standard.
  *
- * @see https://en.wikipedia.org/wiki/IETF_language_tag#Extension_U_(Unicode_Locale)
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale
  */
-export default function isValidLocale<LocaleType extends Locale>(
+export default function hasLocale<LocaleType extends Locale>(
   locales: ReadonlyArray<LocaleType>,
   candidate?: string | null
 ): candidate is LocaleType {
@@ -21,7 +21,7 @@ export default function isValidLocale<LocaleType extends Locale>(
         }
       } catch (cause) {
         throw new Error(
-          `Found invalid locale within provided \`locales\`: "${locale}"\nPlease ensure you're using valid IETF language tags (e.g. "en-US").`,
+          `Found invalid locale within provided \`locales\`: "${locale}"\nPlease ensure you're using a valid Unicode locale identifier (e.g. "en-US").`,
           {cause}
         );
       }

--- a/packages/use-intl/src/core/hasLocale.tsx
+++ b/packages/use-intl/src/core/hasLocale.tsx
@@ -19,10 +19,9 @@ export default function hasLocale<LocaleType extends Locale>(
         if (!constructed.language) {
           throw new Error('Language is required');
         }
-      } catch (cause) {
-        throw new Error(
-          `Found invalid locale within provided \`locales\`: "${locale}"\nPlease ensure you're using a valid Unicode locale identifier (e.g. "en-US").`,
-          {cause}
+      } catch {
+        console.error(
+          `Found invalid locale within provided \`locales\`: "${locale}"\nPlease ensure you're using a valid Unicode locale identifier (e.g. "en-US").`
         );
       }
     }

--- a/packages/use-intl/src/core/index.tsx
+++ b/packages/use-intl/src/core/index.tsx
@@ -19,4 +19,4 @@ export type {default as NestedValueOf} from './utils/NestedValueOf.tsx';
 export {createIntlFormatters as _createIntlFormatters} from './formatters.tsx';
 export {createCache as _createCache} from './formatters.tsx';
 export type {default as AppConfig, Locale, Messages} from './AppConfig.tsx';
-export {default as isValidLocale} from './isValidLocale.tsx';
+export {default as hasLocale} from './hasLocale.tsx';

--- a/packages/use-intl/src/core/index.tsx
+++ b/packages/use-intl/src/core/index.tsx
@@ -18,5 +18,5 @@ export type {default as NestedKeyOf} from './utils/NestedKeyOf.tsx';
 export type {default as NestedValueOf} from './utils/NestedValueOf.tsx';
 export {createIntlFormatters as _createIntlFormatters} from './formatters.tsx';
 export {createCache as _createCache} from './formatters.tsx';
-export type {default as AppConfig, Locale} from './AppConfig.tsx';
+export type {default as AppConfig, Locale, Messages} from './AppConfig.tsx';
 export {default as isValidLocale} from './isValidLocale.tsx';

--- a/packages/use-intl/src/core/index.tsx
+++ b/packages/use-intl/src/core/index.tsx
@@ -18,3 +18,5 @@ export type {default as NestedKeyOf} from './utils/NestedKeyOf.tsx';
 export type {default as NestedValueOf} from './utils/NestedValueOf.tsx';
 export {createIntlFormatters as _createIntlFormatters} from './formatters.tsx';
 export {createCache as _createCache} from './formatters.tsx';
+export type {default as AppConfig, Locale} from './AppConfig.tsx';
+export {default as isValidLocale} from './isValidLocale.tsx';

--- a/packages/use-intl/src/core/isValidLocale.test.tsx
+++ b/packages/use-intl/src/core/isValidLocale.test.tsx
@@ -1,0 +1,10 @@
+import {it} from 'vitest';
+import isValidLocale from './isValidLocale.tsx';
+
+it('narrows down the type', () => {
+  const locales = ['en-US', 'en-GB'] as const;
+  const candidate = 'en-US' as string;
+  if (isValidLocale(locales, candidate)) {
+    candidate satisfies (typeof locales)[number];
+  }
+});

--- a/packages/use-intl/src/core/isValidLocale.test.tsx
+++ b/packages/use-intl/src/core/isValidLocale.test.tsx
@@ -1,4 +1,4 @@
-import {it} from 'vitest';
+import {describe, expect, it} from 'vitest';
 import isValidLocale from './isValidLocale.tsx';
 
 it('narrows down the type', () => {
@@ -7,4 +7,51 @@ it('narrows down the type', () => {
   if (isValidLocale(locales, candidate)) {
     candidate satisfies (typeof locales)[number];
   }
+});
+
+describe('accepts valid formats', () => {
+  it.each([
+    'en',
+    'en-US',
+    'EN-US',
+    'en-us',
+    'en-GB',
+    'zh-Hans-CN',
+    'es-419',
+    'en-Latn',
+    'zh-Hans',
+    'en-US-u-ca-buddhist',
+    'en-x-private1',
+    'en-US-u-nu-thai',
+    'ar-u-nu-arab',
+    'en-t-m0-true',
+    'zh-Hans-CN-x-private1-private2',
+    'en-US-u-ca-gregory-nu-latn',
+    'en-US-x-usd',
+
+    // Somehow tolerated by Intl.Locale
+    'english'
+  ])('accepts: %s', (locale) => {
+    expect(isValidLocale([locale] as const, locale)).toBe(true);
+  });
+});
+
+describe('rejects invalid formats', () => {
+  it.each([
+    'en_US',
+    'en-',
+    'e-US',
+    'en-USA',
+    'und',
+    '123',
+    '-en',
+    'en--US',
+    'toolongstring',
+    'en-US-',
+    '@#$',
+    'en US',
+    'en.US'
+  ])('rejects: %s', (locale) => {
+    expect(() => isValidLocale([locale] as const, locale)).toThrow();
+  });
 });

--- a/packages/use-intl/src/core/isValidLocale.tsx
+++ b/packages/use-intl/src/core/isValidLocale.tsx
@@ -1,0 +1,8 @@
+import type {Locale} from './AppConfig.tsx';
+
+export default function isValidLocale<LocaleType extends Locale>(
+  locales: ReadonlyArray<LocaleType>,
+  candidate?: string
+): candidate is LocaleType {
+  return locales.includes(candidate as LocaleType);
+}

--- a/packages/use-intl/src/core/isValidLocale.tsx
+++ b/packages/use-intl/src/core/isValidLocale.tsx
@@ -10,7 +10,7 @@ import type {Locale} from './AppConfig.tsx';
  */
 export default function isValidLocale<LocaleType extends Locale>(
   locales: ReadonlyArray<LocaleType>,
-  candidate?: string
+  candidate?: string | null
 ): candidate is LocaleType {
   if (process.env.NODE_ENV !== 'production') {
     for (const locale of locales) {

--- a/packages/use-intl/src/core/isValidLocale.tsx
+++ b/packages/use-intl/src/core/isValidLocale.tsx
@@ -1,8 +1,32 @@
 import type {Locale} from './AppConfig.tsx';
 
+/**
+ * Validates a locale against a list of valid locales.
+ *
+ * Additionally, the provided locales are validated to
+ * ensure they follow the IETF language tag standard.
+ *
+ * @see https://en.wikipedia.org/wiki/IETF_language_tag#Extension_U_(Unicode_Locale)
+ */
 export default function isValidLocale<LocaleType extends Locale>(
   locales: ReadonlyArray<LocaleType>,
   candidate?: string
 ): candidate is LocaleType {
+  if (process.env.NODE_ENV !== 'production') {
+    for (const locale of locales) {
+      try {
+        const constructed = new Intl.Locale(locale);
+        if (!constructed.language) {
+          throw new Error('Language is required');
+        }
+      } catch (cause) {
+        throw new Error(
+          `Found invalid locale within provided \`locales\`: "${locale}"\nPlease ensure you're using valid IETF language tags (e.g. "en-US").`,
+          {cause}
+        );
+      }
+    }
+  }
+
   return locales.includes(candidate as LocaleType);
 }

--- a/packages/use-intl/src/react/index.test.tsx
+++ b/packages/use-intl/src/react/index.test.tsx
@@ -1,6 +1,7 @@
 import {render, screen} from '@testing-library/react';
 import {parseISO} from 'date-fns';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {Locale} from '../core.tsx';
 import IntlProvider from './IntlProvider.tsx';
 import useFormatter from './useFormatter.tsx';
 import useNow from './useNow.tsx';
@@ -24,7 +25,7 @@ describe('performance', () => {
     );
   }
 
-  function App({locale}: {locale: string}) {
+  function App({locale}: {locale: Locale}) {
     return (
       <IntlProvider
         locale={locale}

--- a/packages/use-intl/src/react/useLocale.tsx
+++ b/packages/use-intl/src/react/useLocale.tsx
@@ -1,5 +1,6 @@
+import {Locale} from '../core.tsx';
 import useIntlContext from './useIntlContext.tsx';
 
-export default function useLocale() {
+export default function useLocale(): Locale {
   return useIntlContext().locale;
 }

--- a/packages/use-intl/src/react/useMessages.tsx
+++ b/packages/use-intl/src/react/useMessages.tsx
@@ -1,6 +1,7 @@
+import {Messages} from '../core/AppConfig.tsx';
 import useIntlContext from './useIntlContext.tsx';
 
-export default function useMessages(): IntlMessages {
+export default function useMessages(): Messages {
   const context = useIntlContext();
 
   if (!context.messages) {

--- a/packages/use-intl/src/react/useTranslations.tsx
+++ b/packages/use-intl/src/react/useTranslations.tsx
@@ -1,4 +1,5 @@
 import {ReactNode} from 'react';
+import {Messages} from '../core/AppConfig.tsx';
 import Formats from '../core/Formats.tsx';
 import TranslationValues, {
   MarkupTranslationValues,
@@ -20,10 +21,7 @@ import useTranslationsImpl from './useTranslationsImpl.tsx';
  * (e.g. `namespace.Component`).
  */
 export default function useTranslations<
-  NestedKey extends NamespaceKeys<
-    IntlMessages,
-    NestedKeyOf<IntlMessages>
-  > = never
+  NestedKey extends NamespaceKeys<Messages, NestedKeyOf<Messages>> = never
 >(
   namespace?: NestedKey
 ): // Explicitly defining the return type is necessary as TypeScript would get it wrong
@@ -32,12 +30,12 @@ export default function useTranslations<
   <
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -52,12 +50,12 @@ export default function useTranslations<
   rich<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -72,12 +70,12 @@ export default function useTranslations<
   markup<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -92,12 +90,12 @@ export default function useTranslations<
   raw<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -110,12 +108,12 @@ export default function useTranslations<
   has<
     TargetKey extends MessageKeys<
       NestedValueOf<
-        {'!': IntlMessages},
+        {'!': Messages},
         [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
       >,
       NestedKeyOf<
         NestedValueOf<
-          {'!': IntlMessages},
+          {'!': Messages},
           [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
         >
       >
@@ -125,13 +123,13 @@ export default function useTranslations<
   ): boolean;
 } {
   const context = useIntlContext();
-  const messages = context.messages as IntlMessages;
+  const messages = context.messages as Messages;
 
   // We have to wrap the actual hook so the type inference for the optional
   // namespace works correctly. See https://stackoverflow.com/a/71529575/343045
   // The prefix ("!") is arbitrary.
   return useTranslationsImpl<
-    {'!': IntlMessages},
+    {'!': Messages},
     [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
   >(
     {'!': messages},

--- a/packages/use-intl/types/index.d.ts
+++ b/packages/use-intl/types/index.d.ts
@@ -8,14 +8,6 @@ declare namespace NodeJS {
 // by the consumer for optional type safety of messages
 declare interface IntlMessages extends Record<string, any> {}
 
-// This type is intended to be overridden
-// by the consumer for optional type safety of formats
-declare interface IntlFormats {
-  dateTime: any;
-  number: any;
-  list: any;
-}
-
 // Temporarly copied here until the "es2020.intl" lib is published.
 
 declare namespace Intl {

--- a/packages/use-intl/types/index.d.ts
+++ b/packages/use-intl/types/index.d.ts
@@ -4,12 +4,7 @@ declare namespace NodeJS {
   }
 }
 
-// This type is intended to be overridden
-// by the consumer for optional type safety of messages
-declare interface IntlMessages extends Record<string, any> {}
-
 // Temporarly copied here until the "es2020.intl" lib is published.
-
 declare namespace Intl {
   /**
    * [BCP 47 language tag](http://tools.ietf.org/html/rfc5646) definition.


### PR DESCRIPTION
**Changes**
- Revamps the API to augment types by getting rid of the global `IntlMessages` and `IntlFormats` in favor of a more general `AppConfig` that is scoped to `next-intl`.
- Adds support for strictly-typing the locale across `useLocale` as well as the navigation APIs.
- Adds `import {Locale} from 'next-intl';` as a convenience API to be reused wherever a `locale` is passed around.
- Add `hasLocale(locales, candidate)` API for simplified checking of whether a locale is available with TypeScript.
- Adds a new `import {Messages} from 'next-intl;` type that corresponds to the `Messages` you've provided in `AppConfig` (probably rarely needed).


**Example:**

```tsx
// global.d.ts

import {routing} from '@/i18n/routing';
import {formats} from '@/i18n/request';
import en from './messages/en.json';

declare module 'next-intl' {
  interface AppConfig {
    Locale: (typeof routing.locales)[number];
    Formats: typeof formats;
    Messages: typeof en;
  }
}
```

**→ [Proposed docs](https://next-intl-docs-git-feat-augmented-config-next-intl.vercel.app/docs/workflows/typescript)**

Fixes https://github.com/amannn/next-intl/issues/1377
