### PR TITLE
feat:  Allow optimal routing by bypassing middleware

### DIFF
--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -266,7 +266,9 @@ export default function createMiddleware<
       } else {
         const internalHref = formatPathname(
           unprefixedInternalPathname,
-          getLocaleAsPrefix(locale),
+          resolvedRouting.optimalRouting
+            ? undefined
+            : getLocaleAsPrefix(locale),
           request.nextUrl.search
         );
 

--- a/packages/next-intl/src/routing/config.tsx
+++ b/packages/next-intl/src/routing/config.tsx
@@ -67,6 +67,12 @@ export type RoutingConfig<
   alternateLinks?: boolean;
 
   /**
+   * Allows having the optimal routing for the current request by bypassing middleware
+   * and using the default locale when no locale is presented via the URL or domains.
+   **/
+  optimalRouting?: boolean;
+
+  /**
    * By setting this to `false`, the cookie as well as the `accept-language` header will no longer be used for locale detection.
    * @see https://next-intl.dev/docs/routing/middleware#locale-detection
    **/


### PR DESCRIPTION
This PR optimizes `next-intl` by using middeware only for non-default locales.

Currently, using next-intl with app-routing localization, requires using the middleware always.

Since [middleware in Next.js 13+ can be costly to run](https://github.com/vercel/next.js/issues/38273), this PR allows:
* Not having to prefix any of the routes with a `[locale]` directory
* Using middleware only for non-default locales (since the middleware sets the language context, we can retrieve it using the current way when rendering using the app router, and thus is no longer needed to retrieve it via the page params)