### PR TITLE
fix: Correctly handle search params in redirects when using `trailingSlash: true`

### DIFF
--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -1125,6 +1125,20 @@ describe('prefix-based routing', () => {
           'http://localhost:3000/en/'
         );
       });
+      
+      it('keeps search params when redirecting to a locale at the root', () => {
+        middleware(createMockRequest('/?sort=asc'));
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://localhost:3000/en/?sort=asc'
+        );
+      });
+
+      it('keeps search params when redirecting to a locale', () => {
+        middleware(createMockRequest('/users?sort=asc'));
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://localhost:3000/en/users/?sort=asc'
+        );
+      });
     });
 
     describe('localized pathnames', () => {

--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -1125,7 +1125,7 @@ describe('prefix-based routing', () => {
           'http://localhost:3000/en/'
         );
       });
-      
+
       it('keeps search params when redirecting to a locale at the root', () => {
         middleware(createMockRequest('/?sort=asc'));
         expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -120,7 +120,9 @@ export default function createMiddleware<
     }
 
     function redirect(url: string, redirectDomain?: string) {
-      const urlObj = new URL(normalizeTrailingSlash(url), request.url);
+      const urlObj = new URL(url, request.url);
+
+      urlObj.pathname = normalizeTrailingSlash(urlObj.pathname);
 
       if (domainsConfig.length > 0 && !redirectDomain && domain) {
         const bestMatchingDomain = getBestMatchingDomain(


### PR DESCRIPTION
`normalizeTrailingSlash` expects a `pathname` but it's getting pathname + search. 

This causes redirects to urls like `/users/?sort=asc/`