### PR TITLE
fix: Change imports to use `.js` to make them compatible with `eslint-plugin-import` (#1667)

### DIFF
--- a/packages/next-intl/eslint.config.mjs
+++ b/packages/next-intl/eslint.config.mjs
@@ -27,6 +27,7 @@ export default (await getPresets('typescript', 'react', 'vitest')).concat({
     '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/consistent-type-exports': 'error',
     '@typescript-eslint/no-import-type-side-effects': 'error',
-    'import/no-duplicates': ['error', {'prefer-inline': true}]
+    'import/no-duplicates': ['error', {'prefer-inline': true}],
+    'import/extensions': 'error'
   }
 });

--- a/packages/next-intl/src/index.react-client.tsx
+++ b/packages/next-intl/src/index.react-client.tsx
@@ -6,4 +6,4 @@
  * from `./react-server` instead.
  */
 
-export * from './react-client/index.tsx';
+export * from './react-client/index.js';

--- a/packages/next-intl/src/index.react-server.tsx
+++ b/packages/next-intl/src/index.react-server.tsx
@@ -1,1 +1,1 @@
-export * from './react-server/index.tsx';
+export * from './react-server/index.js';

--- a/packages/next-intl/src/middleware.tsx
+++ b/packages/next-intl/src/middleware.tsx
@@ -1,1 +1,1 @@
-export {default} from './middleware/index.tsx';
+export {default} from './middleware/index.js';

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -2,9 +2,9 @@
 
 import {NextRequest} from 'next/server.js';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
-import {receiveRoutingConfig} from '../routing/config.tsx';
-import type {Pathnames} from '../routing.tsx';
-import getAlternateLinksHeaderValue from './getAlternateLinksHeaderValue.tsx';
+import {receiveRoutingConfig} from '../routing/config.js';
+import type {Pathnames} from '../routing.js';
+import getAlternateLinksHeaderValue from './getAlternateLinksHeaderValue.js';
 
 describe.each([{basePath: undefined}, {basePath: '/base'}])(
   'basePath: $basePath',

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -1,12 +1,12 @@
 import type {NextRequest} from 'next/server.js';
-import type {ResolvedRoutingConfig} from '../routing/config.tsx';
+import type {ResolvedRoutingConfig} from '../routing/config.js';
 import type {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../routing/types.tsx';
-import {normalizeTrailingSlash} from '../shared/utils.tsx';
+} from '../routing/types.js';
+import {normalizeTrailingSlash} from '../shared/utils.js';
 import {
   applyBasePath,
   formatTemplatePathname,
@@ -14,7 +14,7 @@ import {
   getLocalePrefixes,
   getNormalizedPathname,
   isLocaleSupportedOnDomain
-} from './utils.tsx';
+} from './utils.js';
 
 /**
  * See https://developers.google.com/search/docs/specialty/international/localized-versions

--- a/packages/next-intl/src/middleware/index.tsx
+++ b/packages/next-intl/src/middleware/index.tsx
@@ -2,4 +2,4 @@
  * The middleware, available as `next-intl/middleware`.
  */
 
-export {default} from './middleware.tsx';
+export {default} from './middleware.js';

--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -12,8 +12,8 @@ import {
   it,
   vi
 } from 'vitest';
-import createMiddleware from '../middleware.tsx';
-import {type Pathnames, defineRouting} from '../routing.tsx';
+import createMiddleware from '../middleware.js';
+import {type Pathnames, defineRouting} from '../routing.js';
 
 const COOKIE_LOCALE_NAME = 'NEXT_LOCALE';
 

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -1,20 +1,20 @@
 import {type NextRequest, NextResponse} from 'next/server.js';
-import {type RoutingConfig, receiveRoutingConfig} from '../routing/config.tsx';
+import {type RoutingConfig, receiveRoutingConfig} from '../routing/config.js';
 import type {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../routing/types.tsx';
-import {HEADER_LOCALE_NAME} from '../shared/constants.tsx';
+} from '../routing/types.js';
+import {HEADER_LOCALE_NAME} from '../shared/constants.js';
 import {
   getLocalePrefix,
   matchesPathname,
   normalizeTrailingSlash
-} from '../shared/utils.tsx';
-import getAlternateLinksHeaderValue from './getAlternateLinksHeaderValue.tsx';
-import resolveLocale from './resolveLocale.tsx';
-import syncCookie from './syncCookie.tsx';
+} from '../shared/utils.js';
+import getAlternateLinksHeaderValue from './getAlternateLinksHeaderValue.js';
+import resolveLocale from './resolveLocale.js';
+import syncCookie from './syncCookie.js';
 import {
   applyBasePath,
   formatPathname,
@@ -26,7 +26,7 @@ import {
   getPathnameMatch,
   isLocaleSupportedOnDomain,
   sanitizePathname
-} from './utils.tsx';
+} from './utils.js';
 
 export default function createMiddleware<
   const AppLocales extends Locales,

--- a/packages/next-intl/src/middleware/resolveLocale.test.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.test.tsx
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {getAcceptLanguageLocale} from './resolveLocale.tsx';
+import {getAcceptLanguageLocale} from './resolveLocale.js';
 
 describe('getAcceptLanguageLocale', () => {
   it('resolves a more specific locale to a generic one', () => {

--- a/packages/next-intl/src/middleware/resolveLocale.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.tsx
@@ -2,19 +2,19 @@ import {match} from '@formatjs/intl-localematcher';
 import Negotiator from 'negotiator';
 import type {RequestCookies} from 'next/dist/server/web/spec-extension/cookies.js';
 import type {Locale} from 'use-intl';
-import type {ResolvedRoutingConfig} from '../routing/config.tsx';
+import type {ResolvedRoutingConfig} from '../routing/config.js';
 import type {
   DomainConfig,
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../routing/types.tsx';
+} from '../routing/types.js';
 import {
   getHost,
   getPathnameMatch,
   isLocaleSupportedOnDomain
-} from './utils.tsx';
+} from './utils.js';
 
 function findDomainFromHost<AppLocales extends Locales>(
   requestHeaders: Headers,

--- a/packages/next-intl/src/middleware/resolveLocale.tsx
+++ b/packages/next-intl/src/middleware/resolveLocale.tsx
@@ -10,11 +10,7 @@ import type {
   Locales,
   Pathnames
 } from '../routing/types.js';
-import {
-  getHost,
-  getPathnameMatch,
-  isLocaleSupportedOnDomain
-} from './utils.js';
+import {getHost, getPathnameMatch, isLocaleSupportedOnDomain} from './utils.js';
 
 function findDomainFromHost<AppLocales extends Locales>(
   requestHeaders: Headers,

--- a/packages/next-intl/src/middleware/syncCookie.tsx
+++ b/packages/next-intl/src/middleware/syncCookie.tsx
@@ -3,15 +3,15 @@ import type {Locale} from 'use-intl';
 import type {
   InitializedLocaleCookieConfig,
   ResolvedRoutingConfig
-} from '../routing/config.tsx';
+} from '../routing/config.js';
 import type {
   DomainConfig,
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../routing/types.tsx';
-import {getAcceptLanguageLocale} from './resolveLocale.tsx';
+} from '../routing/types.js';
+import {getAcceptLanguageLocale} from './resolveLocale.js';
 
 export default function syncCookie<
   AppLocales extends Locales,

--- a/packages/next-intl/src/middleware/utils.test.tsx
+++ b/packages/next-intl/src/middleware/utils.test.tsx
@@ -5,7 +5,7 @@ import {
   getNormalizedPathname,
   getPathnameMatch,
   getRouteParams
-} from './utils.tsx';
+} from './utils.js';
 
 describe('getNormalizedPathname', () => {
   it('should return the normalized pathname', () => {

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -6,7 +6,7 @@ import type {
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../routing/types.tsx';
+} from '../routing/types.js';
 import {
   getLocalePrefix,
   getSortedPathnames,
@@ -14,7 +14,7 @@ import {
   normalizeTrailingSlash,
   prefixPathname,
   templateToRegex
-} from '../shared/utils.tsx';
+} from '../shared/utils.js';
 
 export function getFirstPathnameSegment(pathname: string) {
   return pathname.split('/')[1];

--- a/packages/next-intl/src/navigation.react-client.tsx
+++ b/packages/next-intl/src/navigation.react-client.tsx
@@ -1,1 +1,1 @@
-export * from './navigation/react-client/index.tsx';
+export * from './navigation/react-client/index.js';

--- a/packages/next-intl/src/navigation.react-server.tsx
+++ b/packages/next-intl/src/navigation.react-server.tsx
@@ -1,1 +1,1 @@
-export * from './navigation/react-server/index.tsx';
+export * from './navigation/react-server/index.js';

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -7,11 +7,7 @@ import {
 import {renderToString} from 'react-dom/server';
 import {type Locale, useLocale} from 'use-intl';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {
-  type DomainsConfig,
-  type Pathnames,
-  defineRouting
-} from '../routing.js';
+import {type DomainsConfig, type Pathnames, defineRouting} from '../routing.js';
 import createNavigationClient from './react-client/createNavigation.js';
 import createNavigationServer from './react-server/createNavigation.js';
 import getServerLocale from './react-server/getServerLocale.js';

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -11,10 +11,10 @@ import {
   type DomainsConfig,
   type Pathnames,
   defineRouting
-} from '../routing.tsx';
-import createNavigationClient from './react-client/createNavigation.tsx';
-import createNavigationServer from './react-server/createNavigation.tsx';
-import getServerLocale from './react-server/getServerLocale.tsx';
+} from '../routing.js';
+import createNavigationClient from './react-client/createNavigation.js';
+import createNavigationServer from './react-server/createNavigation.js';
+import getServerLocale from './react-server/getServerLocale.js';
 
 vi.mock('react');
 vi.mock('next/navigation.js', async () => ({

--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -5,8 +5,8 @@ import {
 } from 'next/navigation.js';
 import {type Locale, useLocale} from 'use-intl';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import type {DomainsConfig, Pathnames} from '../../routing.tsx';
-import createNavigation from './createNavigation.tsx';
+import type {DomainsConfig, Pathnames} from '../../routing.js';
+import createNavigation from './createNavigation.js';
 
 vi.mock('next/navigation.js');
 vi.mock('use-intl', async () => ({

--- a/packages/next-intl/src/navigation/react-client/createNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.tsx
@@ -7,17 +7,17 @@ import {type Locale, useLocale} from 'use-intl';
 import type {
   RoutingConfigLocalizedNavigation,
   RoutingConfigSharedNavigation
-} from '../../routing/config.tsx';
+} from '../../routing/config.js';
 import type {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../../routing/types.tsx';
-import createSharedNavigationFns from '../shared/createSharedNavigationFns.tsx';
-import syncLocaleCookie from '../shared/syncLocaleCookie.tsx';
-import {getRoute} from '../shared/utils.tsx';
-import useBasePathname from './useBasePathname.tsx';
+} from '../../routing/types.js';
+import createSharedNavigationFns from '../shared/createSharedNavigationFns.js';
+import syncLocaleCookie from '../shared/syncLocaleCookie.js';
+import {getRoute} from '../shared/utils.js';
+import useBasePathname from './useBasePathname.js';
 
 export default function createNavigation<
   const AppLocales extends Locales,

--- a/packages/next-intl/src/navigation/react-client/index.tsx
+++ b/packages/next-intl/src/navigation/react-client/index.tsx
@@ -1,2 +1,2 @@
-export {default as createNavigation} from './createNavigation.tsx';
-export type {QueryParams} from '../shared/utils.tsx';
+export {default as createNavigation} from './createNavigation.js';
+export type {QueryParams} from '../shared/utils.js';

--- a/packages/next-intl/src/navigation/react-client/useBasePathname.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBasePathname.test.tsx
@@ -1,8 +1,8 @@
 import {render, screen} from '@testing-library/react';
 import {usePathname as useNextPathname} from 'next/navigation.js';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {NextIntlClientProvider, useLocale} from '../../index.react-client.tsx';
-import useBasePathname from './useBasePathname.tsx';
+import {NextIntlClientProvider, useLocale} from '../../index.react-client.js';
+import useBasePathname from './useBasePathname.js';
 
 vi.mock('next/navigation.js');
 vi.mock('use-intl', async () => ({

--- a/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
+++ b/packages/next-intl/src/navigation/react-client/useBasePathname.tsx
@@ -5,13 +5,13 @@ import type {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,
   Locales
-} from '../../routing/types.tsx';
+} from '../../routing/types.js';
 import {
   getLocaleAsPrefix,
   getLocalePrefix,
   hasPathnamePrefixed,
   unprefixPathname
-} from '../../shared/utils.tsx';
+} from '../../shared/utils.js';
 
 export default function useBasePathname<
   AppLocales extends Locales,

--- a/packages/next-intl/src/navigation/react-server/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-server/createNavigation.test.tsx
@@ -1,5 +1,5 @@
 import {describe, expect, it, vi} from 'vitest';
-import createNavigation from './createNavigation.tsx';
+import createNavigation from './createNavigation.js';
 
 vi.mock('react');
 

--- a/packages/next-intl/src/navigation/react-server/createNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-server/createNavigation.tsx
@@ -1,15 +1,15 @@
 import type {
   RoutingConfigLocalizedNavigation,
   RoutingConfigSharedNavigation
-} from '../../routing/config.tsx';
+} from '../../routing/config.js';
 import type {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../../routing/types.tsx';
-import createSharedNavigationFns from '../shared/createSharedNavigationFns.tsx';
-import getServerLocale from './getServerLocale.tsx';
+} from '../../routing/types.js';
+import createSharedNavigationFns from '../shared/createSharedNavigationFns.js';
+import getServerLocale from './getServerLocale.js';
 
 export default function createNavigation<
   const AppLocales extends Locales,

--- a/packages/next-intl/src/navigation/react-server/getServerLocale.tsx
+++ b/packages/next-intl/src/navigation/react-server/getServerLocale.tsx
@@ -1,4 +1,4 @@
-import getConfig from '../../server/react-server/getConfig.tsx';
+import getConfig from '../../server/react-server/getConfig.js';
 
 /**
  * This is only moved to a separate module for easier mocking in

--- a/packages/next-intl/src/navigation/react-server/index.tsx
+++ b/packages/next-intl/src/navigation/react-server/index.tsx
@@ -1,2 +1,2 @@
-export {default as createNavigation} from './createNavigation.tsx';
-export type {Pathnames} from '../../routing/types.tsx';
+export {default as createNavigation} from './createNavigation.js';
+export type {Pathnames} from '../../routing/types.js';

--- a/packages/next-intl/src/navigation/shared/BaseLink.tsx
+++ b/packages/next-intl/src/navigation/shared/BaseLink.tsx
@@ -11,8 +11,8 @@ import {
   useState
 } from 'react';
 import {type Locale, useLocale} from 'use-intl';
-import type {InitializedLocaleCookieConfig} from '../../routing/config.tsx';
-import syncLocaleCookie from './syncLocaleCookie.tsx';
+import type {InitializedLocaleCookieConfig} from '../../routing/config.js';
+import syncLocaleCookie from './syncLocaleCookie.js';
 
 type NextLinkProps = Omit<ComponentProps<'a'>, keyof LinkProps> &
   Omit<LinkProps, 'locale'>;

--- a/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
+++ b/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
@@ -8,18 +8,18 @@ import {
   type RoutingConfigLocalizedNavigation,
   type RoutingConfigSharedNavigation,
   receiveRoutingConfig
-} from '../../routing/config.tsx';
+} from '../../routing/config.js';
 import type {
   DomainConfig,
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../../routing/types.tsx';
-import type {ParametersExceptFirst, Prettify} from '../../shared/types.tsx';
-import use from '../../shared/use.tsx';
-import {isLocalizableHref} from '../../shared/utils.tsx';
-import BaseLink from './BaseLink.tsx';
+} from '../../routing/types.js';
+import type {ParametersExceptFirst, Prettify} from '../../shared/types.js';
+import use from '../../shared/use.js';
+import {isLocalizableHref} from '../../shared/utils.js';
+import BaseLink from './BaseLink.js';
 import {
   type HrefOrHrefWithParams,
   type HrefOrUrlObjectWithParams,
@@ -29,7 +29,7 @@ import {
   normalizeNameOrNameWithParams,
   serializeSearchParams,
   validateReceivedConfig
-} from './utils.tsx';
+} from './utils.js';
 
 type PromiseOrValue<Type> = Type | Promise<Type>;
 

--- a/packages/next-intl/src/navigation/shared/syncLocaleCookie.tsx
+++ b/packages/next-intl/src/navigation/shared/syncLocaleCookie.tsx
@@ -1,6 +1,6 @@
 import type {Locale} from 'use-intl';
-import type {InitializedLocaleCookieConfig} from '../../routing/config.tsx';
-import {getBasePath} from './utils.tsx';
+import type {InitializedLocaleCookieConfig} from '../../routing/config.js';
+import {getBasePath} from './utils.js';
 
 /**
  * We have to keep the cookie value in sync as Next.js might

--- a/packages/next-intl/src/navigation/shared/utils.test.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.test.tsx
@@ -3,7 +3,7 @@ import {
   compileLocalizedPathname,
   getBasePath,
   serializeSearchParams
-} from './utils.tsx';
+} from './utils.js';
 
 describe('serializeSearchParams', () => {
   it('handles strings', () => {

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -1,13 +1,13 @@
 import type {ParsedUrlQueryInput} from 'node:querystring';
 import type {UrlObject} from 'url';
 import type {Locale} from 'use-intl';
-import type {ResolvedRoutingConfig} from '../../routing/config.tsx';
+import type {ResolvedRoutingConfig} from '../../routing/config.js';
 import type {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from '../../routing/types.tsx';
+} from '../../routing/types.js';
 import {
   getLocalePrefix,
   getSortedPathnames,
@@ -15,8 +15,8 @@ import {
   matchesPathname,
   normalizeTrailingSlash,
   prefixPathname
-} from '../../shared/utils.tsx';
-import type StrictParams from './StrictParams.tsx';
+} from '../../shared/utils.js';
+import type StrictParams from './StrictParams.js';
 
 type SearchParamValue = ParsedUrlQueryInput[keyof ParsedUrlQueryInput];
 

--- a/packages/next-intl/src/plugin.tsx
+++ b/packages/next-intl/src/plugin.tsx
@@ -1,1 +1,1 @@
-export {default} from './plugin/index.tsx';
+export {default} from './plugin/index.js';

--- a/packages/next-intl/src/plugin/createMessagesDeclaration.tsx
+++ b/packages/next-intl/src/plugin/createMessagesDeclaration.tsx
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import {throwError} from './utils.tsx';
+import {throwError} from './utils.js';
 
 function runOnce(fn: () => void) {
   if (process.env._NEXT_INTL_COMPILE_MESSAGES === '1') {

--- a/packages/next-intl/src/plugin/createNextIntlPlugin.tsx
+++ b/packages/next-intl/src/plugin/createNextIntlPlugin.tsx
@@ -1,8 +1,8 @@
 import type {NextConfig} from 'next';
-import createMessagesDeclaration from './createMessagesDeclaration.tsx';
-import getNextConfig from './getNextConfig.tsx';
-import type {PluginConfig} from './types.tsx';
-import {warn} from './utils.tsx';
+import createMessagesDeclaration from './createMessagesDeclaration.js';
+import getNextConfig from './getNextConfig.js';
+import type {PluginConfig} from './types.js';
+import {warn} from './utils.js';
 
 function initPlugin(
   pluginConfig: PluginConfig,

--- a/packages/next-intl/src/plugin/getNextConfig.tsx
+++ b/packages/next-intl/src/plugin/getNextConfig.tsx
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import type {NextConfig} from 'next';
-import type {PluginConfig} from './types.tsx';
-import {throwError} from './utils.tsx';
+import type {PluginConfig} from './types.js';
+import {throwError} from './utils.js';
 
 function withExtensions(localPath: string) {
   return [

--- a/packages/next-intl/src/plugin/index.tsx
+++ b/packages/next-intl/src/plugin/index.tsx
@@ -1,1 +1,1 @@
-export {default} from './createNextIntlPlugin.tsx';
+export {default} from './createNextIntlPlugin.js';

--- a/packages/next-intl/src/react-client/index.tsx
+++ b/packages/next-intl/src/react-client/index.tsx
@@ -46,4 +46,4 @@ export const useFormatter = callHook(
   base_useFormatter
 ) as typeof base_useFormatter;
 
-export {default as NextIntlClientProvider} from '../shared/NextIntlClientProvider.tsx';
+export {default as NextIntlClientProvider} from '../shared/NextIntlClientProvider.js';

--- a/packages/next-intl/src/react-client/useFormatter.test.tsx
+++ b/packages/next-intl/src/react-client/useFormatter.test.tsx
@@ -1,6 +1,6 @@
 import {render, screen} from '@testing-library/react';
 import {expect, it} from 'vitest';
-import {NextIntlClientProvider, useFormatter} from './index.tsx';
+import {NextIntlClientProvider, useFormatter} from './index.js';
 
 function Component() {
   const format = useFormatter();

--- a/packages/next-intl/src/react-client/useNow.test.tsx
+++ b/packages/next-intl/src/react-client/useNow.test.tsx
@@ -1,6 +1,6 @@
 import {render, screen} from '@testing-library/react';
 import {it} from 'vitest';
-import {NextIntlClientProvider, useNow} from './index.tsx';
+import {NextIntlClientProvider, useNow} from './index.js';
 
 function Component() {
   const now = useNow();

--- a/packages/next-intl/src/react-client/useTimeZone.test.tsx
+++ b/packages/next-intl/src/react-client/useTimeZone.test.tsx
@@ -1,6 +1,6 @@
 import {render, screen} from '@testing-library/react';
 import {it} from 'vitest';
-import {NextIntlClientProvider, useTimeZone} from './index.tsx';
+import {NextIntlClientProvider, useTimeZone} from './index.js';
 
 function Component() {
   const timeZone = useTimeZone();

--- a/packages/next-intl/src/react-client/useTranslations.test.tsx
+++ b/packages/next-intl/src/react-client/useTranslations.test.tsx
@@ -1,6 +1,6 @@
 import {render, screen} from '@testing-library/react';
 import {expect, it, vi} from 'vitest';
-import {NextIntlClientProvider, useTranslations} from './index.tsx';
+import {NextIntlClientProvider, useTranslations} from './index.js';
 
 function Component() {
   const t = useTranslations('Component');

--- a/packages/next-intl/src/react-server/NextIntlClientProviderServer.test.tsx
+++ b/packages/next-intl/src/react-server/NextIntlClientProviderServer.test.tsx
@@ -1,9 +1,9 @@
 import {expect, it, vi} from 'vitest';
-import getConfigNow from '../server/react-server/getConfigNow.tsx';
-import getFormats from '../server/react-server/getFormats.tsx';
-import {getLocale, getTimeZone} from '../server.react-server.tsx';
-import NextIntlClientProvider from '../shared/NextIntlClientProvider.tsx';
-import NextIntlClientProviderServer from './NextIntlClientProviderServer.tsx';
+import getConfigNow from '../server/react-server/getConfigNow.js';
+import getFormats from '../server/react-server/getFormats.js';
+import {getLocale, getTimeZone} from '../server.react-server.js';
+import NextIntlClientProvider from '../shared/NextIntlClientProvider.js';
+import NextIntlClientProviderServer from './NextIntlClientProviderServer.js';
 
 vi.mock('../../src/server/react-server', async () => ({
   getLocale: vi.fn(async () => 'en-US'),

--- a/packages/next-intl/src/react-server/NextIntlClientProviderServer.tsx
+++ b/packages/next-intl/src/react-server/NextIntlClientProviderServer.tsx
@@ -1,8 +1,8 @@
 import type {ComponentProps} from 'react';
-import getConfigNow from '../server/react-server/getConfigNow.tsx';
-import getFormats from '../server/react-server/getFormats.tsx';
-import {getLocale, getTimeZone} from '../server.react-server.tsx';
-import BaseNextIntlClientProvider from '../shared/NextIntlClientProvider.tsx';
+import getConfigNow from '../server/react-server/getConfigNow.js';
+import getFormats from '../server/react-server/getFormats.js';
+import {getLocale, getTimeZone} from '../server.react-server.js';
+import BaseNextIntlClientProvider from '../shared/NextIntlClientProvider.js';
 
 type Props = ComponentProps<typeof BaseNextIntlClientProvider>;
 

--- a/packages/next-intl/src/react-server/index.test.tsx
+++ b/packages/next-intl/src/react-server/index.test.tsx
@@ -1,5 +1,5 @@
 import {describe, expect, it, vi} from 'vitest';
-import {getTranslations} from '../server.react-server.tsx';
+import {getTranslations} from '../server.react-server.js';
 import {
   _createCache,
   useFormatter,
@@ -7,8 +7,8 @@ import {
   useMessages,
   useNow,
   useTranslations
-} from './index.tsx';
-import {renderToStream} from './testUtils.tsx';
+} from './index.js';
+import {renderToStream} from './testUtils.js';
 
 vi.mock('react');
 

--- a/packages/next-intl/src/react-server/index.test.tsx
+++ b/packages/next-intl/src/react-server/index.test.tsx
@@ -1,5 +1,6 @@
 import {describe, expect, it, vi} from 'vitest';
 import {getTranslations} from '../server.react-server.js';
+import {renderToStream} from './testUtils.js';
 import {
   _createCache,
   useFormatter,
@@ -8,7 +9,6 @@ import {
   useNow,
   useTranslations
 } from './index.js';
-import {renderToStream} from './testUtils.js';
 
 vi.mock('react');
 

--- a/packages/next-intl/src/react-server/index.tsx
+++ b/packages/next-intl/src/react-server/index.tsx
@@ -7,13 +7,13 @@
  */
 
 // Replaced exports from the `react` package
-export {default as useLocale} from './useLocale.tsx';
-export {default as useTranslations} from './useTranslations.tsx';
-export {default as useFormatter} from './useFormatter.tsx';
-export {default as useNow} from './useNow.tsx';
-export {default as useTimeZone} from './useTimeZone.tsx';
-export {default as useMessages} from './useMessages.tsx';
-export {default as NextIntlClientProvider} from './NextIntlClientProviderServer.tsx';
+export {default as useLocale} from './useLocale.js';
+export {default as useTranslations} from './useTranslations.js';
+export {default as useFormatter} from './useFormatter.js';
+export {default as useNow} from './useNow.js';
+export {default as useTimeZone} from './useTimeZone.js';
+export {default as useMessages} from './useMessages.js';
+export {default as NextIntlClientProvider} from './NextIntlClientProviderServer.js';
 
 // Everything from `core`
 export * from 'use-intl/core';

--- a/packages/next-intl/src/react-server/useConfig.tsx
+++ b/packages/next-intl/src/react-server/useConfig.tsx
@@ -1,5 +1,5 @@
-import getConfig from '../server/react-server/getConfig.tsx';
-import use from '../shared/use.tsx';
+import getConfig from '../server/react-server/getConfig.js';
+import use from '../shared/use.js';
 
 function useHook<Value>(hookName: string, promise: Promise<Value>) {
   try {

--- a/packages/next-intl/src/react-server/useFormatter.test.tsx
+++ b/packages/next-intl/src/react-server/useFormatter.test.tsx
@@ -1,7 +1,7 @@
 import {describe, expect, it, vi} from 'vitest';
-import getDefaultNow from '../server/react-server/getDefaultNow.tsx';
-import {renderToStream} from './testUtils.tsx';
-import useFormatter from './useFormatter.tsx';
+import getDefaultNow from '../server/react-server/getDefaultNow.js';
+import {renderToStream} from './testUtils.js';
+import useFormatter from './useFormatter.js';
 
 vi.mock('react');
 vi.mock('../server/react-server/getDefaultNow.tsx', () => ({

--- a/packages/next-intl/src/react-server/useFormatter.tsx
+++ b/packages/next-intl/src/react-server/useFormatter.tsx
@@ -1,6 +1,6 @@
 import type {useFormatter as useFormatterType} from 'use-intl';
-import getServerFormatter from '../server/react-server/getServerFormatter.tsx';
-import useConfig from './useConfig.tsx';
+import getServerFormatter from '../server/react-server/getServerFormatter.js';
+import useConfig from './useConfig.js';
 
 export default function useFormatter(): ReturnType<typeof useFormatterType> {
   const config = useConfig('useFormatter');

--- a/packages/next-intl/src/react-server/useLocale.tsx
+++ b/packages/next-intl/src/react-server/useLocale.tsx
@@ -1,5 +1,5 @@
 import type {useLocale as useLocaleType} from 'use-intl';
-import useConfig from './useConfig.tsx';
+import useConfig from './useConfig.js';
 
 export default function useLocale(): ReturnType<typeof useLocaleType> {
   const config = useConfig('useLocale');

--- a/packages/next-intl/src/react-server/useMessages.tsx
+++ b/packages/next-intl/src/react-server/useMessages.tsx
@@ -1,6 +1,6 @@
 import type {useMessages as useMessagesType} from 'use-intl';
-import {getMessagesFromConfig} from '../server/react-server/getMessages.tsx';
-import useConfig from './useConfig.tsx';
+import {getMessagesFromConfig} from '../server/react-server/getMessages.js';
+import useConfig from './useConfig.js';
 
 export default function useMessages(): ReturnType<typeof useMessagesType> {
   const config = useConfig('useMessages');

--- a/packages/next-intl/src/react-server/useNow.tsx
+++ b/packages/next-intl/src/react-server/useNow.tsx
@@ -1,6 +1,6 @@
 import type {useNow as useNowType} from 'use-intl';
-import getDefaultNow from '../server/react-server/getDefaultNow.tsx';
-import useConfig from './useConfig.tsx';
+import getDefaultNow from '../server/react-server/getDefaultNow.js';
+import useConfig from './useConfig.js';
 
 export default function useNow(
   options?: Parameters<typeof useNowType>[0]

--- a/packages/next-intl/src/react-server/useTimeZone.tsx
+++ b/packages/next-intl/src/react-server/useTimeZone.tsx
@@ -1,5 +1,5 @@
 import type {useTimeZone as useTimeZoneType} from 'use-intl';
-import useConfig from './useConfig.tsx';
+import useConfig from './useConfig.js';
 
 export default function useTimeZone(): ReturnType<typeof useTimeZoneType> {
   const config = useConfig('useTimeZone');

--- a/packages/next-intl/src/react-server/useTranslations.test.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.test.tsx
@@ -1,7 +1,7 @@
 import {cache} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {createTranslator, useTranslations} from './index.tsx';
-import {renderToStream} from './testUtils.tsx';
+import {createTranslator, useTranslations} from './index.js';
+import {renderToStream} from './testUtils.js';
 
 vi.mock('../../src/server/react-server/createRequestConfig', () => ({
   default: async () => ({

--- a/packages/next-intl/src/react-server/useTranslations.test.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.test.tsx
@@ -1,7 +1,7 @@
 import {cache} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {createTranslator, useTranslations} from './index.js';
 import {renderToStream} from './testUtils.js';
+import {createTranslator, useTranslations} from './index.js';
 
 vi.mock('../../src/server/react-server/createRequestConfig', () => ({
   default: async () => ({

--- a/packages/next-intl/src/react-server/useTranslations.tsx
+++ b/packages/next-intl/src/react-server/useTranslations.tsx
@@ -1,6 +1,6 @@
 import type {useTranslations as useTranslationsType} from 'use-intl';
-import getServerTranslator from '../server/react-server/getServerTranslator.tsx';
-import useConfig from './useConfig.tsx';
+import getServerTranslator from '../server/react-server/getServerTranslator.js';
+import useConfig from './useConfig.js';
 
 export default function useTranslations(
   ...[namespace]: Parameters<typeof useTranslationsType>

--- a/packages/next-intl/src/routing.tsx
+++ b/packages/next-intl/src/routing.tsx
@@ -1,1 +1,1 @@
-export * from './routing/index.tsx';
+export * from './routing/index.js';

--- a/packages/next-intl/src/routing/config.tsx
+++ b/packages/next-intl/src/routing/config.tsx
@@ -6,7 +6,7 @@ import type {
   LocalePrefixMode,
   Locales,
   Pathnames
-} from './types.tsx';
+} from './types.js';
 
 type CookieAttributes = Pick<
   NonNullable<Parameters<typeof NextResponse.prototype.cookies.set>['2']>,

--- a/packages/next-intl/src/routing/defineRouting.test.tsx
+++ b/packages/next-intl/src/routing/defineRouting.test.tsx
@@ -1,5 +1,5 @@
 import {describe, it} from 'vitest';
-import defineRouting from './defineRouting.tsx';
+import defineRouting from './defineRouting.js';
 
 describe('defaultLocale', () => {
   it('ensures the `defaultLocale` is within `locales`', () => {

--- a/packages/next-intl/src/routing/defineRouting.tsx
+++ b/packages/next-intl/src/routing/defineRouting.tsx
@@ -1,11 +1,11 @@
-import type {RoutingConfig} from './config.tsx';
+import type {RoutingConfig} from './config.js';
 import type {
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
-} from './types.tsx';
-import validateLocales from './validateLocales.tsx';
+} from './types.js';
+import validateLocales from './validateLocales.js';
 
 export default function defineRouting<
   const AppLocales extends Locales,

--- a/packages/next-intl/src/routing/index.tsx
+++ b/packages/next-intl/src/routing/index.tsx
@@ -3,6 +3,6 @@ export type {
   LocalePrefix,
   DomainsConfig,
   LocalePrefixMode
-} from './types.tsx';
-export {default as defineRouting} from './defineRouting.tsx';
-export type {RoutingConfig} from './config.tsx';
+} from './types.js';
+export {default as defineRouting} from './defineRouting.js';
+export type {RoutingConfig} from './config.js';

--- a/packages/next-intl/src/routing/types.test.tsx
+++ b/packages/next-intl/src/routing/types.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {describe, it} from 'vitest';
-import type {DomainConfig, LocalePrefix} from './types.tsx';
+import type {DomainConfig, LocalePrefix} from './types.js';
 
 describe('LocalePrefix', () => {
   it('does not require a type param for simple values', () => {

--- a/packages/next-intl/src/routing/validateLocales.test.tsx
+++ b/packages/next-intl/src/routing/validateLocales.test.tsx
@@ -1,5 +1,5 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import validateLocales from './validateLocales.tsx';
+import validateLocales from './validateLocales.js';
 
 describe('accepts valid formats', () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;

--- a/packages/next-intl/src/routing/validateLocales.tsx
+++ b/packages/next-intl/src/routing/validateLocales.tsx
@@ -1,4 +1,4 @@
-import type {Locales} from './types.tsx';
+import type {Locales} from './types.js';
 
 export default function validateLocales(locales: Locales) {
   for (const locale of locales) {

--- a/packages/next-intl/src/server.react-client.tsx
+++ b/packages/next-intl/src/server.react-client.tsx
@@ -1,1 +1,1 @@
-export * from './server/react-client/index.tsx';
+export * from './server/react-client/index.js';

--- a/packages/next-intl/src/server.react-server.tsx
+++ b/packages/next-intl/src/server.react-server.tsx
@@ -1,1 +1,1 @@
-export * from './server/react-server/index.tsx';
+export * from './server/react-server/index.js';

--- a/packages/next-intl/src/server/react-client/index.test.tsx
+++ b/packages/next-intl/src/server/react-client/index.test.tsx
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {getRequestConfig} from '../../server.react-client.tsx';
+import {getRequestConfig} from '../../server.react-client.js';
 
 describe('getRequestConfig', () => {
   it('can be called in the outer module closure', () => {

--- a/packages/next-intl/src/server/react-client/index.tsx
+++ b/packages/next-intl/src/server/react-client/index.tsx
@@ -6,7 +6,7 @@ import type {
   getRequestConfig as getRequestConfig_type,
   getTimeZone as getTimeZone_type,
   setRequestLocale as setRequestLocale_type
-} from '../react-server/index.tsx';
+} from '../react-server/index.js';
 
 /**
  * Allows to import `next-intl/server` in non-RSC environments.

--- a/packages/next-intl/src/server/react-server/RequestLocale.tsx
+++ b/packages/next-intl/src/server/react-server/RequestLocale.tsx
@@ -1,8 +1,8 @@
 import {headers} from 'next/headers.js';
 import {cache} from 'react';
 import type {Locale} from 'use-intl';
-import {HEADER_LOCALE_NAME} from '../../shared/constants.tsx';
-import {getCachedRequestLocale} from './RequestLocaleCache.tsx';
+import {HEADER_LOCALE_NAME} from '../../shared/constants.js';
+import {getCachedRequestLocale} from './RequestLocaleCache.js';
 
 async function getHeadersImpl(): Promise<Headers> {
   const promiseOrValue = headers();

--- a/packages/next-intl/src/server/react-server/createRequestConfig.tsx
+++ b/packages/next-intl/src/server/react-server/createRequestConfig.tsx
@@ -2,7 +2,7 @@ import getRuntimeConfig from 'next-intl/config';
 import type {
   GetRequestConfigParams,
   RequestConfig
-} from './getRequestConfig.tsx';
+} from './getRequestConfig.js';
 
 export default getRuntimeConfig as unknown as (
   params: GetRequestConfigParams

--- a/packages/next-intl/src/server/react-server/getConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getConfig.tsx
@@ -6,9 +6,9 @@ import {
   _createIntlFormatters,
   initializeConfig
 } from 'use-intl/core';
-import {getRequestLocale} from './RequestLocale.tsx';
-import createRequestConfig from './createRequestConfig.tsx';
-import type {GetRequestConfigParams} from './getRequestConfig.tsx';
+import {getRequestLocale} from './RequestLocale.js';
+import createRequestConfig from './createRequestConfig.js';
+import type {GetRequestConfigParams} from './getRequestConfig.js';
 
 // This is automatically inherited by `NextIntlClientProvider` if
 // the component is rendered from a Server Component

--- a/packages/next-intl/src/server/react-server/getConfigNow.tsx
+++ b/packages/next-intl/src/server/react-server/getConfigNow.tsx
@@ -1,6 +1,6 @@
 import {cache} from 'react';
 import type {Locale} from 'use-intl';
-import getConfig from './getConfig.tsx';
+import getConfig from './getConfig.js';
 
 async function getConfigNowImpl(locale?: Locale) {
   const config = await getConfig(locale);

--- a/packages/next-intl/src/server/react-server/getFormats.tsx
+++ b/packages/next-intl/src/server/react-server/getFormats.tsx
@@ -1,5 +1,5 @@
 import {cache} from 'react';
-import getConfig from './getConfig.tsx';
+import getConfig from './getConfig.js';
 
 async function getFormatsCachedImpl() {
   const config = await getConfig();

--- a/packages/next-intl/src/server/react-server/getFormatter.test.tsx
+++ b/packages/next-intl/src/server/react-server/getFormatter.test.tsx
@@ -1,6 +1,6 @@
 import {describe, expect, it, vi} from 'vitest';
-import getDefaultNow from './getDefaultNow.tsx';
-import getFormatter from './getFormatter.tsx';
+import getDefaultNow from './getDefaultNow.js';
+import getFormatter from './getFormatter.js';
 
 vi.mock('react');
 vi.mock('./getDefaultNow.tsx', () => ({

--- a/packages/next-intl/src/server/react-server/getFormatter.tsx
+++ b/packages/next-intl/src/server/react-server/getFormatter.tsx
@@ -1,7 +1,7 @@
 import {cache} from 'react';
 import type {Locale, createFormatter} from 'use-intl/core';
-import getConfig from './getConfig.tsx';
-import getServerFormatter from './getServerFormatter.tsx';
+import getConfig from './getConfig.js';
+import getServerFormatter from './getServerFormatter.js';
 
 async function getFormatterCachedImpl(locale?: Locale) {
   const config = await getConfig(locale);

--- a/packages/next-intl/src/server/react-server/getLocale.tsx
+++ b/packages/next-intl/src/server/react-server/getLocale.tsx
@@ -1,6 +1,6 @@
 import {cache} from 'react';
 import type {Locale} from 'use-intl';
-import getConfig from './getConfig.tsx';
+import getConfig from './getConfig.js';
 
 async function getLocaleCachedImpl(): Promise<Locale> {
   const config = await getConfig();

--- a/packages/next-intl/src/server/react-server/getMessages.tsx
+++ b/packages/next-intl/src/server/react-server/getMessages.tsx
@@ -1,6 +1,6 @@
 import {cache} from 'react';
 import type {Locale, useMessages as useMessagesType} from 'use-intl';
-import getConfig from './getConfig.tsx';
+import getConfig from './getConfig.js';
 
 export function getMessagesFromConfig(
   config: Awaited<ReturnType<typeof getConfig>>

--- a/packages/next-intl/src/server/react-server/getNow.tsx
+++ b/packages/next-intl/src/server/react-server/getNow.tsx
@@ -1,6 +1,6 @@
 import type {Locale} from 'use-intl';
-import getConfigNow from './getConfigNow.tsx';
-import getDefaultNow from './getDefaultNow.tsx';
+import getConfigNow from './getConfigNow.js';
+import getDefaultNow from './getDefaultNow.js';
 
 export default async function getNow(opts?: {locale?: Locale}): Promise<Date> {
   return (await getConfigNow(opts?.locale)) ?? getDefaultNow();

--- a/packages/next-intl/src/server/react-server/getServerFormatter.tsx
+++ b/packages/next-intl/src/server/react-server/getServerFormatter.tsx
@@ -1,6 +1,6 @@
 import {cache} from 'react';
 import {createFormatter} from 'use-intl/core';
-import getDefaultNow from './getDefaultNow.tsx';
+import getDefaultNow from './getDefaultNow.js';
 
 function getFormatterCachedImpl(config: Parameters<typeof createFormatter>[0]) {
   // same here?

--- a/packages/next-intl/src/server/react-server/getTimeZone.tsx
+++ b/packages/next-intl/src/server/react-server/getTimeZone.tsx
@@ -1,6 +1,6 @@
 import {cache} from 'react';
 import type {Locale} from 'use-intl';
-import getConfig from './getConfig.tsx';
+import getConfig from './getConfig.js';
 
 async function getTimeZoneCachedImpl(locale?: Locale) {
   const config = await getConfig(locale);

--- a/packages/next-intl/src/server/react-server/getTranslations.test.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslations.test.tsx
@@ -1,6 +1,6 @@
 import {createTranslator} from 'use-intl/core';
 import {expect, it, vi} from 'vitest';
-import getTranslations from './getTranslations.tsx';
+import getTranslations from './getTranslations.js';
 
 vi.mock('react');
 vi.mock('use-intl/core');

--- a/packages/next-intl/src/server/react-server/getTranslations.tsx
+++ b/packages/next-intl/src/server/react-server/getTranslations.tsx
@@ -6,8 +6,8 @@ import type {
   NestedKeyOf,
   createTranslator
 } from 'use-intl/core';
-import getConfig from './getConfig.tsx';
-import getServerTranslator from './getServerTranslator.tsx';
+import getConfig from './getConfig.js';
+import getServerTranslator from './getServerTranslator.js';
 
 // Maintainer note: `getTranslations` has two different call signatures.
 // We need to define these with function overloads, otherwise TypeScript

--- a/packages/next-intl/src/server/react-server/index.test.tsx
+++ b/packages/next-intl/src/server/react-server/index.test.tsx
@@ -1,14 +1,14 @@
 // @vitest-environment edge-runtime
 
 import {describe, expect, it, vi} from 'vitest';
-import {HEADER_LOCALE_NAME} from '../../shared/constants.tsx';
+import {HEADER_LOCALE_NAME} from '../../shared/constants.js';
 import {
   getFormatter,
   getMessages,
   getNow,
   getTimeZone,
   getTranslations
-} from './index.tsx';
+} from './index.js';
 
 vi.mock('next-intl/config', () => ({
   default: async () =>

--- a/packages/next-intl/src/server/react-server/index.tsx
+++ b/packages/next-intl/src/server/react-server/index.tsx
@@ -6,12 +6,12 @@ export {
   default as getRequestConfig,
   type GetRequestConfigParams,
   type RequestConfig
-} from './getRequestConfig.tsx';
-export {default as getFormatter} from './getFormatter.tsx';
-export {default as getNow} from './getNow.tsx';
-export {default as getTimeZone} from './getTimeZone.tsx';
-export {default as getTranslations} from './getTranslations.tsx';
-export {default as getMessages} from './getMessages.tsx';
-export {default as getLocale} from './getLocale.tsx';
+} from './getRequestConfig.js';
+export {default as getFormatter} from './getFormatter.js';
+export {default as getNow} from './getNow.js';
+export {default as getTimeZone} from './getTimeZone.js';
+export {default as getTranslations} from './getTranslations.js';
+export {default as getMessages} from './getMessages.js';
+export {default as getLocale} from './getLocale.js';
 
-export {setCachedRequestLocale as setRequestLocale} from './RequestLocaleCache.tsx';
+export {setCachedRequestLocale as setRequestLocale} from './RequestLocaleCache.js';

--- a/packages/next-intl/src/shared/utils.test.tsx
+++ b/packages/next-intl/src/shared/utils.test.tsx
@@ -5,7 +5,7 @@ import {
   matchesPathname,
   prefixPathname,
   unprefixPathname
-} from './utils.tsx';
+} from './utils.js';
 
 describe('prefixPathname', () => {
   it("doesn't add trailing slashes for the root", () => {

--- a/packages/next-intl/src/shared/utils.tsx
+++ b/packages/next-intl/src/shared/utils.tsx
@@ -3,7 +3,7 @@ import type {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,
   Locales
-} from '../routing/types.tsx';
+} from '../routing/types.js';
 
 type Href = LinkProps['href'];
 

--- a/packages/next-intl/tsconfig.json
+++ b/packages/next-intl/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "eslint-config-molindo/tsconfig.json",
   "include": ["src", "test", "__mocks__", "types", "next-env.d.ts"],
   "compilerOptions": {
-    "allowImportingTsExtensions": true, // For ESM
     "lib": ["dom", "esnext"],
     "target": "ES2020",
     "declaration": true,

--- a/packages/use-intl/eslint.config.mjs
+++ b/packages/use-intl/eslint.config.mjs
@@ -12,6 +12,7 @@ export default (await getPresets('typescript', 'react', 'vitest')).concat({
     '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/consistent-type-exports': 'error',
     '@typescript-eslint/no-import-type-side-effects': 'error',
-    'import/no-duplicates': ['error', {'prefer-inline': true}]
+    'import/no-duplicates': ['error', {'prefer-inline': true}],
+    'import/extensions': 'error'
   }
 });

--- a/packages/use-intl/src/core.tsx
+++ b/packages/use-intl/src/core.tsx
@@ -1,1 +1,1 @@
-export * from './core/index.tsx';
+export * from './core/index.js';

--- a/packages/use-intl/src/core/DateTimeFormatOptions.tsx
+++ b/packages/use-intl/src/core/DateTimeFormatOptions.tsx
@@ -1,6 +1,6 @@
 // https://github.com/microsoft/TypeScript/issues/35865
 
-import type TimeZone from './TimeZone.tsx';
+import type TimeZone from './TimeZone.js';
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat

--- a/packages/use-intl/src/core/Formats.tsx
+++ b/packages/use-intl/src/core/Formats.tsx
@@ -1,5 +1,5 @@
-import type DateTimeFormatOptions from './DateTimeFormatOptions.tsx';
-import type NumberFormatOptions from './NumberFormatOptions.tsx';
+import type DateTimeFormatOptions from './DateTimeFormatOptions.js';
+import type NumberFormatOptions from './NumberFormatOptions.js';
 
 type Formats = {
   number?: Record<string, NumberFormatOptions>;

--- a/packages/use-intl/src/core/IntlConfig.tsx
+++ b/packages/use-intl/src/core/IntlConfig.tsx
@@ -1,8 +1,8 @@
-import type AbstractIntlMessages from './AbstractIntlMessages.tsx';
-import type {Locale} from './AppConfig.tsx';
-import type Formats from './Formats.tsx';
-import type IntlError from './IntlError.tsx';
-import type TimeZone from './TimeZone.tsx';
+import type AbstractIntlMessages from './AbstractIntlMessages.js';
+import type {Locale} from './AppConfig.js';
+import type Formats from './Formats.js';
+import type IntlError from './IntlError.js';
+import type TimeZone from './TimeZone.js';
 
 /**
  * Should be used for entry points that configure the library.

--- a/packages/use-intl/src/core/IntlError.tsx
+++ b/packages/use-intl/src/core/IntlError.tsx
@@ -1,4 +1,4 @@
-import type IntlErrorCode from './IntlErrorCode.tsx';
+import type IntlErrorCode from './IntlErrorCode.js';
 
 export default class IntlError extends Error {
   public readonly code: IntlErrorCode;

--- a/packages/use-intl/src/core/convertFormatsToIntlMessageFormat.tsx
+++ b/packages/use-intl/src/core/convertFormatsToIntlMessageFormat.tsx
@@ -2,8 +2,8 @@ import {
   type Formats as IntlFormats,
   IntlMessageFormat
 } from 'intl-messageformat';
-import type Formats from './Formats.tsx';
-import type TimeZone from './TimeZone.tsx';
+import type Formats from './Formats.js';
+import type TimeZone from './TimeZone.js';
 
 /**
  * `intl-messageformat` uses separate keys for `date` and `time`, but there's

--- a/packages/use-intl/src/core/createBaseTranslator.tsx
+++ b/packages/use-intl/src/core/createBaseTranslator.tsx
@@ -1,27 +1,27 @@
 import {IntlMessageFormat} from 'intl-messageformat';
 import {type ReactNode, cloneElement, isValidElement} from 'react';
-import type AbstractIntlMessages from './AbstractIntlMessages.tsx';
-import type {Locale} from './AppConfig.tsx';
-import type Formats from './Formats.tsx';
-import type {InitializedIntlConfig} from './IntlConfig.tsx';
-import IntlError from './IntlError.tsx';
-import IntlErrorCode from './IntlErrorCode.tsx';
-import type {MessageKeys, NestedKeyOf, NestedValueOf} from './MessageKeys.tsx';
+import type AbstractIntlMessages from './AbstractIntlMessages.js';
+import type {Locale} from './AppConfig.js';
+import type Formats from './Formats.js';
+import type {InitializedIntlConfig} from './IntlConfig.js';
+import IntlError from './IntlError.js';
+import IntlErrorCode from './IntlErrorCode.js';
+import type {MessageKeys, NestedKeyOf, NestedValueOf} from './MessageKeys.js';
 import type {
   MarkupTranslationValues,
   RichTranslationValues,
   TranslationValues
-} from './TranslationValues.tsx';
-import convertFormatsToIntlMessageFormat from './convertFormatsToIntlMessageFormat.tsx';
-import {defaultGetMessageFallback, defaultOnError} from './defaults.tsx';
+} from './TranslationValues.js';
+import convertFormatsToIntlMessageFormat from './convertFormatsToIntlMessageFormat.js';
+import {defaultGetMessageFallback, defaultOnError} from './defaults.js';
 import {
   type Formatters,
   type IntlCache,
   type IntlFormatters,
   type MessageFormatter,
   memoFn
-} from './formatters.tsx';
-import joinPath from './joinPath.tsx';
+} from './formatters.js';
+import joinPath from './joinPath.js';
 
 // Placed here for improved tree shaking. Somehow when this is placed in
 // `formatters.tsx`, then it can't be shaken off from `next-intl`.

--- a/packages/use-intl/src/core/createFormatter.test.tsx
+++ b/packages/use-intl/src/core/createFormatter.test.tsx
@@ -1,6 +1,6 @@
 import {parseISO} from 'date-fns';
 import {describe, expect, it} from 'vitest';
-import createFormatter from './createFormatter.tsx';
+import createFormatter from './createFormatter.js';
 
 describe('dateTime', () => {
   it('formats a date and time', () => {

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -1,19 +1,19 @@
 import type {ReactElement} from 'react';
-import type {FormatNames, Locale} from './AppConfig.tsx';
-import type DateTimeFormatOptions from './DateTimeFormatOptions.tsx';
-import type Formats from './Formats.tsx';
-import IntlError from './IntlError.tsx';
-import IntlErrorCode from './IntlErrorCode.tsx';
-import type NumberFormatOptions from './NumberFormatOptions.tsx';
-import type RelativeTimeFormatOptions from './RelativeTimeFormatOptions.tsx';
-import type TimeZone from './TimeZone.tsx';
-import {defaultOnError} from './defaults.tsx';
+import type {FormatNames, Locale} from './AppConfig.js';
+import type DateTimeFormatOptions from './DateTimeFormatOptions.js';
+import type Formats from './Formats.js';
+import IntlError from './IntlError.js';
+import IntlErrorCode from './IntlErrorCode.js';
+import type NumberFormatOptions from './NumberFormatOptions.js';
+import type RelativeTimeFormatOptions from './RelativeTimeFormatOptions.js';
+import type TimeZone from './TimeZone.js';
+import {defaultOnError} from './defaults.js';
 import {
   type Formatters,
   type IntlCache,
   createCache,
   createIntlFormatters
-} from './formatters.tsx';
+} from './formatters.js';
 
 const SECOND = 1;
 const MINUTE = SECOND * 60;

--- a/packages/use-intl/src/core/createTranslator.test.tsx
+++ b/packages/use-intl/src/core/createTranslator.test.tsx
@@ -1,10 +1,10 @@
 import {isValidElement} from 'react';
 import {renderToString} from 'react-dom/server';
 import {describe, expect, it, vi} from 'vitest';
-import type {Messages} from './AppConfig.tsx';
-import type IntlError from './IntlError.tsx';
-import IntlErrorCode from './IntlErrorCode.tsx';
-import createTranslator from './createTranslator.tsx';
+import type {Messages} from './AppConfig.js';
+import type IntlError from './IntlError.js';
+import IntlErrorCode from './IntlErrorCode.js';
+import createTranslator from './createTranslator.js';
 
 const messages = {
   Home: {

--- a/packages/use-intl/src/core/createTranslator.tsx
+++ b/packages/use-intl/src/core/createTranslator.tsx
@@ -1,28 +1,28 @@
 import type {ReactNode} from 'react';
-import type Formats from './Formats.tsx';
-import type ICUArgs from './ICUArgs.tsx';
-import type ICUTags from './ICUTags.tsx';
-import type IntlConfig from './IntlConfig.tsx';
+import type Formats from './Formats.js';
+import type ICUArgs from './ICUArgs.js';
+import type ICUTags from './ICUTags.js';
+import type IntlConfig from './IntlConfig.js';
 import type {
   MessageKeys,
   NamespaceKeys,
   NestedKeyOf,
   NestedValueOf
-} from './MessageKeys.tsx';
+} from './MessageKeys.js';
 import type {
   MarkupTagsFunction,
   RichTagsFunction,
   TranslationValues
-} from './TranslationValues.tsx';
-import createTranslatorImpl from './createTranslatorImpl.tsx';
-import {defaultGetMessageFallback, defaultOnError} from './defaults.tsx';
+} from './TranslationValues.js';
+import createTranslatorImpl from './createTranslatorImpl.js';
+import {defaultGetMessageFallback, defaultOnError} from './defaults.js';
 import {
   type Formatters,
   type IntlCache,
   createCache,
   createIntlFormatters
-} from './formatters.tsx';
-import type {Prettify} from './types.tsx';
+} from './formatters.js';
+import type {Prettify} from './types.js';
 
 type ICUArgsWithTags<
   MessageString extends string,

--- a/packages/use-intl/src/core/createTranslatorImpl.tsx
+++ b/packages/use-intl/src/core/createTranslatorImpl.tsx
@@ -1,9 +1,9 @@
-import type AbstractIntlMessages from './AbstractIntlMessages.tsx';
-import type {InitializedIntlConfig} from './IntlConfig.tsx';
-import type {NestedKeyOf} from './MessageKeys.tsx';
-import createBaseTranslator from './createBaseTranslator.tsx';
-import type {Formatters, IntlCache} from './formatters.tsx';
-import resolveNamespace from './resolveNamespace.tsx';
+import type AbstractIntlMessages from './AbstractIntlMessages.js';
+import type {InitializedIntlConfig} from './IntlConfig.js';
+import type {NestedKeyOf} from './MessageKeys.js';
+import createBaseTranslator from './createBaseTranslator.js';
+import type {Formatters, IntlCache} from './formatters.js';
+import resolveNamespace from './resolveNamespace.js';
 
 export type CreateTranslatorImplProps<Messages> = Omit<
   InitializedIntlConfig,

--- a/packages/use-intl/src/core/defaults.tsx
+++ b/packages/use-intl/src/core/defaults.tsx
@@ -1,5 +1,5 @@
-import type IntlError from './IntlError.tsx';
-import joinPath from './joinPath.tsx';
+import type IntlError from './IntlError.js';
+import joinPath from './joinPath.js';
 
 /**
  * Contains defaults that are used for all entry points into the core.

--- a/packages/use-intl/src/core/hasLocale.test.tsx
+++ b/packages/use-intl/src/core/hasLocale.test.tsx
@@ -1,5 +1,5 @@
 import {expect, it} from 'vitest';
-import hasLocale from './hasLocale.tsx';
+import hasLocale from './hasLocale.js';
 
 it('narrows down the type', () => {
   const locales = ['en-US', 'en-GB'] as const;

--- a/packages/use-intl/src/core/hasLocale.tsx
+++ b/packages/use-intl/src/core/hasLocale.tsx
@@ -1,4 +1,4 @@
-import type {Locale} from './AppConfig.tsx';
+import type {Locale} from './AppConfig.js';
 
 /**
  * Checks if a locale exists in a list of locales.

--- a/packages/use-intl/src/core/index.tsx
+++ b/packages/use-intl/src/core/index.tsx
@@ -1,31 +1,31 @@
-export type {default as AbstractIntlMessages} from './AbstractIntlMessages.tsx';
+export type {default as AbstractIntlMessages} from './AbstractIntlMessages.js';
 export type {
   TranslationValues,
   RichTranslationValues,
   MarkupTranslationValues,
   RichTagsFunction,
   MarkupTagsFunction
-} from './TranslationValues.tsx';
-export type {default as Formats} from './Formats.tsx';
-export type {default as IntlConfig} from './IntlConfig.tsx';
-export type {default as DateTimeFormatOptions} from './DateTimeFormatOptions.tsx';
-export type {default as NumberFormatOptions} from './NumberFormatOptions.tsx';
-export {default as IntlError} from './IntlError.tsx';
-export {default as IntlErrorCode} from './IntlErrorCode.tsx';
-export {default as createTranslator} from './createTranslator.tsx';
-export {default as createFormatter} from './createFormatter.tsx';
-export {default as initializeConfig} from './initializeConfig.tsx';
+} from './TranslationValues.js';
+export type {default as Formats} from './Formats.js';
+export type {default as IntlConfig} from './IntlConfig.js';
+export type {default as DateTimeFormatOptions} from './DateTimeFormatOptions.js';
+export type {default as NumberFormatOptions} from './NumberFormatOptions.js';
+export {default as IntlError} from './IntlError.js';
+export {default as IntlErrorCode} from './IntlErrorCode.js';
+export {default as createTranslator} from './createTranslator.js';
+export {default as createFormatter} from './createFormatter.js';
+export {default as initializeConfig} from './initializeConfig.js';
 export type {
   MessageKeys,
   NamespaceKeys,
   NestedKeyOf,
   NestedValueOf
-} from './MessageKeys.tsx';
-export {createIntlFormatters as _createIntlFormatters} from './formatters.tsx';
-export {createCache as _createCache} from './formatters.tsx';
-export type {default as AppConfig, Locale, Messages} from './AppConfig.tsx';
-export {default as hasLocale} from './hasLocale.tsx';
-export type {default as RelativeTimeFormatOptions} from './RelativeTimeFormatOptions.tsx';
-export type {default as Timezone} from './TimeZone.tsx';
-export type {default as ICUArgs} from './ICUArgs.tsx';
-export type {default as ICUTags} from './ICUTags.tsx';
+} from './MessageKeys.js';
+export {createIntlFormatters as _createIntlFormatters} from './formatters.js';
+export {createCache as _createCache} from './formatters.js';
+export type {default as AppConfig, Locale, Messages} from './AppConfig.js';
+export {default as hasLocale} from './hasLocale.js';
+export type {default as RelativeTimeFormatOptions} from './RelativeTimeFormatOptions.js';
+export type {default as Timezone} from './TimeZone.js';
+export type {default as ICUArgs} from './ICUArgs.js';
+export type {default as ICUTags} from './ICUTags.js';

--- a/packages/use-intl/src/core/initializeConfig.tsx
+++ b/packages/use-intl/src/core/initializeConfig.tsx
@@ -1,6 +1,6 @@
-import type IntlConfig from './IntlConfig.tsx';
-import {defaultGetMessageFallback, defaultOnError} from './defaults.tsx';
-import validateMessages from './validateMessages.tsx';
+import type IntlConfig from './IntlConfig.js';
+import {defaultGetMessageFallback, defaultOnError} from './defaults.js';
+import validateMessages from './validateMessages.js';
 
 /**
  * Enhances the incoming props with defaults.

--- a/packages/use-intl/src/core/validateMessages.tsx
+++ b/packages/use-intl/src/core/validateMessages.tsx
@@ -1,7 +1,7 @@
-import type AbstractIntlMessages from './AbstractIntlMessages.tsx';
-import IntlError from './IntlError.tsx';
-import IntlErrorCode from './IntlErrorCode.tsx';
-import joinPath from './joinPath.tsx';
+import type AbstractIntlMessages from './AbstractIntlMessages.js';
+import IntlError from './IntlError.js';
+import IntlErrorCode from './IntlErrorCode.js';
+import joinPath from './joinPath.js';
 
 function validateMessagesSegment(
   messages: AbstractIntlMessages,

--- a/packages/use-intl/src/index.tsx
+++ b/packages/use-intl/src/index.tsx
@@ -1,2 +1,2 @@
-export * from './core.tsx';
-export * from './react.tsx';
+export * from './core.js';
+export * from './react.js';

--- a/packages/use-intl/src/react.tsx
+++ b/packages/use-intl/src/react.tsx
@@ -1,1 +1,1 @@
-export * from './react/index.tsx';
+export * from './react/index.js';

--- a/packages/use-intl/src/react/IntlContext.tsx
+++ b/packages/use-intl/src/react/IntlContext.tsx
@@ -1,6 +1,6 @@
 import {createContext} from 'react';
-import type {InitializedIntlConfig} from '../core/IntlConfig.tsx';
-import type {Formatters, IntlCache} from '../core/formatters.tsx';
+import type {InitializedIntlConfig} from '../core/IntlConfig.js';
+import type {Formatters, IntlCache} from '../core/formatters.js';
 
 export type IntlContextValue = InitializedIntlConfig & {
   formatters: Formatters;

--- a/packages/use-intl/src/react/IntlProvider.test.tsx
+++ b/packages/use-intl/src/react/IntlProvider.test.tsx
@@ -1,9 +1,9 @@
 import {fireEvent, render, screen} from '@testing-library/react';
 import {memo, useState} from 'react';
 import {expect, it, vi} from 'vitest';
-import IntlProvider from './IntlProvider.tsx';
-import useNow from './useNow.tsx';
-import useTranslations from './useTranslations.tsx';
+import IntlProvider from './IntlProvider.js';
+import useNow from './useNow.js';
+import useTranslations from './useTranslations.js';
 
 it("doesn't re-render context consumers unnecessarily", () => {
   const messages = {StaticText: {hello: 'Hello!'}};

--- a/packages/use-intl/src/react/IntlProvider.tsx
+++ b/packages/use-intl/src/react/IntlProvider.tsx
@@ -1,12 +1,12 @@
 import {type ReactNode, useContext, useMemo} from 'react';
-import type IntlConfig from '../core/IntlConfig.tsx';
+import type IntlConfig from '../core/IntlConfig.js';
 import {
   type Formatters,
   createCache,
   createIntlFormatters
-} from '../core/formatters.tsx';
-import initializeConfig from '../core/initializeConfig.tsx';
-import IntlContext from './IntlContext.tsx';
+} from '../core/formatters.js';
+import initializeConfig from '../core/initializeConfig.js';
+import IntlContext from './IntlContext.js';
 
 type Props = IntlConfig & {
   children: ReactNode;

--- a/packages/use-intl/src/react/index.test.tsx
+++ b/packages/use-intl/src/react/index.test.tsx
@@ -1,11 +1,11 @@
 import {render, screen} from '@testing-library/react';
 import {parseISO} from 'date-fns';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import type {Locale} from '../core.tsx';
-import IntlProvider from './IntlProvider.tsx';
-import useFormatter from './useFormatter.tsx';
-import useNow from './useNow.tsx';
-import useTranslations from './useTranslations.tsx';
+import type {Locale} from '../core.js';
+import IntlProvider from './IntlProvider.js';
+import useFormatter from './useFormatter.js';
+import useNow from './useNow.js';
+import useTranslations from './useTranslations.js';
 
 describe('performance', () => {
   beforeEach(() => {

--- a/packages/use-intl/src/react/index.tsx
+++ b/packages/use-intl/src/react/index.tsx
@@ -1,7 +1,7 @@
-export {default as IntlProvider} from './IntlProvider.tsx';
-export {default as useTranslations} from './useTranslations.tsx';
-export {default as useLocale} from './useLocale.tsx';
-export {default as useNow} from './useNow.tsx';
-export {default as useTimeZone} from './useTimeZone.tsx';
-export {default as useMessages} from './useMessages.tsx';
-export {default as useFormatter} from './useFormatter.tsx';
+export {default as IntlProvider} from './IntlProvider.js';
+export {default as useTranslations} from './useTranslations.js';
+export {default as useLocale} from './useLocale.js';
+export {default as useNow} from './useNow.js';
+export {default as useTimeZone} from './useTimeZone.js';
+export {default as useMessages} from './useMessages.js';
+export {default as useFormatter} from './useFormatter.js';

--- a/packages/use-intl/src/react/useFormatter.test.tsx
+++ b/packages/use-intl/src/react/useFormatter.test.tsx
@@ -3,9 +3,9 @@ import {parseISO} from 'date-fns';
 import type {ComponentProps, ReactElement, ReactNode} from 'react';
 import {type SpyImpl, spyOn} from 'tinyspy';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {type IntlError, IntlErrorCode} from '../core.tsx';
-import IntlProvider from './IntlProvider.tsx';
-import useFormatter from './useFormatter.tsx';
+import {type IntlError, IntlErrorCode} from '../core.js';
+import IntlProvider from './IntlProvider.js';
+import useFormatter from './useFormatter.js';
 
 function MockProvider(
   props: Partial<ComponentProps<typeof IntlProvider>> & {children: ReactNode}

--- a/packages/use-intl/src/react/useFormatter.tsx
+++ b/packages/use-intl/src/react/useFormatter.tsx
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
-import createFormatter from '../core/createFormatter.tsx';
-import useIntlContext from './useIntlContext.tsx';
+import createFormatter from '../core/createFormatter.js';
+import useIntlContext from './useIntlContext.js';
 
 export default function useFormatter(): ReturnType<typeof createFormatter> {
   const {

--- a/packages/use-intl/src/react/useIntlContext.tsx
+++ b/packages/use-intl/src/react/useIntlContext.tsx
@@ -1,5 +1,5 @@
 import {useContext} from 'react';
-import IntlContext, {type IntlContextValue} from './IntlContext.tsx';
+import IntlContext, {type IntlContextValue} from './IntlContext.js';
 
 export default function useIntlContext(): IntlContextValue {
   const context = useContext(IntlContext);

--- a/packages/use-intl/src/react/useLocale.test.tsx
+++ b/packages/use-intl/src/react/useLocale.test.tsx
@@ -1,7 +1,7 @@
 import {render, screen} from '@testing-library/react';
 import {it} from 'vitest';
-import IntlProvider from './IntlProvider.tsx';
-import useLocale from './useLocale.tsx';
+import IntlProvider from './IntlProvider.js';
+import useLocale from './useLocale.js';
 
 it('returns the current locale', () => {
   function Component() {

--- a/packages/use-intl/src/react/useLocale.tsx
+++ b/packages/use-intl/src/react/useLocale.tsx
@@ -1,5 +1,5 @@
-import type {Locale} from '../core.tsx';
-import useIntlContext from './useIntlContext.tsx';
+import type {Locale} from '../core.js';
+import useIntlContext from './useIntlContext.js';
 
 export default function useLocale(): Locale {
   return useIntlContext().locale;

--- a/packages/use-intl/src/react/useMessages.test.tsx
+++ b/packages/use-intl/src/react/useMessages.test.tsx
@@ -1,7 +1,7 @@
 import {render, screen} from '@testing-library/react';
 import {expect, it} from 'vitest';
-import IntlProvider from './IntlProvider.tsx';
-import useMessages from './useMessages.tsx';
+import IntlProvider from './IntlProvider.js';
+import useMessages from './useMessages.js';
 
 function Component() {
   const messages = useMessages();

--- a/packages/use-intl/src/react/useMessages.tsx
+++ b/packages/use-intl/src/react/useMessages.tsx
@@ -1,5 +1,5 @@
-import type {Messages} from '../core/AppConfig.tsx';
-import useIntlContext from './useIntlContext.tsx';
+import type {Messages} from '../core/AppConfig.js';
+import useIntlContext from './useIntlContext.js';
 
 export default function useMessages(): Messages {
   const context = useIntlContext();

--- a/packages/use-intl/src/react/useNow.test.tsx
+++ b/packages/use-intl/src/react/useNow.test.tsx
@@ -1,8 +1,8 @@
 import {render, waitFor} from '@testing-library/react';
 import {parseISO} from 'date-fns';
 import {expect, it} from 'vitest';
-import IntlProvider from './IntlProvider.tsx';
-import useNow from './useNow.tsx';
+import IntlProvider from './IntlProvider.js';
+import useNow from './useNow.js';
 
 it('returns the current time', () => {
   function Component() {

--- a/packages/use-intl/src/react/useNow.tsx
+++ b/packages/use-intl/src/react/useNow.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useState} from 'react';
-import useIntlContext from './useIntlContext.tsx';
+import useIntlContext from './useIntlContext.js';
 
 type Options = {
   updateInterval?: number;

--- a/packages/use-intl/src/react/useTimeZone.test.tsx
+++ b/packages/use-intl/src/react/useTimeZone.test.tsx
@@ -1,7 +1,7 @@
 import {render, screen} from '@testing-library/react';
 import {expect, it} from 'vitest';
-import IntlProvider from './IntlProvider.tsx';
-import useTimeZone from './useTimeZone.tsx';
+import IntlProvider from './IntlProvider.js';
+import useTimeZone from './useTimeZone.js';
 
 it('returns the time zone when it is configured', () => {
   function Component() {

--- a/packages/use-intl/src/react/useTimeZone.tsx
+++ b/packages/use-intl/src/react/useTimeZone.tsx
@@ -1,4 +1,4 @@
-import useIntlContext from './useIntlContext.tsx';
+import useIntlContext from './useIntlContext.js';
 
 export default function useTimeZone() {
   return useIntlContext().timeZone;

--- a/packages/use-intl/src/react/useTranslations.test.tsx
+++ b/packages/use-intl/src/react/useTranslations.test.tsx
@@ -9,9 +9,9 @@ import {
   IntlErrorCode,
   type RichTranslationValues,
   type TranslationValues
-} from '../core.tsx';
-import IntlProvider from './IntlProvider.tsx';
-import useTranslations from './useTranslations.tsx';
+} from '../core.js';
+import IntlProvider from './IntlProvider.js';
+import useTranslations from './useTranslations.js';
 
 // Wrap the library to include a counter for parse
 // invocations for the cache test below.

--- a/packages/use-intl/src/react/useTranslations.tsx
+++ b/packages/use-intl/src/react/useTranslations.tsx
@@ -1,8 +1,8 @@
-import type {Messages} from '../core/AppConfig.tsx';
-import type {NamespaceKeys, NestedKeyOf} from '../core/MessageKeys.tsx';
-import type createTranslator from '../core/createTranslator.tsx';
-import useIntlContext from './useIntlContext.tsx';
-import useTranslationsImpl from './useTranslationsImpl.tsx';
+import type {Messages} from '../core/AppConfig.js';
+import type {NamespaceKeys, NestedKeyOf} from '../core/MessageKeys.js';
+import type createTranslator from '../core/createTranslator.js';
+import useIntlContext from './useIntlContext.js';
+import useTranslationsImpl from './useTranslationsImpl.js';
 
 /**
  * Translates messages from the given namespace by using the ICU syntax.

--- a/packages/use-intl/src/react/useTranslationsImpl.tsx
+++ b/packages/use-intl/src/react/useTranslationsImpl.tsx
@@ -1,10 +1,10 @@
 import {useMemo} from 'react';
-import type AbstractIntlMessages from '../core/AbstractIntlMessages.tsx';
-import type {NestedKeyOf} from '../core/MessageKeys.tsx';
-import createBaseTranslator from '../core/createBaseTranslator.tsx';
-import resolveNamespace from '../core/resolveNamespace.tsx';
-import {IntlError, IntlErrorCode} from '../core.tsx';
-import useIntlContext from './useIntlContext.tsx';
+import type AbstractIntlMessages from '../core/AbstractIntlMessages.js';
+import type {NestedKeyOf} from '../core/MessageKeys.js';
+import createBaseTranslator from '../core/createBaseTranslator.js';
+import resolveNamespace from '../core/resolveNamespace.js';
+import {IntlError, IntlErrorCode} from '../core.js';
+import useIntlContext from './useIntlContext.js';
 
 let hasWarnedForMissingTimezone = false;
 const isServer = typeof window === 'undefined';

--- a/packages/use-intl/tsconfig.json
+++ b/packages/use-intl/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "eslint-config-molindo/tsconfig.json",
   "include": ["src", "test", "types"],
   "compilerOptions": {
-    "allowImportingTsExtensions": true, // For ESM
     "lib": ["dom", "esnext"],
     "target": "ES2020",
     "declaration": true,


### PR DESCRIPTION
@amannn Following our conversation on X, these are the changes that I've made that appear to be fixing the imports when the `import/named` ESLint rule is used. 

As mentioned before, I also took the liberty of adding the ESLint rule `'import/extensions': 'error'` to ensure the right extensions are used in the import/export statements. For context, when compiling to ESM modules, TS copies over the import/export statements as-is, so during development, runtime compatible file extensions must be used.

For local testing I ran a build and then manually copied over the `dist` folder into `node_modules/next-intl` in my other project.