### PR TITLE
fix: Follow-up for #1573 to also handle the case when a non-default locale is in use

### DIFF
--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -550,7 +550,8 @@ describe("localePrefix: 'as-needed', custom `prefixes`", () => {
     localePrefix: {
       mode: 'as-needed',
       prefixes: {
-        en: '/uk'
+        en: '/english',
+        de: '/deutsch'
       }
     }
   });
@@ -560,6 +561,13 @@ describe("localePrefix: 'as-needed', custom `prefixes`", () => {
   it('is tolerant when a locale is used in the pathname for the default locale', () => {
     mockCurrentLocale('en');
     mockLocation({pathname: '/en/about'});
+    renderPathname();
+    screen.getByText('/about');
+  });
+
+  it('is tolerant when a locale is used in the pathname for a non-default locale', () => {
+    mockCurrentLocale('de');
+    mockLocation({pathname: '/de/about'});
     renderPathname();
     screen.getByText('/about');
   });

--- a/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
@@ -47,7 +47,6 @@ export default function useBasePathname<
       unlocalizedPathname = unprefixPathname(pathname, prefix);
     } else if (
       config.localePrefix.mode === 'as-needed' &&
-      config.defaultLocale === locale &&
       config.localePrefix.prefixes
     ) {
       // Workaround for https://github.com/vercel/next.js/issues/73085
@@ -58,5 +57,5 @@ export default function useBasePathname<
     }
 
     return unlocalizedPathname;
-  }, [config.defaultLocale, config.localePrefix, locale, pathname]);
+  }, [config.localePrefix, locale, pathname]);
 }


### PR DESCRIPTION


Fixes #1568