### PR TITLE
docs: params is async on async layout

### DIFF
--- a/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
+++ b/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
@@ -193,11 +193,12 @@ import {routing} from '@/i18n/routing';
 
 export default async function LocaleLayout({
   children,
-  params: {locale}
+  params,
 }: {
   children: React.ReactNode;
-  params: {locale: string};
+  params: Promise<{locale: string}>;
 }) {
+  const { locale } = await params;
   // Ensure that the incoming `locale` is valid
   if (!routing.locales.includes(locale as any)) {
     notFound();


### PR DESCRIPTION
Since NextJS 15 the params props is async on async layout.

If we don't specify the async an error is raised in console in dev mode
```
Error: Route "/[locale]" used `params.locale`. `params` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
    at createParamsAccessError (node_modules/.pnpm/next@15.0.3_react-dom@19.0.0-rc-66855b96-20241106_react@19.0.0-rc-66855b96-20241106__react@19.0.0-rc-66855b96-20241106/node_modules/next/dist/src/server/request/params.ts:467:9)
    at getMessage (node_modules/.pnpm/next@15.0.3_react-dom@19.0.0-rc-66855b96-20241106_react@19.0.0-rc-66855b96-20241106__react@19.0.0-rc-66855b96-20241106/node_modules/next/dist/src/server/create-deduped-by-callsite-server-error-logger.ts:46:20)
    at warnForSyncAccess (node_modules/.pnpm/next@15.0.3_react-dom@19.0.0-rc-66855b96-20241106_react@19.0.0-rc-66855b96-20241106__react@19.0.0-rc-66855b96-20241106/node_modules/next/dist/src/server/request/params.ts:445:4)
    at syncIODev (node_modules/.pnpm/next@15.0.3_react-dom@19.0.0-rc-66855b96-20241106_react@19.0.0-rc-66855b96-20241106__react@19.0.0-rc-66855b96-20241106/node_modules/next/dist/src/server/request/params.ts:403:10)
    at LocaleLayout (src/app/[locale]/layout.tsx:32:65)
  30 | }>;
  31 |
> 32 | export default async function LocaleLayout({ children, params: { locale } }: Props) {
     |                                                                 ^
  33 |   // Ensure that the incoming `locale` is valid
  34 |   if (!routing.locales.includes(locale as string)) {
  35 |     notFound();
```


see: https://nextjs.org/docs/app/building-your-application/upgrading/version-15\#asynchronous-layout