### PR TITLE
fix: Handle `query` in `<Link />` correctly when using `localePrefix: 'as-needed'` with `domains`

### DIFF
--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -15,37 +15,37 @@ const config: SizeLimitConfig = [
     name: "import {createSharedPathnamesNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createSharedPathnamesNavigation}',
-    limit: '4.125 KB'
+    limit: '4.145 KB'
   },
   {
     name: "import {createLocalizedPathnamesNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createLocalizedPathnamesNavigation}',
-    limit: '4.125 KB'
+    limit: '4.145 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/production/navigation.react-client.js',
     import: '{createNavigation}',
-    limit: '4.125 KB'
+    limit: '4.145 KB'
   },
   {
     name: "import {createSharedPathnamesNavigation} from 'next-intl/navigation' (react-server)",
     path: 'dist/production/navigation.react-server.js',
     import: '{createSharedPathnamesNavigation}',
-    limit: '16.805 KB'
+    limit: '16.825 KB'
   },
   {
     name: "import {createLocalizedPathnamesNavigation} from 'next-intl/navigation' (react-server)",
     path: 'dist/production/navigation.react-server.js',
     import: '{createLocalizedPathnamesNavigation}',
-    limit: '16.805 KB'
+    limit: '16.82 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-server)",
     path: 'dist/production/navigation.react-server.js',
     import: '{createNavigation}',
-    limit: '16.805 KB'
+    limit: '16.82 KB'
   },
   {
     name: "import * from 'next-intl/server' (react-client)",

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -924,6 +924,15 @@ describe.each([
         );
         expect(markup).toContain('href="/de/about"');
       });
+
+      it('accepts search params', () => {
+        render(
+          <Link href={{pathname: '/about', query: {foo: 'bar'}}}>Test</Link>
+        );
+        expect(
+          screen.getByRole('link', {name: 'Test'}).getAttribute('href')
+        ).toBe('/about?foo=bar');
+      });
     });
 
     describe('getPathname', () => {
@@ -974,6 +983,39 @@ describe.each([
       it('adds a prefix for a secondary locale', () => {
         runInRender(() => redirectFn({href: '/', locale: 'de'}));
         expect(nextRedirectFn).toHaveBeenLastCalledWith('/de');
+      });
+    });
+  });
+
+  describe("localePrefix: 'as-needed', with `domains` and `pathnames`", () => {
+    const {Link, permanentRedirect, redirect} = createNavigation({
+      locales,
+      defaultLocale,
+      domains,
+      localePrefix: 'as-needed',
+      pathnames
+    });
+
+    describe('Link', () => {
+      it('accepts search params', () => {
+        render(
+          <Link href={{pathname: '/about', query: {foo: 'bar'}}}>Test</Link>
+        );
+        expect(
+          screen.getByRole('link', {name: 'Test'}).getAttribute('href')
+        ).toBe('/about?foo=bar');
+      });
+    });
+
+    describe.each([
+      ['redirect', redirect, nextRedirect],
+      ['permanentRedirect', permanentRedirect, nextPermanentRedirect]
+    ])('%s', (_, redirectFn, nextRedirectFn) => {
+      it('accepts search params', () => {
+        runInRender(() =>
+          redirectFn({href: {pathname: '/', query: {foo: 'bar'}}, locale: 'en'})
+        );
+        expect(nextRedirectFn).toHaveBeenLastCalledWith('/en?foo=bar');
       });
     });
   });

--- a/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
+++ b/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
@@ -98,9 +98,10 @@ export default function createSharedNavigationFns<
     {href, locale, ...rest}: LinkProps<Pathname>,
     ref: ComponentProps<typeof BaseLink>['ref']
   ) {
-    let pathname, params;
+    let pathname, params, query;
     if (typeof href === 'object') {
       pathname = href.pathname;
+      query = href.query;
       // @ts-expect-error -- This is ok
       params = href.params;
     } else {
@@ -159,7 +160,10 @@ export default function createSharedNavigationFns<
                   // @ts-expect-error -- This is ok
                   {
                     locale: curLocale,
-                    href: pathnames == null ? pathname : {pathname, params}
+                    href:
+                      pathnames == null
+                        ? {pathname, query}
+                        : {pathname, query, params}
                   },
                   false
                 )


### PR DESCRIPTION
Fixes #1731 

Many thanks to @seanpavlov for analyzing the issue and suggesting the fix!