### PR TITLE
fix: Handle edge case for `localePrefix: 'as-needed'`, `domains` & `pathnames`

### DIFF
--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -45,7 +45,7 @@ const config: SizeLimitConfig = [
     name: "import {createNavigation} from 'next-intl/navigation' (react-server)",
     path: 'dist/production/navigation.react-server.js',
     import: '{createNavigation}',
-    limit: '16.8 KB'
+    limit: '16.815 KB'
   },
   {
     name: "import * from 'next-intl/server' (react-client)",

--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -2704,6 +2704,27 @@ describe('domain-based routing', () => {
         } satisfies Pathnames<ReadonlyArray<'en' | 'fr'>>
       });
 
+      it('redirects an unprefixed pathname from the fr locale on the en domain', () => {
+        middlewareWithPathnames(
+          createMockRequest('/a-propos', 'fr', 'http://en.example.com')
+        );
+        expect(MockedNextResponse.redirect).toHaveBeenCalled();
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          'http://en.example.com/about'
+        );
+      });
+
+      it('redirects a prefixed pathname from the fr locale on the en domain', () => {
+        middlewareWithPathnames(
+          createMockRequest('/fr/a-propos', 'fr', 'http://en.example.com')
+        );
+        expect(MockedNextResponse.redirect).toHaveBeenCalled();
+        expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
+          // (will get another redirect to /a-propos on this domain)
+          'http://fr.example.com/fr/a-propos'
+        );
+      });
+
       it('serves requests for the default locale at the root', () => {
         middlewareWithPathnames(
           createMockRequest('/', 'en', 'http://en.example.com')


### PR DESCRIPTION
Related to https://github.com/amannn/next-intl/issues/1107#issuecomment-2518412015

Couldn't find the bug yet, only added tests so far.