### PR TITLE
fix: Support `t.has` when `getTranslations` is called with an object argument

### DIFF
--- a/packages/next-intl/src/server/react-server/getTranslations.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslations.tsx
@@ -210,6 +210,24 @@ Promise<{
   >(
     key: TargetKey
   ): any;
+
+  // `has`
+  has<
+    TargetKey extends MessageKeys<
+      NestedValueOf<
+        {'!': IntlMessages},
+        [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
+      >,
+      NestedKeyOf<
+        NestedValueOf<
+          {'!': IntlMessages},
+          [NestedKey] extends [never] ? '!' : `!.${NestedKey}`
+        >
+      >
+    >
+  >(
+    key: [TargetKey] extends [never] ? string : TargetKey
+  ): boolean;
 }>;
 // IMPLEMENTATION
 async function getTranslations<


### PR DESCRIPTION
See https://github.com/amannn/next-intl/discussions/437#discussioncomment-11593318