### PR TITLE
fix!: Return `x-default` alternate link also for sub pages when using `localePrefix: 'always'` and update middleware matcher suggestion in docs

### DIFF
--- a/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
+++ b/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
@@ -61,7 +61,7 @@ The simplest option is to add JSON files in your local project folder:
 
 ### `next.config.mjs` [#next-config]
 
-Now, set up the plugin which creates an alias to provide a request-specific i18n configuration to Server Components—more on this in the following steps.
+Now, set up the plugin which creates an alias to provide a request-specific i18n configuration like your messages to Server Components—more on this in the following steps.
 
 <Tabs items={['next.config.mjs', 'next.config.js']}>
 <Tabs.Tab>
@@ -117,8 +117,8 @@ export const routing = defineRouting({
   defaultLocale: 'en'
 });
 
-// Lightweight wrappers around Next.js' navigation APIs
-// that will consider the routing configuration
+// Lightweight wrappers around Next.js' navigation
+// APIs that consider the routing configuration
 export const {Link, redirect, usePathname, useRouter, getPathname} =
   createNavigation(routing);
 ```
@@ -136,10 +136,37 @@ import {routing} from './i18n/routing';
 export default createMiddleware(routing);
 
 export const config = {
-  // Match only internationalized pathnames
-  matcher: ['/', '/(de|en)/:path*']
+  // Match all pathnames except for
+  // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
+  // - … the ones containing a dot (e.g. `favicon.ico`)
+  matcher: '/((?!api|trpc|_next|_vercel|.*\\..*).*)'
 };
 ```
+
+<Details id="middleware-matcher-dots">
+  <summary>How can I match pathnames that contain dots like `/users/jane.doe`?</summary>
+
+If you have pathnames where dots are expected, you can match them with explicit entries:
+
+```tsx filename="src/middleware.ts" {10,11}
+// ...
+
+export const config = {
+  matcher: [
+    // Match all pathnames except for
+    // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
+    // - … the ones containing a dot (e.g. `favicon.ico`)
+    '/((?!api|trpc|_next|_vercel|.*\\..*).*)'
+
+    // Match all pathnames within `{/:locale}/users`
+    '/([\\w-]+)?/users/(.+)'
+  ];
+}
+```
+
+This will match e.g. `/users/jane.doe`, also optionally with a locale prefix.
+
+</Details>
 
 ### `src/i18n/request.ts` [#i18n-request]
 

--- a/docs/src/pages/docs/routing.mdx
+++ b/docs/src/pages/docs/routing.mdx
@@ -63,13 +63,6 @@ export const routing = defineRouting({
 });
 ```
 
-<Details id="redirect-unprefixed-pathnames">
-<summary>How can I redirect unprefixed pathnames?</summary>
-
-If you want to redirect unprefixed pathnames like `/about` to a prefixed alternative like `/en/about`, you can adjust your middleware matcher to [match unprefixed pathnames](/docs/routing/middleware#matcher-no-prefix) too.
-
-</Details>
-
 #### Don't use a locale prefix for the default locale [#locale-prefix-as-needed]
 
 If you want to use no prefix for the default locale (e.g. `/about`), you can configure your routing accordingly:
@@ -83,9 +76,10 @@ export const routing = defineRouting({
 });
 ```
 
-**Important**: For this routing strategy to work as expected, you should additionally adapt your middleware matcher to detect [unprefixed pathnames](/docs/routing/middleware#matcher-no-prefix).
+**Note that:**
 
-Note that if a superfluous locale prefix like `/en/about` is requested, the middleware will automatically redirect to the unprefixed version `/about`. This can be helpful in case you're redirecting from another locale and you want to update a potential cookie value first (e.g. [`<Link />`](/docs/routing/navigation#link) relies on this mechanism).
+1. If you use this routing strategy, make sure that your [middleware matcher](/docs/routing/middleware#matcher-config) detects unprefixed pathnames.
+2. If a superfluous locale prefix like `/en/about` is requested, the middleware will automatically redirect to the unprefixed version `/about`. This can be helpful in case you're redirecting from another locale and you want to update a potential cookie value first (e.g. [`<Link />`](/docs/routing/navigation#link) relies on this mechanism).
 
 #### Never use a locale prefix [#locale-prefix-never]
 
@@ -109,7 +103,7 @@ In this case, requests for all locales will be rewritten to have the locale only
 
 **Note that:**
 
-1. If you use this strategy, you should adapt your matcher to detect [unprefixed pathnames](/docs/routing/middleware#matcher-no-prefix).
+1. If you use this routing strategy, make sure that your [middleware matcher](/docs/routing/middleware#matcher-config) detects unprefixed pathnames.
 2. [Alternate links](#alternate-links) are disabled in this mode since URLs might not be unique per locale. Due to this, consider including these yourself, or set up a [sitemap](/docs/environments/actions-metadata-route-handlers#sitemap) that links localized pages via `alternates`.
 3. You can consider increasing the [`maxAge`](#locale-cookie) attribute of the locale cookie to a longer duration to remember the user's preference across sessions.
 
@@ -561,12 +555,7 @@ link: <https://example.com/en>; rel="alternate"; hreflang="en",
 
 The [`x-default`](https://developers.google.com/search/docs/specialty/international/localized-versions#xdefault) entry is included to point to a variant that can be used if no other language matches the user's browser setting. This special entry is reserved for language selection & detection, in our case issuing a 307 redirect to the best matching locale.
 
-Note that middleware configuration is automatically incorporated with the following special cases:
-
-1. **`localePrefix: 'always'` (default)**: The `x-default` entry is only included for `/`, not for nested pathnames like `/about`. The reason is that the default [matcher](#matcher-config) doesn't handle unprefixed pathnames apart from `/`, therefore these URLs could be 404s. Note that this only applies to the optional `x-default` entry, locale-specific URLs are always included.
-2. **`localePrefix: 'never'`**: Alternate links are entirely turned off since there might not be unique URLs per locale.
-
-Other configuration options like `domains`, `pathnames` and `basePath` are automatically considered.
+Your middleware configuration, including options like `domains`, `pathnames` and `basePath`, is automatically incorporated.
 
 </Details>
 

--- a/docs/src/pages/docs/routing/middleware.mdx
+++ b/docs/src/pages/docs/routing/middleware.mdx
@@ -23,8 +23,10 @@ import {routing} from './i18n/routing';
 export default createMiddleware(routing);
 
 export const config = {
-  // Match only internationalized pathnames
-  matcher: ['/', '/(de|en)/:path*']
+  // Match all pathnames except for
+  // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
+  // - … the ones containing a dot (e.g. `favicon.ico`)
+  matcher: '/((?!api|trpc|_next|_vercel|.*\\..*).*)'
 };
 ```
 
@@ -106,58 +108,6 @@ The bestmatching domain is detected based on these priorities:
 
 The middleware is intended to only run on pages, not on arbitrary files that you serve independently of the user locale (e.g. `/favicon.ico`).
 
-Because of this, the following config is generally recommended:
-
-```tsx filename="middleware.ts"
-export const config = {
-  // Match only internationalized pathnames
-  matcher: ['/', '/(de|en)/:path*']
-};
-```
-
-This enables:
-
-1. A redirect at `/` to a suitable locale
-2. Internationalization of all pathnames starting with a locale (e.g. `/en/about`)
-
-<Details id="matcher-avoid-hardcoding">
-<summary>Can I avoid hardcoding the locales in the `matcher` config?</summary>
-
-A [Next.js `matcher`](https://nextjs.org/docs/app/building-your-application/routing/middleware#matcher) needs to be statically analyzable, therefore you can't use variables to generate this value. However, you can alternatively implement a programmatic condition in the middleware:
-
-```tsx filename="middleware.ts"
-import {NextRequest} from 'next/server';
-import createMiddleware from 'next-intl/middleware';
-import {routing} from './i18n/routing';
-
-const handleI18nRouting = createMiddleware(routing);
-
-export default function middleware(request: NextRequest) {
-  const {pathname} = request.nextUrl;
-
-  // Matches '/', as well as all paths that start with a locale like '/en'
-  const shouldHandle =
-    pathname === '/' ||
-    new RegExp(`^/(${locales.join('|')})(/.*)?$`).test(
-      request.nextUrl.pathname
-    );
-  if (!shouldHandle) return;
-
-  return handleI18nRouting(request);
-}
-```
-
-</Details>
-
-### Pathnames without a locale prefix [#matcher-no-prefix]
-
-There are two use cases where you might want to match pathnames without a locale prefix:
-
-1. You're using a config for [`localePrefix`](/docs/routing#locale-prefix) other than [`always`](/docs/routing#locale-prefix-always)
-2. You want to enable redirects that add a locale for unprefixed pathnames (e.g. `/about` → `/en/about`)
-
-For these cases, the middleware should run on requests for pathnames without a locale prefix as well.
-
 A popular strategy is to match all routes that don't start with certain segments (e.g. `/_next`) and also none that include a dot (`.`) since these typically indicate static files. However, if you have some routes where a dot is expected (e.g. `/users/jane.doe`), you should explicitly provide a matcher for these.
 
 ```tsx filename="middleware.ts"
@@ -169,6 +119,7 @@ export const config = {
     // - … if they start with `/api`, `/_next` or `/_vercel`
     // - … the ones containing a dot (e.g. `favicon.ico`)
     '/((?!api|_next|_vercel|.*\\..*).*)',
+
     // However, match all pathnames within `/users`, optionally with a locale prefix
     '/([\\w-]+)?/users/(.+)'
   ]

--- a/examples/example-app-router-migration/src/middleware.ts
+++ b/examples/example-app-router-migration/src/middleware.ts
@@ -4,6 +4,8 @@ import {routing} from './i18n/routing';
 export default createMiddleware(routing);
 
 export const config = {
-  // Skip all paths that should not be internationalized
-  matcher: ['/((?!api|_next|_vercel|.*\\..*).*)']
+  // Match all pathnames except for
+  // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
+  // - … the ones containing a dot (e.g. `favicon.ico`)
+  matcher: '/((?!api|trpc|_next|_vercel|.*\\..*).*)'
 };

--- a/examples/example-app-router-mixed-routing/src/middleware.ts
+++ b/examples/example-app-router-mixed-routing/src/middleware.ts
@@ -4,6 +4,8 @@ import {routing} from './i18n/routing.public';
 export default createMiddleware(routing);
 
 export const config = {
-  // Match only public pathnames
-  matcher: ['/', '/(de|en)/:path*']
+  // Match all pathnames except for
+  // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
+  // - … the ones containing a dot (e.g. `favicon.ico`)
+  matcher: '/((?!api|trpc|_next|_vercel|.*\\..*).*)'
 };

--- a/examples/example-app-router-mixed-routing/src/middleware.ts
+++ b/examples/example-app-router-mixed-routing/src/middleware.ts
@@ -5,7 +5,7 @@ export default createMiddleware(routing);
 
 export const config = {
   // Match all pathnames except for
-  // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
+  // - … if they start with `/app`, `/_next` or `/_vercel`
   // - … the ones containing a dot (e.g. `favicon.ico`)
-  matcher: '/((?!api|trpc|_next|_vercel|.*\\..*).*)'
+  matcher: '/((?!app|_next|_vercel|.*\\..*).*)'
 };

--- a/examples/example-app-router-mixed-routing/tests/main.spec.ts
+++ b/examples/example-app-router-mixed-routing/tests/main.spec.ts
@@ -1,4 +1,4 @@
-import {test as it, expect} from '@playwright/test';
+import {expect, test as it} from '@playwright/test';
 
 it('syncs the locale across the public and private pages', async ({page}) => {
   await page.goto('/');

--- a/examples/example-app-router-next-auth/src/middleware.ts
+++ b/examples/example-app-router-next-auth/src/middleware.ts
@@ -43,6 +43,8 @@ export default function middleware(req: NextRequest) {
 }
 
 export const config = {
-  // Skip all paths that should not be internationalized
-  matcher: ['/((?!api|_next|.*\\..*).*)']
+  // Match all pathnames except for
+  // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
+  // - … the ones containing a dot (e.g. `favicon.ico`)
+  matcher: ['/((?!api|trpc|_next|_vercel|.*\\..*).*)']
 };

--- a/examples/example-app-router/src/middleware.ts
+++ b/examples/example-app-router/src/middleware.ts
@@ -4,10 +4,8 @@ import {routing} from './i18n/routing';
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: [
-    // Match all pathnames except for
-    // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
-    // - … the ones containing a dot (e.g. `favicon.ico`)
-    '/((?!api|trpc|_next|_vercel|.*\\..*).*)'
-  ]
+  // Match all pathnames except for
+  // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
+  // - … the ones containing a dot (e.g. `favicon.ico`)
+  matcher: '/((?!api|trpc|_next|_vercel|.*\\..*).*)'
 };

--- a/examples/example-app-router/src/middleware.ts
+++ b/examples/example-app-router/src/middleware.ts
@@ -5,15 +5,10 @@ export default createMiddleware(routing);
 
 export const config = {
   matcher: [
-    // Enable a redirect to a matching locale at the root
-    '/',
-
-    // Set a cookie to remember the previous locale for
-    // all requests that have a locale prefix
-    '/(de|en)/:path*',
-
-    // Enable redirects that add missing locales
-    // (e.g. `/pathnames` -> `/en/pathnames`)
+    // Only match content pages by excluding:
+    // - Next.js internals at /_next
+    // - Vercel internals at /_vercel
+    // - Pathnames that look like static files
     '/((?!_next|_vercel|.*\\..*).*)'
   ]
 };

--- a/examples/example-app-router/src/middleware.ts
+++ b/examples/example-app-router/src/middleware.ts
@@ -5,10 +5,9 @@ export default createMiddleware(routing);
 
 export const config = {
   matcher: [
-    // Only match content pages by excluding:
-    // - Next.js internals at /_next
-    // - Vercel internals at /_vercel
-    // - Pathnames that look like static files
-    '/((?!_next|_vercel|.*\\..*).*)'
+    // Match all pathnames except for
+    // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
+    // - … the ones containing a dot (e.g. `favicon.ico`)
+    '/((?!api|trpc|_next|_vercel|.*\\..*).*)'
   ]
 };

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -184,7 +184,8 @@ describe.each([{basePath: undefined}, {basePath: '/base'}])(
         }).split(', ')
       ).toEqual([
         `<https://example.com${basePath}/en/about>; rel="alternate"; hreflang="en"`,
-        `<https://example.com${basePath}/es/about>; rel="alternate"; hreflang="es"`
+        `<https://example.com${basePath}/es/about>; rel="alternate"; hreflang="es"`,
+        `<https://example.com${basePath}/about>; rel="alternate"; hreflang="x-default"`
       ]);
     });
 

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.tsx
@@ -143,8 +143,7 @@ export default function getAlternateLinksHeaderValue<
   // Add x-default entry
   const shouldAddXDefault =
     // For domain-based routing there is no reasonable x-default
-    !routing.domains &&
-    (routing.localePrefix.mode !== 'always' || normalizedUrl.pathname === '/');
+    !routing.domains || routing.domains.length === 0;
   if (shouldAddXDefault) {
     const url = new URL(
       getLocalizedPathname(normalizedUrl.pathname, routing.defaultLocale),

--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -1400,35 +1400,42 @@ describe('prefix-based routing', () => {
         ]);
         expect(getLinks(createMockRequest('/en/about', 'en'))).toEqual([
           '<http://localhost:3000/en/about>; rel="alternate"; hreflang="en"',
-          '<http://localhost:3000/de/ueber>; rel="alternate"; hreflang="de"'
+          '<http://localhost:3000/de/ueber>; rel="alternate"; hreflang="de"',
+          '<http://localhost:3000/about>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(getLinks(createMockRequest('/de/ueber', 'de'))).toEqual([
           '<http://localhost:3000/en/about>; rel="alternate"; hreflang="en"',
-          '<http://localhost:3000/de/ueber>; rel="alternate"; hreflang="de"'
+          '<http://localhost:3000/de/ueber>; rel="alternate"; hreflang="de"',
+          '<http://localhost:3000/about>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(getLinks(createMockRequest('/en/users/1', 'en'))).toEqual([
           '<http://localhost:3000/en/users/1>; rel="alternate"; hreflang="en"',
-          '<http://localhost:3000/de/benutzer/1>; rel="alternate"; hreflang="de"'
+          '<http://localhost:3000/de/benutzer/1>; rel="alternate"; hreflang="de"',
+          '<http://localhost:3000/users/1>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(getLinks(createMockRequest('/de/benutzer/1', 'de'))).toEqual([
           '<http://localhost:3000/en/users/1>; rel="alternate"; hreflang="en"',
-          '<http://localhost:3000/de/benutzer/1>; rel="alternate"; hreflang="de"'
+          '<http://localhost:3000/de/benutzer/1>; rel="alternate"; hreflang="de"',
+          '<http://localhost:3000/users/1>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(
           getLinks(createMockRequest('/en/products/apparel/t-shirts', 'en'))
         ).toEqual([
           '<http://localhost:3000/en/products/apparel/t-shirts>; rel="alternate"; hreflang="en"',
-          '<http://localhost:3000/de/produkte/apparel/t-shirts>; rel="alternate"; hreflang="de"'
+          '<http://localhost:3000/de/produkte/apparel/t-shirts>; rel="alternate"; hreflang="de"',
+          '<http://localhost:3000/products/apparel/t-shirts>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(
           getLinks(createMockRequest('/de/produkte/apparel/t-shirts', 'de'))
         ).toEqual([
           '<http://localhost:3000/en/products/apparel/t-shirts>; rel="alternate"; hreflang="en"',
-          '<http://localhost:3000/de/produkte/apparel/t-shirts>; rel="alternate"; hreflang="de"'
+          '<http://localhost:3000/de/produkte/apparel/t-shirts>; rel="alternate"; hreflang="de"',
+          '<http://localhost:3000/products/apparel/t-shirts>; rel="alternate"; hreflang="x-default"'
         ]);
         expect(getLinks(createMockRequest('/en/unknown', 'en'))).toEqual([
           '<http://localhost:3000/en/unknown>; rel="alternate"; hreflang="en"',
-          '<http://localhost:3000/de/unknown>; rel="alternate"; hreflang="de"'
+          '<http://localhost:3000/de/unknown>; rel="alternate"; hreflang="de"',
+          '<http://localhost:3000/unknown>; rel="alternate"; hreflang="x-default"'
         ]);
       });
 
@@ -1747,7 +1754,8 @@ describe('prefix-based routing', () => {
             '<http://localhost:3000/en/about>; rel="alternate"; hreflang="en"',
             '<http://localhost:3000/uk/about>; rel="alternate"; hreflang="en-gb"',
             '<http://localhost:3000/de/at/about>; rel="alternate"; hreflang="de-at"',
-            '<http://localhost:3000/br/about>; rel="alternate"; hreflang="pt"'
+            '<http://localhost:3000/br/about>; rel="alternate"; hreflang="pt"',
+            '<http://localhost:3000/about>; rel="alternate"; hreflang="x-default"'
           ]);
         });
 
@@ -1755,7 +1763,8 @@ describe('prefix-based routing', () => {
           '<http://localhost:3000/en/unknown>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/uk/unknown>; rel="alternate"; hreflang="en-gb"',
           '<http://localhost:3000/de/at/unknown>; rel="alternate"; hreflang="de-at"',
-          '<http://localhost:3000/br/unknown>; rel="alternate"; hreflang="pt"'
+          '<http://localhost:3000/br/unknown>; rel="alternate"; hreflang="pt"',
+          '<http://localhost:3000/unknown>; rel="alternate"; hreflang="x-default"'
         ]);
       });
     });
@@ -1880,7 +1889,8 @@ describe('prefix-based routing', () => {
             '<http://localhost:3000/en/about>; rel="alternate"; hreflang="en"',
             '<http://localhost:3000/uk/about>; rel="alternate"; hreflang="en-gb"',
             '<http://localhost:3000/de/at/ueber>; rel="alternate"; hreflang="de-at"',
-            '<http://localhost:3000/br/sobre>; rel="alternate"; hreflang="pt"'
+            '<http://localhost:3000/br/sobre>; rel="alternate"; hreflang="pt"',
+            '<http://localhost:3000/about>; rel="alternate"; hreflang="x-default"'
           ]);
         });
 
@@ -1888,7 +1898,8 @@ describe('prefix-based routing', () => {
           '<http://localhost:3000/en/unknown>; rel="alternate"; hreflang="en"',
           '<http://localhost:3000/uk/unknown>; rel="alternate"; hreflang="en-gb"',
           '<http://localhost:3000/de/at/unknown>; rel="alternate"; hreflang="de-at"',
-          '<http://localhost:3000/br/unknown>; rel="alternate"; hreflang="pt"'
+          '<http://localhost:3000/br/unknown>; rel="alternate"; hreflang="pt"',
+          '<http://localhost:3000/unknown>; rel="alternate"; hreflang="x-default"'
         ]);
       });
     });


### PR DESCRIPTION
Previously, we suggested a middleware matcher that looked like this:

```tsx
// middleware.ts

export const config = {
  // Match only internationalized pathnames
  matcher: ['/', '/(de|en)/:path*']
};
```

Even though the hardcoded locales need to be updated when new locales are added, this was suggested in light of providing an error-free getting started experience.

However, based on the apps I've seen over time, it seems like this choice was unpopular and users typically go for a matcher that looks like this:

```tsx
export const config = {
  // Match all pathnames except for
  // - … if they start with `/api`, `/_next` or `/_vercel`
  // - … the ones containing a dot (e.g. `favicon.ico`)
  matcher: '/((?!api|_next|_vercel|.*\\..*).*)'
};
```

While this avoids hardcoding locales, it requires extra care to [match pathnames that contain a dot](https://next-intl.dev/docs/routing/middleware#matcher-config) (e.g. `/users/jane.doe`).

To align better with user expectations, we now suggest the negative lookahead in the getting started docs and point out the case with pathnames containing dots. As an extra benefit, it makes it significantly easier to switch between routing strategies and add custom prefixes.

With the new matcher in place, the middleware now also returns an `x-default` [alternate link](https://next-intl.dev/docs/routing#alternate-links-details) for non-root pathnames (previously only one for `/` was returned when using `localePrefix: 'always'`). Due to this, please update your middleware matcher as shown in the [getting started docs](https://next-intl.dev/docs/getting-started/app-router/with-i18n-routing#middleware) if you're using alternate links.

**Related discussions:**
- https://github.com/amannn/next-intl/issues/1136
- https://github.com/amannn/next-intl/pull/505
- https://github.com/amannn/next-intl/issues/504


