### PR TITLE
docs: clarify TypeScript version requirement and add troubleshooting for TypeScript error

### DIFF
--- a/docs/src/pages/docs/routing.mdx
+++ b/docs/src/pages/docs/routing.mdx
@@ -46,6 +46,23 @@ Still, in case you're defining other routing config, make sure to keep them in s
 
 </Details>
 
+<Details id="typescript-version-error">
+  <summary>What if I encounter a TypeScript error like `TS2554: Expected 0 arguments, but got 1`?</summary>
+
+  If you're seeing TypeScript errors such as `TS2554: Expected 0 arguments, but got 1` when using `defineRouting` or other routing functions, this may be due to an incompatible TypeScript version. To fix this, ensure that your project is using **TypeScript version 5 or later**.
+
+  You can upgrade your TypeScript version by running:
+
+  ```sh
+  npm install typescript@latest
+  # or with yarn
+  yarn add typescript@latest
+  ```
+
+  After upgrading, restart your editor or TypeScript server to ensure the latest types are loaded.
+
+</Details>
+
 ### Locale prefix
 
 By default, the pathnames of your app will be available under a prefix that matches your directory structure (e.g. `/en/about` → `app/[locale]/about/page.tsx`). You can however adapt the routing to optionally remove the prefix or customize it per locale by configuring the `localePrefix` setting.

--- a/docs/src/pages/docs/routing.mdx
+++ b/docs/src/pages/docs/routing.mdx
@@ -46,23 +46,6 @@ Still, in case you're defining other routing config, make sure to keep them in s
 
 </Details>
 
-<Details id="typescript-version-error">
-  <summary>What if I encounter a TypeScript error like `TS2554: Expected 0 arguments, but got 1`?</summary>
-
-  If you're seeing TypeScript errors such as `TS2554: Expected 0 arguments, but got 1` when using `defineRouting` or other routing functions, this may be due to an incompatible TypeScript version. To fix this, ensure that your project is using **TypeScript version 5 or later**.
-
-  You can upgrade your TypeScript version by running:
-
-  ```sh
-  npm install typescript@latest
-  # or with yarn
-  yarn add typescript@latest
-  ```
-
-  After upgrading, restart your editor or TypeScript server to ensure the latest types are loaded.
-
-</Details>
-
 ### Locale prefix
 
 By default, the pathnames of your app will be available under a prefix that matches your directory structure (e.g. `/en/about` → `app/[locale]/about/page.tsx`). You can however adapt the routing to optionally remove the prefix or customize it per locale by configuring the `localePrefix` setting.

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -115,7 +115,7 @@ declare global {
 If you're encountering problems, double check that:
 
 1. Your interface uses the correct name.
-2. You're using TypeScript version 4 or later.
+2. You're using TypeScript version 5 or later.
 3. You're using correct paths for all modules you're importing into your global declaration file.
 4. Your type declaration file is included in `tsconfig.json`.
 5. Your editor has loaded the most recent type declarations. When in doubt, you can restart.


### PR DESCRIPTION
### 🔍 Overview
This PR enhances the **TypeScript Integration** and **Routing** sections of the `next-intl` documentation by:
- Specifying **TypeScript version 5** or later as a requirement for compatibility with `next-intl`.
- Adding a troubleshooting tip under the **Define routing** section to help developers resolve a common TypeScript error.

---

### 📄 Changes
1. **TypeScript Version Requirement**: 
   - Updated the TypeScript Integration section to recommend **TypeScript version 5 or later** to prevent issues such as `TS2554: Expected 0 arguments, but got 1`.
   - This provides users with upfront guidance to avoid compatibility issues.
2. **New Troubleshooting Detail**:
   - Added a `Details` section in **Define routing** explaining how to resolve the `TS2554` TypeScript error by upgrading to TypeScript 5 or later.
   - This gives clear instructions on how to upgrade TypeScript if users encounter this error during setup.

---

### 🤔 Why This Update?
While setting up `next-intl` with the code in the documentation, I encountered an error _(also found it [on Stackoverflow](https://stackoverflow.com/questions/79168391/next-intl-routing-ts-giving-ts2554-expected-0-arguments-but-got-1))_ due to using **TypeScript 4**.

Upgrading to **TypeScript 5** resolved the issue.

To help others avoid this confusion, I’ve added a clear version requirement and troubleshooting section to the documentation.

---

### 📌 Notes
As this is my first Pull Request for `next-intl`, please let me know if I need to correct anything 🙏 