### PR TITLE
feat: Allow to override options of global formats

### DIFF
--- a/docs/src/pages/docs/usage/dates-times.mdx
+++ b/docs/src/pages/docs/usage/dates-times.mdx
@@ -34,7 +34,11 @@ See [the MDN docs about `DateTimeFormat`](https://developer.mozilla.org/en-US/do
 If you have [global formats](/docs/usage/configuration#formats) configured, you can reference them by passing a name as the second argument:
 
 ```js
+// Use a global format
 format.dateTime(dateTime, 'short');
+
+// Optionally override some options
+format.dateTime(dateTime, 'short', {year: 'numeric'});
 ```
 
 <Details id="parsing-manipulation">
@@ -204,10 +208,14 @@ function Component() {
 }
 ```
 
-If you have [global formats](/docs/usage/configuration#formats) configured, you can reference them by passing a name as the trailing argument:
+If you have [global formats](/docs/usage/configuration#formats) configured, you can reference them by passing a name as the third argument:
 
 ```js
+// Use a global format
 format.dateTimeRange(dateTimeA, dateTimeB, 'short');
+
+// Optionally override some options
+format.dateTimeRange(dateTimeA, dateTimeB, 'short', {year: 'numeric'});
 ```
 
 ## Dates and times within messages

--- a/docs/src/pages/docs/usage/numbers.mdx
+++ b/docs/src/pages/docs/usage/numbers.mdx
@@ -31,7 +31,11 @@ See [the MDN docs about `NumberFormat`](https://developer.mozilla.org/en-US/docs
 If you have [global formats](/docs/usage/configuration#formats) configured, you can reference them by passing a name as the second argument:
 
 ```js
+// Use a global format
 format.number(499.9, 'precise');
+
+// Optionally override some options
+format.number(499.9, 'price', {currency: 'USD'});
 ```
 
 ## Numbers within messages

--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -4,7 +4,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-client)",
     path: 'dist/esm/production/index.react-client.js',
-    limit: '13.065 KB'
+    limit: '13.125 KB'
   },
   {
     name: "import {NextIntlClientProvider} from 'next-intl' (react-client)",

--- a/packages/use-intl/.size-limit.ts
+++ b/packages/use-intl/.size-limit.ts
@@ -5,14 +5,14 @@ const config: SizeLimitConfig = [
     name: "import * from 'use-intl' (production)",
     import: '*',
     path: 'dist/esm/production/index.js',
-    limit: '12.955 kB'
+    limit: '13.015 kB'
   },
   {
     name: "import {IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter} from 'use-intl' (production)",
     path: 'dist/esm/production/index.js',
     import:
       '{IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter}',
-    limit: '1.995 kB'
+    limit: '2.005 kB'
   }
 ];
 

--- a/packages/use-intl/src/core/createFormatter.test.tsx
+++ b/packages/use-intl/src/core/createFormatter.test.tsx
@@ -28,6 +28,26 @@ describe('dateTime', () => {
       })
     ).toBe('Nov 20, 2020, 5:36:01 AM');
   });
+
+  it('can combine a global format with an override', () => {
+    const formatter = createFormatter({
+      locale: 'en',
+      timeZone: 'Europe/Berlin',
+      formats: {
+        dateTime: {
+          short: {
+            dateStyle: 'short',
+            timeStyle: 'short'
+          }
+        }
+      }
+    });
+    expect(
+      formatter.dateTime(parseISO('2020-11-20T10:36:01.516Z'), 'short', {
+        timeZone: 'America/New_York'
+      })
+    ).toBe('11/20/20, 5:36 AM');
+  });
 });
 
 describe('number', () => {
@@ -70,6 +90,25 @@ describe('number', () => {
         currency: 'USD'
       })
     ).toBe('$123,456,789,123,456,789.00');
+  });
+
+  it('can combine a global format with an override', () => {
+    const formatter = createFormatter({
+      locale: 'en',
+      timeZone: 'Europe/Berlin',
+      formats: {
+        number: {
+          price: {
+            style: 'currency',
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+          }
+        }
+      }
+    });
+    expect(formatter.number(123456.789, 'price', {currency: 'EUR'})).toBe(
+      '€123,456.79'
+    );
   });
 });
 
@@ -349,6 +388,31 @@ describe('dateTimeRange', () => {
       )
     ).toBe('Jan 10, 2007, 4:00:00 AM – Jan 10, 2008, 5:00:00 AM');
   });
+
+  it('can combine a global format with an override', () => {
+    const formatter = createFormatter({
+      locale: 'en',
+      timeZone: 'Europe/Berlin',
+      formats: {
+        dateTime: {
+          short: {
+            dateStyle: 'short',
+            timeStyle: 'short'
+          }
+        }
+      }
+    });
+    expect(
+      formatter.dateTimeRange(
+        new Date(2007, 0, 10, 10, 0, 0),
+        new Date(2008, 0, 10, 11, 0, 0),
+        'short',
+        {
+          timeZone: 'America/New_York'
+        }
+      )
+    ).toBe('1/10/07, 4:00 AM – 1/10/08, 5:00 AM');
+  });
 });
 
 describe('list', () => {
@@ -372,5 +436,23 @@ describe('list', () => {
         type: 'disjunction'
       })
     ).toBe('apple, banana, or orange');
+  });
+
+  it('can combine a global format with an override', () => {
+    const formatter = createFormatter({
+      locale: 'en',
+      formats: {
+        list: {
+          short: {
+            type: 'disjunction'
+          }
+        }
+      }
+    });
+    expect(
+      formatter.list(['apple', 'banana', 'orange'], 'short', {
+        type: 'conjunction'
+      })
+    ).toBe('apple, banana, and orange');
   });
 });

--- a/packages/use-intl/src/react/useFormatter.test.tsx
+++ b/packages/use-intl/src/react/useFormatter.test.tsx
@@ -3,7 +3,12 @@ import {parseISO} from 'date-fns';
 import type {ComponentProps, ReactElement, ReactNode} from 'react';
 import {type SpyImpl, spyOn} from 'tinyspy';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {type IntlError, IntlErrorCode} from '../core.js';
+import {
+  type DateTimeFormatOptions,
+  type IntlError,
+  IntlErrorCode,
+  type NumberFormatOptions
+} from '../core.js';
 import IntlProvider from './IntlProvider.js';
 import useFormatter from './useFormatter.js';
 
@@ -25,7 +30,7 @@ describe('dateTime', () => {
 
   function renderDateTime(
     value: Date | number,
-    options?: Parameters<ReturnType<typeof useFormatter>['dateTime']>['1']
+    options?: DateTimeFormatOptions
   ) {
     function Component() {
       const format = useFormatter();
@@ -287,10 +292,7 @@ describe('dateTime', () => {
 });
 
 describe('number', () => {
-  function renderNumber(
-    value: number | bigint,
-    options?: Parameters<ReturnType<typeof useFormatter>['number']>['1']
-  ) {
+  function renderNumber(value: number | bigint, options?: NumberFormatOptions) {
     function Component() {
       const format = useFormatter();
       return <>{format.number(value, options)}</>;
@@ -629,7 +631,7 @@ describe('relativeTime', () => {
 describe('list', () => {
   function renderList(
     value: Iterable<string>,
-    options?: Parameters<ReturnType<typeof useFormatter>['list']>['1']
+    options?: Intl.ListFormatOptions
   ) {
     function Component() {
       const format = useFormatter();


### PR DESCRIPTION
**Example:**

```tsx
formatter.dateTime(date, 'short', {
  timeZone: 'America/New_York'
})
```

