### PR TITLE
docs: Fix sitemap example

### DIFF
--- a/docs/src/pages/docs/environments/actions-metadata-route-handlers.mdx
+++ b/docs/src/pages/docs/environments/actions-metadata-route-handlers.mdx
@@ -169,7 +169,7 @@ If you're using a sitemap to inform search engines about all pages of your site,
 
 Note that by default, `next-intl` returns [the `link` response header](/docs/routing#alternate-links) to instruct search engines that a page is available in multiple languages. While this sufficiently links localized pages for search engines, you may choose to provide this information in a sitemap in case you have more specific requirements.
 
-Next.js supports providing alternate URLs per language via the [`alternates` entry](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap#generate-a-localized-sitemap) as of version 14.2. You can use your default locale for the main URL and provide alternate URLs based on all locales that your app supports. Keep in mind that also the default locale should be included in the `alternates` object.
+Next.js supports providing alternate URLs per language via the [`alternates` entry](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap#generate-a-localized-sitemap). You can construct a list of entries for each pathname and locale as follows:
 
 ```tsx filename="app/sitemap.ts" {4-5,8-9}
 import {MetadataRoute} from 'next';
@@ -180,20 +180,20 @@ const host = 'https://acme.com';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   // Adapt this as necessary
-  return [getEntry('/'), getEntry('/users')];
+  return [...getEntries('/'), ...getEntries('/users')];
 }
 
 type Href = Parameters<typeof getPathname>[0]['href'];
 
-function getEntry(href: Href) {
-  return {
-    url: getUrl(href, routing.defaultLocale),
+function getEntries(href: Href) {
+  return routing.locales.map((locale) => ({
+    url: getUrl(href, locale),
     alternates: {
       languages: Object.fromEntries(
-        routing.locales.map((locale) => [locale, getUrl(href, locale)])
+        routing.locales.map((cur) => [cur, getUrl(href, cur)])
       )
     }
-  };
+  }));
 }
 
 function getUrl(href: Href, locale: (typeof routing.locales)[number]) {
@@ -206,14 +206,19 @@ Depending on if you're using the [`pathnames`](/docs/routing#pathnames) setting,
 
 ```tsx
 // 1. A final string (when not using `pathnames`)
-getEntry('/users/1');
+getEntries('/users/1');
 
 // 2. An object (when using `pathnames`)
-getEntry({
+getEntries({
   pathname: '/users/[id]',
   params: {id: '1'}
 });
 ```
+
+**Keep in mind**:
+
+- Each pathname should have a separate entry for every locale that your app supports.
+- Also the locale of a given pathname should be included in the `alternates` object.
 
 ([working implementation](https://github.com/amannn/next-intl/blob/main/examples/example-app-router/src/app/sitemap.ts))
 

--- a/examples/example-app-router/src/app/sitemap.ts
+++ b/examples/example-app-router/src/app/sitemap.ts
@@ -3,20 +3,20 @@ import {host} from '@/config';
 import {Locale, getPathname, routing} from '@/i18n/routing';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [getEntry('/'), getEntry('/pathnames')];
+  return [...getEntries('/'), ...getEntries('/pathnames')];
 }
 
 type Href = Parameters<typeof getPathname>[0]['href'];
 
-function getEntry(href: Href) {
-  return {
-    url: getUrl(href, routing.defaultLocale),
+function getEntries(href: Href) {
+  return routing.locales.map((locale) => ({
+    url: getUrl(href, locale),
     alternates: {
       languages: Object.fromEntries(
-        routing.locales.map((locale) => [locale, getUrl(href, locale)])
+        routing.locales.map((cur) => [cur, getUrl(href, cur)])
       )
     }
-  };
+  }));
 }
 
 function getUrl(href: Href, locale: Locale) {

--- a/examples/example-app-router/tests/main.spec.ts
+++ b/examples/example-app-router/tests/main.spec.ts
@@ -1,4 +1,4 @@
-import {test as it, expect} from '@playwright/test';
+import {expect, test as it} from '@playwright/test';
 
 it('handles i18n routing', async ({page}) => {
   await page.goto('/');
@@ -111,7 +111,17 @@ it('serves a sitemap.xml', async ({page}) => {
 <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de" />
 </url>
 <url>
+<loc>http://localhost:3000/de</loc>
+<xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/en" />
+<xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de" />
+</url>
+<url>
 <loc>http://localhost:3000/en/pathnames</loc>
+<xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/en/pathnames" />
+<xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/pfadnamen" />
+</url>
+<url>
+<loc>http://localhost:3000/de/pfadnamen</loc>
 <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/en/pathnames" />
 <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/pfadnamen" />
 </url>


### PR DESCRIPTION
[(ref)](https://github.com/amannn/next-intl/discussions/629#discussioncomment-12136289)

As a side note, it seems like currently all pages of the example are indexed correctly:

![Screenshot 2025-02-13 at 09 54 35](https://github.com/user-attachments/assets/0cfdc805-2c93-4ce0-bd1e-506990ae25c8)

Let's check this again after some time to verify this is still the case.