### PR TITLE
docs: fix variable name on landing page example

### DIFF
--- a/docs/src/components/HeroCode.tsx
+++ b/docs/src/components/HeroCode.tsx
@@ -164,7 +164,7 @@ const files = [
           <span data-token="text">:</span>
           <span data-token="text"> </span>
           <span data-token="string">
-            "{'{'}firstname{'}'}'s profile"
+            "{'{'}firstName{'}'}'s profile"
           </span>
           <span data-token="text">,</span>
         </span>


### PR DESCRIPTION
Fixed the capitalization in `firstName` variable
<img width="718" alt="Screenshot 2025-02-24 at 2 06 49 PM" src="https://github.com/user-attachments/assets/41ebc663-7755-4b91-b56c-2b0005f246c6" />


<img width="722" alt="Screenshot 2025-02-24 at 2 10 27 PM" src="https://github.com/user-attachments/assets/7f7988a3-75d8-4d52-9455-4ebc2fd0e609" />
