### PR TITLE
experiment: PPR & friends

### DIFF
--- a/examples/example-app-router/src/app/[locale]/layout.tsx
+++ b/examples/example-app-router/src/app/[locale]/layout.tsx
@@ -1,5 +1,4 @@
-import {notFound} from 'next/navigation';
-import {Locale, hasLocale} from 'next-intl';
+import {Locale} from 'next-intl';
 import {getTranslations, setRequestLocale} from 'next-intl/server';
 import {ReactNode} from 'react';
 import BaseLayout from '@/components/BaseLayout';
@@ -24,14 +23,13 @@ export async function generateMetadata({
   };
 }
 
+// Return a 404 for unknown locales
+export const dynamicParams = false;
+
 export default async function LocaleLayout({
   children,
   params: {locale}
 }: Props) {
-  if (!hasLocale(routing.locales, locale)) {
-    notFound();
-  }
-
   // Enable static rendering
   setRequestLocale(locale);
 


### PR DESCRIPTION
An exploration of how `next-intl` can adapt better for PPR & friends.

**Findings:**
- If params could be read deeply, we can use `dynamicParams = false` to return a 404 for unknown locales (see https://github.com/amannn/next-intl/commit/d1a0308e72d7f5111a7dcc6f34efd22d8ad0e576). This is not a good idea to introduce currently, because a large number of users might not use `generateStaticParams`.
