### PR TITLE
fix: Handle inconsistency in Next.js when using `usePathname` with custom prefixes, `localePrefix: 'as-needed'` and static rendering

### DIFF
--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -15,19 +15,19 @@ const config: SizeLimitConfig = [
     name: "import {createSharedPathnamesNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createSharedPathnamesNavigation}',
-    limit: '4.085 KB'
+    limit: '4.125 KB'
   },
   {
     name: "import {createLocalizedPathnamesNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createLocalizedPathnamesNavigation}',
-    limit: '4.095 KB'
+    limit: '4.115 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createNavigation}',
-    limit: '4.085 KB'
+    limit: '4.115 KB'
   },
   {
     name: "import {createSharedPathnamesNavigation} from 'next-intl/navigation' (react-server)",

--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -15,25 +15,25 @@ const config: SizeLimitConfig = [
     name: "import {createSharedPathnamesNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createSharedPathnamesNavigation}',
-    limit: '4.045 KB'
+    limit: '4.085 KB'
   },
   {
     name: "import {createLocalizedPathnamesNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createLocalizedPathnamesNavigation}',
-    limit: '4.045 KB'
+    limit: '4.095 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createNavigation}',
-    limit: '4.055 KB'
+    limit: '4.085 KB'
   },
   {
     name: "import {createSharedPathnamesNavigation} from 'next-intl/navigation' (react-server)",
     path: 'dist/production/navigation.react-server.js',
     import: '{createSharedPathnamesNavigation}',
-    limit: '16.795 KB'
+    limit: '16.805 KB'
   },
   {
     name: "import {createLocalizedPathnamesNavigation} from 'next-intl/navigation' (react-server)",

--- a/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createLocalizedPathnamesNavigation.tsx
@@ -168,7 +168,7 @@ export default function createLocalizedPathnamesNavigation<
   }
 
   function usePathname(): keyof AppPathnames {
-    const pathname = useBasePathname(config.localePrefix);
+    const pathname = useBasePathname(config);
     const locale = useTypedLocale();
 
     // @ts-expect-error -- Mirror the behavior from Next.js, where `null` is returned when `usePathname` is used outside of Next, but the types indicate that a string is always returned.

--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -467,14 +467,6 @@ describe("localePrefix: 'always', custom `prefixes`", () => {
       renderPathname();
       screen.getByText('/about');
     });
-
-    // https://github.com/vercel/next.js/issues/73085
-    it('is tolerant when a locale is used in the pathname', () => {
-      mockCurrentLocale('en');
-      mockLocation({pathname: '/en/about'});
-      renderPathname();
-      screen.getByText('/about');
-    });
   });
 });
 
@@ -548,6 +540,28 @@ describe("localePrefix: 'as-needed'", () => {
       renderPathname();
       screen.getByText('/about');
     });
+  });
+});
+
+describe("localePrefix: 'as-needed', custom `prefixes`", () => {
+  const {usePathname} = createNavigation({
+    defaultLocale,
+    locales,
+    localePrefix: {
+      mode: 'as-needed',
+      prefixes: {
+        en: '/uk'
+      }
+    }
+  });
+  const renderPathname = getRenderPathname(usePathname);
+
+  // https://github.com/vercel/next.js/issues/73085
+  it('is tolerant when a locale is used in the pathname for the default locale', () => {
+    mockCurrentLocale('en');
+    mockLocation({pathname: '/en/about'});
+    renderPathname();
+    screen.getByText('/about');
   });
 });
 

--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -467,6 +467,14 @@ describe("localePrefix: 'always', custom `prefixes`", () => {
       renderPathname();
       screen.getByText('/about');
     });
+
+    // https://github.com/vercel/next.js/issues/73085
+    it('is tolerant when a locale is used in the pathname', () => {
+      mockCurrentLocale('en');
+      mockLocation({pathname: '/en/about'});
+      renderPathname();
+      screen.getByText('/about');
+    });
   });
 });
 

--- a/packages/next-intl/src/navigation/react-client/createNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.tsx
@@ -55,7 +55,7 @@ export default function createNavigation<
   function usePathname(): [AppPathnames] extends [never]
     ? string
     : keyof AppPathnames {
-    const pathname = useBasePathname(config.localePrefix);
+    const pathname = useBasePathname(config);
     const locale = useTypedLocale();
 
     // @ts-expect-error -- Mirror the behavior from Next.js, where `null` is returned when `usePathname` is used outside of Next, but the types indicate that a string is always returned.

--- a/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createSharedPathnamesNavigation.tsx
@@ -62,7 +62,10 @@ export default function createSharedPathnamesNavigation<
   }
 
   function usePathname(): string {
-    const result = useBasePathname(localePrefix);
+    const result = useBasePathname({
+      localePrefix,
+      defaultLocale: routing?.defaultLocale
+    });
     // @ts-expect-error -- Mirror the behavior from Next.js, where `null` is returned when `usePathname` is used outside of Next, but the types indicate that a string is always returned.
     return result;
   }

--- a/packages/next-intl/src/navigation/react-client/useBasePathname.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBasePathname.test.tsx
@@ -13,12 +13,13 @@ function mockPathname(pathname: string) {
 }
 
 function Component() {
-  const pathname = useBasePathname({
-    // The mode is not used, only the absence of
-    // `prefixes` is relevant for this test suite
-    mode: 'as-needed'
+  return useBasePathname({
+    localePrefix: {
+      // The mode is not used, only the absence of
+      // `prefixes` is relevant for this test suite
+      mode: 'as-needed'
+    }
   });
-  return <>{pathname}</>;
 }
 
 describe('unprefixed routing', () => {

--- a/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
@@ -7,6 +7,7 @@ import {
   Locales
 } from '../../routing/types';
 import {
+  getLocaleAsPrefix,
   getLocalePrefix,
   hasPathnamePrefixed,
   unprefixPathname
@@ -34,11 +35,20 @@ export default function useBasePathname<
   return useMemo(() => {
     if (!pathname) return pathname;
 
+    let unlocalizedPathname = pathname;
+
     const prefix = getLocalePrefix(locale, localePrefix);
     const isPathnamePrefixed = hasPathnamePrefixed(prefix, pathname);
-    const unlocalizedPathname = isPathnamePrefixed
-      ? unprefixPathname(pathname, prefix)
-      : pathname;
+
+    if (isPathnamePrefixed) {
+      unlocalizedPathname = unprefixPathname(pathname, prefix);
+    } else {
+      // https://github.com/vercel/next.js/issues/73085
+      const localeAsPrefix = getLocaleAsPrefix(locale);
+      if (hasPathnamePrefixed(localeAsPrefix, pathname)) {
+        unlocalizedPathname = unprefixPathname(pathname, localeAsPrefix);
+      }
+    }
 
     return unlocalizedPathname;
   }, [locale, localePrefix, pathname]);

--- a/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
@@ -50,7 +50,7 @@ export default function useBasePathname<
       config.defaultLocale === locale &&
       config.localePrefix.prefixes
     ) {
-      // Workaround for https://github.com/vercel/next.js/issues/73085.
+      // Workaround for https://github.com/vercel/next.js/issues/73085
       const localeAsPrefix = getLocaleAsPrefix(locale);
       if (hasPathnamePrefixed(localeAsPrefix, pathname)) {
         unlocalizedPathname = unprefixPathname(pathname, localeAsPrefix);

--- a/packages/next-intl/src/shared/utils.tsx
+++ b/packages/next-intl/src/shared/utils.tsx
@@ -154,8 +154,12 @@ export function getLocalePrefix<
     (localePrefix.mode !== 'never' && localePrefix.prefixes?.[locale]) ||
     // We return a prefix even if `mode: 'never'`. It's up to the consumer
     // to decide to use it or not.
-    '/' + locale
+    getLocaleAsPrefix(locale)
   );
+}
+
+export function getLocaleAsPrefix(locale: string) {
+  return '/' + locale;
 }
 
 export function templateToRegex(template: string): RegExp {


### PR DESCRIPTION
Fixes https://github.com/amannn/next-intl/issues/1568
