### PR TITLE
docs: Fix typo with closing tag

### DIFF
--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -190,7 +190,7 @@ export default async function RootLayout({children}) {
           messages={messages}
         >
           {children}
-        </NextIntlClientProvider>
+        </IntlProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
Update doc to fix the closing tag.