### PR TITLE
fix: type safe useMessages return type

### DIFF
--- a/packages/use-intl/src/react/useMessages.tsx
+++ b/packages/use-intl/src/react/useMessages.tsx
@@ -1,7 +1,6 @@
-import {AbstractIntlMessages} from '../core';
 import useIntlContext from './useIntlContext';
 
-export default function useMessages(): AbstractIntlMessages {
+export default function useMessages(): IntlMessages {
   const context = useIntlContext();
 
   if (!context.messages) {


### PR DESCRIPTION
Currently, the `useMessages` hook return `AbstractIntlMessages` which is inconvenient for type-safety.
Instead the return type should be `IntlMessages`.

The workaround currently is to use `as`:
```tsx
const messages = useMessages() as IntlMessages
```