### PR TITLE
docs: Fix horizontal scroll on the landing page

### DIFF
--- a/docs/src/components/GetStartedBackground.tsx
+++ b/docs/src/components/GetStartedBackground.tsx
@@ -4,7 +4,7 @@ export default function GetStartedBackground() {
   const size = 530;
   const radius = 2;
   const className =
-    'absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-screen';
+    'absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full';
   const patternSize = 19;
 
   return (


### PR DESCRIPTION
Hi! I'd just like to make a small fix to the site's landing page.

`width: 100vw` causes appearing of a horizontal scrollbar:

![image](https://github.com/user-attachments/assets/2bf6af96-161d-48b2-93d1-c4e323d072de)

You can read more about the reasons for this behavior, for example, [here](https://dev.to/tepythai/why-100vw-causes-horizontal-scrollbar-4nlm), but in brief, on Windows, the vertical scrollbar occupies part of the viewport but `100vw` doesn't include the vertical scrollbar's width into its calculation, so there is not enough space for a block with `width: 100vw`. The fix is very simple: use `100%` instead of `100vw`.

In the next-intl case, `width: 100vw` is set on the `<svg>` element at the bottom of the page:

![image](https://github.com/user-attachments/assets/76ad3ca5-f144-4726-9995-0709fbdf7fa7)

I tested the fix, and it doesn't break the layout at any screen breakpoints:

![image](https://github.com/user-attachments/assets/314b074d-19a1-44fb-89f1-9745c8ca5a8f)

![image](https://github.com/user-attachments/assets/e0215e38-3140-4020-84a2-d25489a03577)
