### PR TITLE
feat!: Remove default of `now={new Date()}` from `NextIntlClientProvider` for usage with `format.relativeTime`  (preparation for `dynamicIO`)

### DIFF
--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -218,7 +218,7 @@ import {getLocale} from 'next-intl/server';
 const locale = await getLocale();
 ```
 
-### `Locale` [#locale-type]
+### `Locale` type [#locale-type]
 
 When passing a `locale` to another function, you can use the `Locale` type for the receiving parameter:
 
@@ -453,7 +453,7 @@ const timeZone = await getTimeZone();
 
 When formatting [relative dates and times](/docs/usage/dates-times#relative-times), `next-intl` will format times in relation to a reference point in time that is referred to as "now". By default, this is the time a component renders.
 
-If you prefer to override the default, you can provide an explicit value for `now`:
+If you prefer to provide a global default, you can configure an explicit value for `now`:
 
 <Tabs items={['i18n/request.ts', 'Provider']}>
 <Tabs.Tab>
@@ -461,32 +461,35 @@ If you prefer to override the default, you can provide an explicit value for `no
 ```tsx filename="i18n/request.ts"
 import {getRequestConfig} from 'next-intl/server';
 
+function now() {
+  'use cache';
+
+  // Use this value consistently
+  return new Date();
+}
+
 export default getRequestConfig(async () => {
   return {
-    // This is the default, a single date instance will be
-    // used by all Server Components to ensure consistency.
-    // Tip: This value can be mocked to a constant value
-    // for consistent results in end-to-end-tests.
-    now: new Date()
+    now: now()
 
     // ...
   };
 });
 ```
 
+If a `now` value is provided in `i18n/request.ts`, this will automatically be inherited by Client Components if you wrap them in a `NextIntlClientProvider` that is rendered by a Server Component.
+
 </Tabs.Tab>
 <Tabs.Tab>
 
 ```tsx
-const now = new Date('2020-11-20T10:36:01.516Z');
+const now = new Date();
 
 <NextIntlClientProvider now={now}>...</NextIntlClientProvider>;
 ```
 
 </Tabs.Tab>
 </Tabs>
-
-Similarly to the `timeZone`, the `now` value in Client Components is automatically inherited from the server side if you wrap the relevant components in a `NextIntlClientProvider` that is rendered by a Server Component.
 
 ### `useNow` & `getNow` [#use-now]
 

--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -451,7 +451,7 @@ const timeZone = await getTimeZone();
 
 ## Now value [#now]
 
-When formatting [relative dates and times](/docs/usage/dates-times#relative-times), `next-intl` will format times in relation to a reference point in time that is referred to as "now". If you want to ensure that this value is consistent across components, you can configure a global `now` value:
+When formatting [relative dates and times](/docs/usage/dates-times#relative-times), `next-intl` will format times in relation to a reference point in time that is referred to as "now". While it can be beneficial in terms of caching to [provide this value](/docs/usage/dates-times#relative-times-usenow) where necessary, you can provide a global value for `now`, e.g. to ensure consistency when running tests.
 
 <Tabs items={['i18n/request.ts', 'Provider']}>
 <Tabs.Tab>
@@ -459,55 +459,28 @@ When formatting [relative dates and times](/docs/usage/dates-times#relative-time
 ```tsx filename="i18n/request.ts"
 import {getRequestConfig} from 'next-intl/server';
 
-async function now() {
-  // (if you're using `dynamicIO`)
-  // 'use cache';
-
-  // Use this value consistently
-  // when formatting relative times
-  return new Date();
-}
-
 export default getRequestConfig(async () => {
   return {
-    now: await now()
+    now: new Date('2024-11-14T10:36:01.516Z')
 
     // ...
   };
 });
 ```
 
-If a `now` value is provided in `i18n/request.ts`, this will automatically be inherited by Client Components if you wrap them in a `NextIntlClientProvider` that is rendered by a Server Component.
-
-<Details id="now-cache">
-<summary>How does the usage of `'use cache'` with `now` relate to cache expiration?</summary>
-
-If you're using [`dynamicIO`](https://nextjs.org/docs/canary/app/api-reference/config/next-config-js/dynamicIO), you can cache the value of `now` with the [`'use cache'`](https://nextjs.org/docs/canary/app/api-reference/directives/use-cache) directive:
-
-```tsx
-async function now() {
-  'use cache';
-  const now = new Date();
-}
-```
-
-Since the request config from `i18n/request.ts` is shared among all Server Components that use features from `next-intl`, the cache expiration for `now` will apply to all of these, regardless of if they're using relative time formatting or not.
-
-If you want more granular cache control, you can consider passing the `now` value to [`format.relativeTime`](/docs/usage/dates-times#relative-times) explicitly as a second argument where relevant.
-
-</Details>
-
 </Tabs.Tab>
 <Tabs.Tab>
 
 ```tsx
-const now = new Date();
+const now = new Date('2024-11-14T10:36:01.516Z');
 
 <NextIntlClientProvider now={now}>...</NextIntlClientProvider>;
 ```
 
 </Tabs.Tab>
 </Tabs>
+
+If a `now` value is provided in `i18n/request.ts`, this will automatically be inherited by Client Components if you wrap them in a `NextIntlClientProvider` that is rendered by a Server Component.
 
 ### `useNow` & `getNow` [#use-now]
 
@@ -522,6 +495,8 @@ const now = useNow();
 import {getNow} from 'next-intl/server';
 const now = await getNow();
 ```
+
+Note that the returned value defaults to the current date and time, therefore making this hook useful when [providing `now`](/docs/usage/dates-times#relative-times-usenow) for `format.relativeTime` even when you haven't configured a global `now` value.
 
 ## Formats
 

--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -461,7 +461,7 @@ If you prefer to provide a global default, you can configure an explicit value f
 ```tsx filename="i18n/request.ts"
 import {getRequestConfig} from 'next-intl/server';
 
-function now() {
+async function now() {
   'use cache';
 
   // Use this value consistently
@@ -470,7 +470,7 @@ function now() {
 
 export default getRequestConfig(async () => {
   return {
-    now: now()
+    now: await now()
 
     // ...
   };

--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -451,9 +451,7 @@ const timeZone = await getTimeZone();
 
 ## Now value [#now]
 
-When formatting [relative dates and times](/docs/usage/dates-times#relative-times), `next-intl` will format times in relation to a reference point in time that is referred to as "now". By default, this is the time a component renders.
-
-If you prefer to provide a global default, you can configure an explicit value for `now`:
+When formatting [relative dates and times](/docs/usage/dates-times#relative-times), `next-intl` will format times in relation to a reference point in time that is referred to as "now". If you want to ensure that this value is consistent across components, you can configure a global `now` value:
 
 <Tabs items={['i18n/request.ts', 'Provider']}>
 <Tabs.Tab>
@@ -462,9 +460,11 @@ If you prefer to provide a global default, you can configure an explicit value f
 import {getRequestConfig} from 'next-intl/server';
 
 async function now() {
-  'use cache';
+  // (if you're using `dynamicIO`)
+  // 'use cache';
 
   // Use this value consistently
+  // when formatting relative times
   return new Date();
 }
 
@@ -478,6 +478,24 @@ export default getRequestConfig(async () => {
 ```
 
 If a `now` value is provided in `i18n/request.ts`, this will automatically be inherited by Client Components if you wrap them in a `NextIntlClientProvider` that is rendered by a Server Component.
+
+<Details id="now-cache">
+<summary>How does the usage of `'use cache'` with `now` relate to cache expiration?</summary>
+
+If you're using [`dynamicIO`](https://nextjs.org/docs/canary/app/api-reference/config/next-config-js/dynamicIO), you can cache the value of `now` with the [`'use cache'`](https://nextjs.org/docs/canary/app/api-reference/directives/use-cache) directive:
+
+```tsx
+async function now() {
+  'use cache';
+  const now = new Date();
+}
+```
+
+Since the request config from `i18n/request.ts` is shared among all Server Components that use features from `next-intl`, the cache expiration for `now` will apply to all of these, regardless of if they're using relative time formatting or not.
+
+If you want more granular cache control, you can consider passing the `now` value to [`format.relativeTime`](/docs/usage/dates-times#relative-times) explicitly as a second argument where relevant.
+
+</Details>
 
 </Tabs.Tab>
 <Tabs.Tab>

--- a/docs/src/pages/docs/usage/dates-times.mdx
+++ b/docs/src/pages/docs/usage/dates-times.mdx
@@ -77,7 +77,7 @@ Note that values are rounded, so e.g. if 126 minutes have passed, "2 hours ago" 
 
 ### Supplying `now`
 
-By default, `relativeTime` will use [the global value for `now`](/docs/usage/configuration#now). If you want to use a different value, you can explicitly pass this as the second parameter.
+By default, `relativeTime` will use the [global value for `now`](/docs/usage/configuration#now). If you want to use a different value, you can explicitly pass this as the second parameter.
 
 ```js
 import {useFormatter} from 'next-intl';
@@ -92,7 +92,7 @@ function Component() {
 }
 ```
 
-If you want the relative time value to update over time, you can do so with [the `useNow` hook](/docs/usage/configuration#now):
+In case you want the relative time value to update over time, you can do so with [the `useNow` hook](/docs/usage/configuration#now):
 
 ```js
 import {useNow, useFormatter} from 'next-intl';
@@ -114,7 +114,7 @@ function Component() {
 
 ### Customizing the unit
 
-By default, `relativeTime` will pick a unit based on the difference between the passed date and `now` (e.g. 3 seconds, 40 minutes, 4 days, etc.).
+By default, `relativeTime` will pick a unit based on the difference between the passed date and `now` like "3 seconds" or "5 days".
 
 If you want to use a specific unit, you can provide options via the second argument:
 

--- a/docs/src/pages/docs/usage/dates-times.mdx
+++ b/docs/src/pages/docs/usage/dates-times.mdx
@@ -77,20 +77,72 @@ function Component() {
 
 Note that values are rounded, so e.g. if 126 minutes have passed, "2 hours ago" will be returned.
 
-### Providing `now` [#relative-times-now]
+### `useNow` [#relative-times-usenow]
 
-The `now` value can either be provided on a case-by-case basis or configured [globally](/docs/usage/configuration#now).
+Since providing `now` is a common pattern, `next-intl` provides a convenience hook that can be used to retrieve the current date and time:
 
-If you've configured a global `now` value, you can omit the corresponding parameter:
+```tsx {4}
+import {useNow, useFormatter} from 'next-intl';
 
-```js
-// Uses the global now value
-format.relativeTime(dateTime);
+function FormattedDate({date}) {
+  const now = useNow();
+  const format = useFormatter();
+
+  format.relativeTime(date, now);
+}
 ```
 
-### Continuously updating relative times [#relative-times-update]
+In contrast to simply calling `new Date()` in your component, `useNow` has some benefits:
 
-In case you want a relative time value to update over time, you can do so with [the `useNow` hook](/docs/usage/configuration#now):
+1. The returned value is consistent across re-renders.
+2. The value can optionally be [updated continuously](#relative-times-update) based on an interval.
+3. The value can optionally be initialized from a [global value](/docs/usage/configuration#now), e.g. allowing you to use a static `now` value to ensure consistency when running tests.
+
+<Details id="relative-times-hydration">
+<summary>How can I avoid hydration errors with `useNow`?</summary>
+
+If you're using `useNow` in a component that renders both on the server as well as the client, you can consider using [`suppressHydrationWarning`](https://react.dev/reference/react-dom/client/hydrateRoot#suppressing-unavoidable-hydration-mismatch-errors) to tell React that this particular text is expected to potentially be updated on the client side:
+
+```tsx {7}
+import {useNow, useFormatter} from 'next-intl';
+
+function FormattedDate({date}) {
+  const now = useNow();
+  const format = useFormatter();
+
+  return <span suppressHydrationWarning>{format.relativeTime(date, now)}</span>;
+}
+```
+
+While this prop has a somewhat intimidating name, it's an escape hatch that was purposefully designed for cases like this.
+
+</Details>
+
+<Details id="relative-times-server">
+<summary>How can I use `now` in Server Components with `dynamicIO`?</summary>
+
+If you're using [`dynamicIO`](https://nextjs.org/docs/canary/app/api-reference/config/next-config-js/dynamicIO), Next.js may prompt you to specify a cache expiration in case you're using `useNow` in a Server Component.
+
+You can do so by annotating your component with the `'use cache'` directive, while converting it to an async function:
+
+```tsx
+import {getNow, getFormatter} from 'next-intl/server';
+
+async function FormattedDate({date}) {
+  'use cache';
+
+  const now = await getNow();
+  const format = await getFormatter();
+
+  return format.relativeTime(date, now);
+}
+```
+
+</Details>
+
+### `updateInterval` [#relative-times-update]
+
+In case you want a relative time value to update over time, you can do so with [the `useNow` hook](/docs/usage/configuration#use-now):
 
 ```js
 import {useNow, useFormatter} from 'next-intl';
@@ -110,7 +162,7 @@ function Component() {
 }
 ```
 
-### Customizing the unit
+### Customizing the unit [#relative-times-unit]
 
 By default, `relativeTime` will pick a unit based on the difference between the passed date and `now` like "3 seconds" or "5 days".
 

--- a/docs/src/pages/docs/usage/dates-times.mdx
+++ b/docs/src/pages/docs/usage/dates-times.mdx
@@ -67,32 +67,30 @@ function Component() {
   const format = useFormatter();
   const dateTime = new Date('2020-11-20T08:30:00.000Z');
 
-  // At 2020-11-20T10:36:00.000Z,
-  // this will render "2 hours ago"
-  format.relativeTime(dateTime);
+  // A reference point in time
+  const now = new Date('2020-11-20T10:36:00.000Z');
+
+  // This will render "2 hours ago"
+  format.relativeTime(dateTime, now);
 }
 ```
 
 Note that values are rounded, so e.g. if 126 minutes have passed, "2 hours ago" will be returned.
 
-### Supplying `now`
+### Providing `now` [#relative-times-now]
 
-By default, `relativeTime` will use the [global value for `now`](/docs/usage/configuration#now). If you want to use a different value, you can explicitly pass this as the second parameter.
+The `now` value can either be provided on a case-by-case basis or configured [globally](/docs/usage/configuration#now).
+
+If you've configured a global `now` value, you can omit the corresponding parameter:
 
 ```js
-import {useFormatter} from 'next-intl';
-
-function Component() {
-  const format = useFormatter();
-  const dateTime = new Date('2020-11-20T08:30:00.000Z');
-  const now = new Date('2020-11-20T10:36:00.000Z');
-
-  // Renders "2 hours ago"
-  format.relativeTime(dateTime, now);
-}
+// Uses the global now value
+format.relativeTime(dateTime);
 ```
 
-In case you want the relative time value to update over time, you can do so with [the `useNow` hook](/docs/usage/configuration#now):
+### Continuously updating relative times [#relative-times-update]
+
+In case you want a relative time value to update over time, you can do so with [the `useNow` hook](/docs/usage/configuration#now):
 
 ```js
 import {useNow, useFormatter} from 'next-intl';

--- a/examples/example-app-router-playground/next.config.mjs
+++ b/examples/example-app-router-playground/next.config.mjs
@@ -12,7 +12,7 @@ const withNextIntl = createNextIntlPlugin({
 const withMdx = mdxPlugin();
 
 export default withMdx(
-  withNextIntl({,
+  withNextIntl({
     eslint: {
       ignoreDuringBuilds: true
     },

--- a/examples/example-app-router-playground/next.config.mjs
+++ b/examples/example-app-router-playground/next.config.mjs
@@ -12,7 +12,10 @@ const withNextIntl = createNextIntlPlugin({
 const withMdx = mdxPlugin();
 
 export default withMdx(
-  withNextIntl({
+  withNextIntl({,
+    eslint: {
+      ignoreDuringBuilds: true
+    },
     trailingSlash: process.env.NEXT_PUBLIC_USE_CASE === 'trailing-slash',
     basePath:
       process.env.NEXT_PUBLIC_USE_CASE === 'base-path'

--- a/examples/example-app-router-playground/src/i18n/request.tsx
+++ b/examples/example-app-router-playground/src/i18n/request.tsx
@@ -45,7 +45,7 @@ export default getRequestConfig(async ({requestLocale}) => {
 
   return {
     locale,
-    now: now ? new Date(now) : new Date(),
+    now: now ? new Date(now) : undefined,
     timeZone,
     messages,
     formats,

--- a/examples/example-app-router-playground/src/i18n/request.tsx
+++ b/examples/example-app-router-playground/src/i18n/request.tsx
@@ -45,7 +45,7 @@ export default getRequestConfig(async ({requestLocale}) => {
 
   return {
     locale,
-    now: now ? new Date(now) : undefined,
+    now: now ? new Date(now) : new Date(),
     timeZone,
     messages,
     formats,

--- a/examples/example-app-router-playground/src/i18n/request.tsx
+++ b/examples/example-app-router-playground/src/i18n/request.tsx
@@ -45,7 +45,10 @@ export default getRequestConfig(async ({requestLocale}) => {
 
   return {
     locale,
-    now: now ? new Date(now) : undefined,
+    now: now
+      ? new Date(now)
+      : // Ensure a consistent value for a render
+        new Date(),
     timeZone,
     messages,
     formats,

--- a/packages/next-intl/src/react-server/NextIntlClientProviderServer.test.tsx
+++ b/packages/next-intl/src/react-server/NextIntlClientProviderServer.test.tsx
@@ -1,12 +1,12 @@
 import {expect, it, vi} from 'vitest';
+import getConfigNow from '../server/react-server/getConfigNow.tsx';
 import getFormats from '../server/react-server/getFormats.tsx';
-import {getLocale, getNow, getTimeZone} from '../server.react-server.tsx';
+import {getLocale, getTimeZone} from '../server.react-server.tsx';
 import NextIntlClientProvider from '../shared/NextIntlClientProvider.tsx';
 import NextIntlClientProviderServer from './NextIntlClientProviderServer.tsx';
 
 vi.mock('../../src/server/react-server', async () => ({
   getLocale: vi.fn(async () => 'en-US'),
-  getNow: vi.fn(async () => new Date('2020-01-01T00:00:00.000Z')),
   getTimeZone: vi.fn(async () => 'America/New_York')
 }));
 
@@ -18,6 +18,10 @@ vi.mock('../../src/server/react-server/getFormats', () => ({
       }
     }
   }))
+}));
+
+vi.mock('../../src/server/react-server/getConfigNow', () => ({
+  default: vi.fn(async () => new Date('2020-01-01T00:00:00.000Z'))
 }));
 
 vi.mock('../../src/shared/NextIntlClientProvider', async () => ({
@@ -43,7 +47,7 @@ it("doesn't read from headers if all relevant configuration is passed", async ()
   });
 
   expect(getLocale).not.toHaveBeenCalled();
-  expect(getNow).not.toHaveBeenCalled();
+  expect(getConfigNow).not.toHaveBeenCalled();
   expect(getTimeZone).not.toHaveBeenCalled();
   expect(getFormats).not.toHaveBeenCalled();
 });
@@ -69,7 +73,7 @@ it('reads missing configuration from getter functions', async () => {
   });
 
   expect(getLocale).toHaveBeenCalled();
-  expect(getNow).toHaveBeenCalled();
+  expect(getConfigNow).toHaveBeenCalled();
   expect(getTimeZone).toHaveBeenCalled();
   expect(getFormats).toHaveBeenCalled();
 });

--- a/packages/next-intl/src/react-server/NextIntlClientProviderServer.tsx
+++ b/packages/next-intl/src/react-server/NextIntlClientProviderServer.tsx
@@ -1,6 +1,7 @@
 import {ComponentProps} from 'react';
+import getConfigNow from '../server/react-server/getConfigNow.tsx';
 import getFormats from '../server/react-server/getFormats.tsx';
-import {getLocale, getNow, getTimeZone} from '../server.react-server.tsx';
+import {getLocale, getTimeZone} from '../server.react-server.tsx';
 import BaseNextIntlClientProvider from '../shared/NextIntlClientProvider.tsx';
 
 type Props = ComponentProps<typeof BaseNextIntlClientProvider>;
@@ -18,7 +19,8 @@ export default async function NextIntlClientProviderServer({
       // See https://github.com/amannn/next-intl/issues/631
       formats={formats === undefined ? await getFormats() : formats}
       locale={locale ?? (await getLocale())}
-      now={now ?? (await getNow())}
+      // Note that don't assign a default for `now` here
+      now={now ?? (await getConfigNow())}
       timeZone={timeZone ?? (await getTimeZone())}
       {...rest}
     />

--- a/packages/next-intl/src/react-server/NextIntlClientProviderServer.tsx
+++ b/packages/next-intl/src/react-server/NextIntlClientProviderServer.tsx
@@ -19,7 +19,9 @@ export default async function NextIntlClientProviderServer({
       // See https://github.com/amannn/next-intl/issues/631
       formats={formats === undefined ? await getFormats() : formats}
       locale={locale ?? (await getLocale())}
-      // Note that don't assign a default for `now` here
+      // Note that we don't assign a default for `now` here,
+      // we only read one from the request config - if any.
+      // Otherwise this would cause a `dynamicIO` error.
       now={now ?? (await getConfigNow())}
       timeZone={timeZone ?? (await getTimeZone())}
       {...rest}

--- a/packages/next-intl/src/react-server/useFormatter.test.tsx
+++ b/packages/next-intl/src/react-server/useFormatter.test.tsx
@@ -1,0 +1,43 @@
+import {describe, expect, it, vi} from 'vitest';
+import getDefaultNow from '../server/react-server/getDefaultNow.tsx';
+import {renderToStream} from './testUtils.tsx';
+import useFormatter from './useFormatter.tsx';
+
+vi.mock('react');
+vi.mock('../server/react-server/getDefaultNow.tsx', () => ({
+  default: vi.fn(() => new Date())
+}));
+
+vi.mock('../../src/server/react-server/createRequestConfig', () => ({
+  default: async () => ({
+    locale: 'en'
+  })
+}));
+
+describe('dynamicIO', () => {
+  it('should not include `now` in the translator config', async () => {
+    function TestComponent() {
+      const format = useFormatter();
+      format.dateTime(new Date());
+      format.number(1);
+      format.dateTimeRange(new Date(), new Date());
+      format.list(['a', 'b']);
+      format.relativeTime(new Date(), new Date());
+      return null;
+    }
+
+    await renderToStream(<TestComponent />);
+    expect(getDefaultNow).not.toHaveBeenCalled();
+  });
+
+  it('should read `now` for `relativeTime` if relying on a global `now`', async () => {
+    function TestComponent() {
+      const format = useFormatter();
+      format.relativeTime(new Date());
+      return null;
+    }
+
+    await renderToStream(<TestComponent />);
+    expect(getDefaultNow).toHaveBeenCalled();
+  });
+});

--- a/packages/next-intl/src/react-server/useFormatter.tsx
+++ b/packages/next-intl/src/react-server/useFormatter.tsx
@@ -1,11 +1,20 @@
 import {cache} from 'react';
 import type {useFormatter as useFormatterType} from 'use-intl';
 import {createFormatter} from 'use-intl/core';
+import getDefaultNow from '../server/react-server/getDefaultNow.tsx';
 import useConfig from './useConfig.tsx';
 
 const createFormatterCached = cache(createFormatter);
 
 export default function useFormatter(): ReturnType<typeof useFormatterType> {
   const config = useConfig('useFormatter');
-  return createFormatterCached(config);
+
+  return createFormatterCached({
+    ...config,
+    // Only init when necessary to avoid triggering a `dynamicIO` error
+    // unnecessarily (`now` is only needed for `format.relativeTime`)
+    get now() {
+      return config.now ?? getDefaultNow();
+    }
+  });
 }

--- a/packages/next-intl/src/react-server/useFormatter.tsx
+++ b/packages/next-intl/src/react-server/useFormatter.tsx
@@ -1,20 +1,8 @@
-import {cache} from 'react';
 import type {useFormatter as useFormatterType} from 'use-intl';
-import {createFormatter} from 'use-intl/core';
-import getDefaultNow from '../server/react-server/getDefaultNow.tsx';
+import getServerFormatter from '../server/react-server/getServerFormatter.tsx';
 import useConfig from './useConfig.tsx';
-
-const createFormatterCached = cache(createFormatter);
 
 export default function useFormatter(): ReturnType<typeof useFormatterType> {
   const config = useConfig('useFormatter');
-
-  return createFormatterCached({
-    ...config,
-    // Only init when necessary to avoid triggering a `dynamicIO` error
-    // unnecessarily (`now` is only needed for `format.relativeTime`)
-    get now() {
-      return config.now ?? getDefaultNow();
-    }
-  });
+  return getServerFormatter(config);
 }

--- a/packages/next-intl/src/react-server/useNow.tsx
+++ b/packages/next-intl/src/react-server/useNow.tsx
@@ -1,4 +1,5 @@
 import type {useNow as useNowType} from 'use-intl';
+import getDefaultNow from '../server/react-server/getDefaultNow.tsx';
 import useConfig from './useConfig.tsx';
 
 export default function useNow(
@@ -11,5 +12,5 @@ export default function useNow(
   }
 
   const config = useConfig('useNow');
-  return config.now;
+  return config.now ?? getDefaultNow();
 }

--- a/packages/next-intl/src/react-server/useTranslations.test.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.test.tsx
@@ -31,6 +31,20 @@ vi.mock('use-intl/core', async (importActual) => {
   };
 });
 
+describe('dynamicIO', () => {
+  it('should not include `now` in the translator config', async () => {
+    function TestComponent() {
+      useTranslations('A');
+      return null;
+    }
+
+    await renderToStream(<TestComponent />);
+    expect(createTranslator).toHaveBeenCalledWith(
+      expect.not.objectContaining({now: expect.anything()})
+    );
+  });
+});
+
 describe('performance', () => {
   let attemptedRenders: Record<string, number>;
   let finishedRenders: Record<string, number>;

--- a/packages/next-intl/src/react-server/useTranslations.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.tsx
@@ -1,10 +1,10 @@
 import type {useTranslations as useTranslationsType} from 'use-intl';
-import getTranslator from '../server/react-server/getTranslator.tsx';
+import getServerTranslator from '../server/react-server/getServerTranslator.tsx';
 import useConfig from './useConfig.tsx';
 
 export default function useTranslations(
   ...[namespace]: Parameters<typeof useTranslationsType>
 ): ReturnType<typeof useTranslationsType> {
   const config = useConfig('useTranslations');
-  return getTranslator(config, namespace);
+  return getServerTranslator(config, namespace);
 }

--- a/packages/next-intl/src/react-server/useTranslations.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.tsx
@@ -1,10 +1,10 @@
 import type {useTranslations as useTranslationsType} from 'use-intl';
-import getBaseTranslator from './getTranslator.tsx';
+import getTranslator from '../server/react-server/getTranslator.tsx';
 import useConfig from './useConfig.tsx';
 
 export default function useTranslations(
   ...[namespace]: Parameters<typeof useTranslationsType>
 ): ReturnType<typeof useTranslationsType> {
   const config = useConfig('useTranslations');
-  return getBaseTranslator(config, namespace);
+  return getTranslator(config, namespace);
 }

--- a/packages/next-intl/src/server/react-server/getConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getConfig.tsx
@@ -65,12 +65,7 @@ See also: https://next-intl-docs.vercel.app/docs/usage/configuration#i18n-reques
     );
   }
 
-  return {
-    ...result,
-    locale: result.locale,
-    now: result.now || getDefaultNow(),
-    timeZone: result.timeZone || getDefaultTimeZone()
-  };
+  return result;
 }
 const receiveRuntimeConfig = cache(receiveRuntimeConfigImpl);
 
@@ -92,7 +87,14 @@ async function getConfigImpl(localeOverride?: Locale): Promise<
   );
   return {
     ...initializeConfig(runtimeConfig),
-    _formatters: getFormatters(getCache())
+    _formatters: getFormatters(getCache()),
+    timeZone: runtimeConfig.timeZone || getDefaultTimeZone(),
+
+    // Only init when necessary to avoid triggering a `dynamicIO` error
+    // (i.e. when using `format.relativeTime` or `useNow`)
+    get now() {
+      return runtimeConfig.now ?? getDefaultNow();
+    }
   };
 }
 const getConfig = cache(getConfigImpl);

--- a/packages/next-intl/src/server/react-server/getConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getConfig.tsx
@@ -10,12 +10,6 @@ import {getRequestLocale} from './RequestLocale.tsx';
 import createRequestConfig from './createRequestConfig.tsx';
 import {GetRequestConfigParams} from './getRequestConfig.tsx';
 
-// Make sure `now` is consistent across the request in case none was configured
-function getDefaultNowImpl() {
-  return new Date();
-}
-const getDefaultNow = cache(getDefaultNowImpl);
-
 // This is automatically inherited by `NextIntlClientProvider` if
 // the component is rendered from a Server Component
 function getDefaultTimeZoneImpl() {
@@ -75,7 +69,6 @@ const getCache = cache(_createCache);
 async function getConfigImpl(localeOverride?: Locale): Promise<
   IntlConfig & {
     getMessageFallback: NonNullable<IntlConfig['getMessageFallback']>;
-    now: NonNullable<IntlConfig['now']>;
     onError: NonNullable<IntlConfig['onError']>;
     timeZone: NonNullable<IntlConfig['timeZone']>;
     _formatters: ReturnType<typeof _createIntlFormatters>;
@@ -88,13 +81,7 @@ async function getConfigImpl(localeOverride?: Locale): Promise<
   return {
     ...initializeConfig(runtimeConfig),
     _formatters: getFormatters(getCache()),
-    timeZone: runtimeConfig.timeZone || getDefaultTimeZone(),
-
-    // Only init when necessary to avoid triggering a `dynamicIO` error
-    // (i.e. when using `format.relativeTime` or `useNow`)
-    get now() {
-      return runtimeConfig.now ?? getDefaultNow();
-    }
+    timeZone: runtimeConfig.timeZone || getDefaultTimeZone()
   };
 }
 const getConfig = cache(getConfigImpl);

--- a/packages/next-intl/src/server/react-server/getConfigNow.tsx
+++ b/packages/next-intl/src/server/react-server/getConfigNow.tsx
@@ -1,0 +1,11 @@
+import {cache} from 'react';
+import type {Locale} from 'use-intl';
+import getConfig from './getConfig.tsx';
+
+async function getConfigNowImpl(locale?: Locale) {
+  const config = await getConfig(locale);
+  return config.now;
+}
+const getConfigNow = cache(getConfigNowImpl);
+
+export default getConfigNow;

--- a/packages/next-intl/src/server/react-server/getDefaultNow.tsx
+++ b/packages/next-intl/src/server/react-server/getDefaultNow.tsx
@@ -1,7 +1,7 @@
 import {cache} from 'react';
 
 function defaultNow() {
-  // See https://next-intl-docs.vercel.app/docs/usage/dates-times#relative-times
+  // See https://next-intl-docs.vercel.app/docs/usage/dates-times#relative-times-server
   return new Date();
 }
 

--- a/packages/next-intl/src/server/react-server/getDefaultNow.tsx
+++ b/packages/next-intl/src/server/react-server/getDefaultNow.tsx
@@ -1,0 +1,8 @@
+import {cache} from 'react';
+
+function getDefaultNowImpl() {
+  return new Date();
+}
+const getDefaultNow = cache(getDefaultNowImpl);
+
+export default getDefaultNow;

--- a/packages/next-intl/src/server/react-server/getDefaultNow.tsx
+++ b/packages/next-intl/src/server/react-server/getDefaultNow.tsx
@@ -1,8 +1,10 @@
 import {cache} from 'react';
 
-function getDefaultNowImpl() {
+function defaultNow() {
+  // See https://next-intl-docs.vercel.app/docs/usage/dates-times#relative-times
   return new Date();
 }
-const getDefaultNow = cache(getDefaultNowImpl);
+
+const getDefaultNow = cache(defaultNow);
 
 export default getDefaultNow;

--- a/packages/next-intl/src/server/react-server/getFormats.tsx
+++ b/packages/next-intl/src/server/react-server/getFormats.tsx
@@ -5,6 +5,6 @@ async function getFormatsCachedImpl() {
   const config = await getConfig();
   return config.formats;
 }
-const getFormatsCached = cache(getFormatsCachedImpl);
+const getFormats = cache(getFormatsCachedImpl);
 
-export default getFormatsCached;
+export default getFormats;

--- a/packages/next-intl/src/server/react-server/getFormatter.test.tsx
+++ b/packages/next-intl/src/server/react-server/getFormatter.test.tsx
@@ -1,0 +1,35 @@
+import {describe, expect, it, vi} from 'vitest';
+import getDefaultNow from './getDefaultNow.tsx';
+import getFormatter from './getFormatter.tsx';
+
+vi.mock('react');
+vi.mock('./getDefaultNow.tsx', () => ({
+  default: vi.fn(() => new Date())
+}));
+
+vi.mock('next-intl/config', () => ({
+  default: async () =>
+    (
+      (await vi.importActual('../../../src/server/react-server')) as any
+    ).getRequestConfig({
+      locale: 'en'
+    })
+}));
+
+describe('dynamicIO', () => {
+  it('should not read `now` unnecessarily', async () => {
+    const format = await getFormatter();
+    format.dateTime(new Date());
+    format.number(1);
+    format.dateTimeRange(new Date(), new Date());
+    format.list(['a', 'b']);
+    format.relativeTime(new Date(), new Date());
+    expect(getDefaultNow).not.toHaveBeenCalled();
+  });
+
+  it('should read `now` for `relativeTime` if relying on a global `now`', async () => {
+    const format = await getFormatter();
+    format.relativeTime(new Date());
+    expect(getDefaultNow).toHaveBeenCalled();
+  });
+});

--- a/packages/next-intl/src/server/react-server/getFormatter.tsx
+++ b/packages/next-intl/src/server/react-server/getFormatter.tsx
@@ -1,10 +1,11 @@
 import {cache} from 'react';
 import {type Locale, createFormatter} from 'use-intl/core';
 import getConfig from './getConfig.tsx';
+import getServerFormatter from './getServerFormatter.tsx';
 
 async function getFormatterCachedImpl(locale?: Locale) {
   const config = await getConfig(locale);
-  return createFormatter(config);
+  return getServerFormatter(config);
 }
 const getFormatterCached = cache(getFormatterCachedImpl);
 

--- a/packages/next-intl/src/server/react-server/getNow.tsx
+++ b/packages/next-intl/src/server/react-server/getNow.tsx
@@ -1,13 +1,7 @@
-import {cache} from 'react';
 import type {Locale} from 'use-intl';
-import getConfig from './getConfig.tsx';
-
-async function getNowCachedImpl(locale?: Locale) {
-  const config = await getConfig(locale);
-  return config.now;
-}
-const getNowCached = cache(getNowCachedImpl);
+import getConfigNow from './getConfigNow.tsx';
+import getDefaultNow from './getDefaultNow.tsx';
 
 export default async function getNow(opts?: {locale?: Locale}): Promise<Date> {
-  return getNowCached(opts?.locale);
+  return (await getConfigNow(opts?.locale)) ?? getDefaultNow();
 }

--- a/packages/next-intl/src/server/react-server/getServerFormatter.tsx
+++ b/packages/next-intl/src/server/react-server/getServerFormatter.tsx
@@ -1,0 +1,21 @@
+import {cache} from 'react';
+import {createFormatter} from 'use-intl/core';
+import getDefaultNow from './getDefaultNow.tsx';
+
+function getFormatterCachedImpl(config: Parameters<typeof createFormatter>[0]) {
+  // same here?
+  // also add a test
+  // also for getTranslations/useTranslations
+  // add a test with a getter maybe, don't mock
+  return createFormatter({
+    ...config,
+    // Only init when necessary to avoid triggering a `dynamicIO` error
+    // unnecessarily (`now` is only needed for `format.relativeTime`)
+    get now() {
+      return config.now ?? getDefaultNow();
+    }
+  });
+}
+const getFormatterCached = cache(getFormatterCachedImpl);
+
+export default getFormatterCached;

--- a/packages/next-intl/src/server/react-server/getServerTranslator.tsx
+++ b/packages/next-intl/src/server/react-server/getServerTranslator.tsx
@@ -6,7 +6,7 @@ import {
   createTranslator
 } from 'use-intl/core';
 
-function getTranslatorImpl<
+function getServerTranslatorImpl<
   NestedKey extends NamespaceKeys<Messages, NestedKeyOf<Messages>> = never
 >(
   config: Parameters<typeof createTranslator>[0],
@@ -18,4 +18,4 @@ function getTranslatorImpl<
   });
 }
 
-export default cache(getTranslatorImpl);
+export default cache(getServerTranslatorImpl);

--- a/packages/next-intl/src/server/react-server/getTranslations.test.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslations.test.tsx
@@ -1,0 +1,29 @@
+import {createTranslator} from 'use-intl/core';
+import {expect, it, vi} from 'vitest';
+import getTranslations from './getTranslations.tsx';
+
+vi.mock('react');
+vi.mock('use-intl/core');
+
+vi.mock('next-intl/config', () => ({
+  default: async () =>
+    (
+      (await vi.importActual('../../../src/server/react-server')) as any
+    ).getRequestConfig({
+      locale: 'en',
+      timeZone: 'Europe/London',
+      messages: {
+        title: 'Hello'
+      }
+    })
+}));
+
+it('should not include `now` in the translator config', async () => {
+  await getTranslations();
+
+  expect(createTranslator).toHaveBeenCalledWith(
+    expect.not.objectContaining({
+      now: expect.anything()
+    })
+  );
+});

--- a/packages/next-intl/src/server/react-server/getTranslations.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslations.tsx
@@ -7,7 +7,7 @@ import {
   createTranslator
 } from 'use-intl/core';
 import getConfig from './getConfig.tsx';
-import getTranslator from './getTranslator.tsx';
+import getServerTranslator from './getServerTranslator.tsx';
 
 // Maintainer note: `getTranslations` has two different call signatures.
 // We need to define these with function overloads, otherwise TypeScript
@@ -41,7 +41,7 @@ async function getTranslations<
   }
 
   const config = await getConfig(locale);
-  return getTranslator(config, namespace);
+  return getServerTranslator(config, namespace);
 }
 
 export default cache(getTranslations);

--- a/packages/next-intl/src/server/react-server/getTranslations.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslations.tsx
@@ -7,6 +7,7 @@ import {
   createTranslator
 } from 'use-intl/core';
 import getConfig from './getConfig.tsx';
+import getTranslator from './getTranslator.tsx';
 
 // Maintainer note: `getTranslations` has two different call signatures.
 // We need to define these with function overloads, otherwise TypeScript
@@ -40,12 +41,7 @@ async function getTranslations<
   }
 
   const config = await getConfig(locale);
-
-  return createTranslator({
-    ...config,
-    namespace,
-    messages: config.messages
-  });
+  return getTranslator(config, namespace);
 }
 
 export default cache(getTranslations);

--- a/packages/next-intl/src/server/react-server/getTranslator.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslator.tsx
@@ -13,17 +13,8 @@ function getTranslatorImpl<
   namespace?: NestedKey
 ): ReturnType<typeof createTranslator<Messages, NestedKey>> {
   return createTranslator({
-    locale: config.locale,
-    _cache: config._cache,
-    _formatters: config._formatters,
-    formats: config.formats,
-    getMessageFallback: config.getMessageFallback,
-    messages: config.messages,
-    onError: config.onError,
-    timeZone: config.timeZone,
+    ...config,
     namespace
-    // We don't pass `now` here because a) it's not needed and b) it might
-    // require reading the current time, which causes an error with `dynamicIO`
   });
 }
 

--- a/packages/next-intl/src/server/react-server/getTranslator.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslator.tsx
@@ -13,8 +13,17 @@ function getTranslatorImpl<
   namespace?: NestedKey
 ): ReturnType<typeof createTranslator<Messages, NestedKey>> {
   return createTranslator({
-    ...config,
+    locale: config.locale,
+    _cache: config._cache,
+    _formatters: config._formatters,
+    formats: config.formats,
+    getMessageFallback: config.getMessageFallback,
+    messages: config.messages,
+    onError: config.onError,
+    timeZone: config.timeZone,
     namespace
+    // We don't pass `now` here because a) it's not needed and b) it might
+    // require reading the current time, which causes an error with `dynamicIO`
   });
 }
 

--- a/packages/use-intl/.size-limit.ts
+++ b/packages/use-intl/.size-limit.ts
@@ -5,7 +5,7 @@ const config: SizeLimitConfig = [
     name: "import * from 'use-intl' (production)",
     import: '*',
     path: 'dist/esm/production/index.js',
-    limit: '12.945 kB'
+    limit: '12.965 kB'
   },
   {
     name: "import {IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter} from 'use-intl' (production)",

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -219,7 +219,7 @@ export default function createFormatter({
         new IntlError(
           IntlErrorCode.ENVIRONMENT_FALLBACK,
           process.env.NODE_ENV !== 'production'
-            ? `The \`now\` parameter wasn't provided and there is no global default configured. Consider adding a global default to avoid markup mismatches caused by environment differences. Learn more: https://next-intl-docs.vercel.app/docs/configuration#now`
+            ? `The \`now\` parameter wasn't provided and there is no global default configured, therefore the current time will be used as a fallback. To avoid markup mismatches caused by environment differences, either provide the \`now\` parameter or configure a global default. Learn more: https://next-intl-docs.vercel.app/docs/configuration#now`
             : undefined
         )
       );

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -82,15 +82,16 @@ type Props = {
   _cache?: IntlCache;
 };
 
-export default function createFormatter({
-  _cache: cache = createCache(),
-  _formatters: formatters = createIntlFormatters(cache),
-  formats,
-  locale,
-  now: globalNow,
-  onError = defaultOnError,
-  timeZone: globalTimeZone
-}: Props) {
+export default function createFormatter(props: Props) {
+  const {
+    _cache: cache = createCache(),
+    _formatters: formatters = createIntlFormatters(cache),
+    formats,
+    locale,
+    onError = defaultOnError,
+    timeZone: globalTimeZone
+  } = props;
+
   function applyTimeZone(options?: DateTimeFormatOptions) {
     if (!options?.timeZone) {
       if (globalTimeZone) {
@@ -212,8 +213,10 @@ export default function createFormatter({
   }
 
   function getGlobalNow() {
-    if (globalNow) {
-      return globalNow;
+    // Only read when necessary to avoid triggering a `dynamicIO` error
+    // unnecessarily (`now` is only needed for `format.relativeTime`)
+    if (props.now) {
+      return props.now;
     } else {
       onError(
         new IntlError(

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -233,7 +233,7 @@ export default function createFormatter(props: Props) {
   function relativeTime(
     /** The date time that needs to be formatted. */
     date: number | Date,
-    /** The reference point in time to which `date` will be formatted in relation to.  */
+    /** The reference point in time to which `date` will be formatted in relation to. If this value is absent, a globally configured `now` value or alternatively the current time will be used. */
     nowOrOptions?: RelativeTimeFormatOptions['now'] | RelativeTimeFormatOptions
   ) {
     try {

--- a/packages/use-intl/src/react/useFormatter.test.tsx
+++ b/packages/use-intl/src/react/useFormatter.test.tsx
@@ -279,9 +279,7 @@ describe('dateTime', () => {
       );
 
       const error: IntlError = onError.mock.calls[0][0];
-      expect(error.message).toMatch(
-        "ENVIRONMENT_FALLBACK: The `timeZone` parameter wasn't provided and there is no global default configured."
-      );
+      expect(error.message).toMatch(/^ENVIRONMENT_FALLBACK/);
       expect(error.code).toBe(IntlErrorCode.ENVIRONMENT_FALLBACK);
       expect(container.textContent).toBe('11/20/2020');
     });
@@ -622,9 +620,7 @@ describe('relativeTime', () => {
       );
 
       const error: IntlError = onError.mock.calls[0][0];
-      expect(error.message).toMatch(
-        "ENVIRONMENT_FALLBACK: The `now` parameter wasn't provided and there is no global default configured."
-      );
+      expect(error.message).toMatch(/^ENVIRONMENT_FALLBACK/);
       expect(error.code).toBe(IntlErrorCode.ENVIRONMENT_FALLBACK);
     });
   });

--- a/packages/use-intl/src/react/useNow.tsx
+++ b/packages/use-intl/src/react/useNow.tsx
@@ -10,22 +10,7 @@ function getNow() {
 }
 
 /**
- * Reading the current date via `new Date()` in components should be avoided, as
- * it causes components to be impure and can lead to flaky tests. Instead, this
- * hook can be used.
- *
- * By default, it returns the time when the component mounts. If `updateInterval`
- * is specified, the value will be updated based on the interval.
- *
- * You can however also return a static value from this hook, if you
- * configure the `now` parameter on the context provider. Note however,
- * that if `updateInterval` is configured in this case, the component
- * will initialize with the global value, but will afterwards update
- * continuously based on the interval.
- *
- * For unit tests, this can be mocked to a constant value. For end-to-end
- * testing, an environment parameter can be passed to the `now` parameter
- * of the provider to mock this to a static value.
+ * @see https://next-intl-docs.vercel.app/docs/usage/dates-times#relative-times-usenow
  */
 export default function useNow(options?: Options) {
   const updateInterval = options?.updateInterval;

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,9 @@
     "lint": {
       "dependsOn": ["^build"]
     },
+    "example-app-router-playground#lint": {
+      "dependsOn": ["example-app-router-playground#build"]
+    },
     "test": {
       "dependsOn": ["build"]
     },


### PR DESCRIPTION
In preparation for [`dynamicIO`](https://nextjs.org/docs/canary/app/api-reference/config/next-config-js/dynamicIO) and [`ppr`](https://nextjs.org/docs/app/api-reference/next-config-js/ppr), the default of `now={new Date()}` on `NextIntlClientProvider` has been removed for usage in Client Components.

While you can restore this behavior by adding [`now: new Date()`](https://next-intl-docs.vercel.app/docs/usage/configuration#now) in your `i18n/request.ts` config, the [relative time formatting docs](https://next-intl-docs-git-feat-dio-now-next-intl.vercel.app/docs/usage/dates-times#relative-times) now suggest a slightly adapted pattern with some benefits:

1. Always pass an explicit `now` argument to `format.relativeTime(date, now)` instead of relying on a global default
2. `now` can conveniently be retrieved from `useNow()`, optionally using a global default (if configured)
3. Use [`suppressHydrationWarning`](https://react.dev/reference/react-dom/client/hydrateRoot#suppressing-unavoidable-hydration-mismatch-errors) when using `format.relativeTime` in Client Components

During a lengthy exploration of the upcoming `dynamicIO` rendering mode, this approach has proven beneficial:
1. Use granular caching when reading `now` in Server Components
2. Render up-to-date relative times on the client side instead of relying on caching

