### PR TITLE
feat: Support partial `pathnames`

### DIFF
--- a/examples/example-app-router/src/i18n/routing.ts
+++ b/examples/example-app-router/src/i18n/routing.ts
@@ -7,7 +7,7 @@ export const routing = defineRouting({
   pathnames: {
     '/': '/',
     '/pathnames': {
-      en: '/pathnames',
+      en: null,
       de: '/pfadnamen'
     }
   }

--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -21,13 +21,13 @@ const config: SizeLimitConfig = [
     name: "import {createNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/esm/production/navigation.react-client.js',
     import: '{createNavigation}',
-    limit: '2.285 KB'
+    limit: '2.305 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-server)",
     path: 'dist/esm/production/navigation.react-server.js',
     import: '{createNavigation}',
-    limit: '3.055 KB'
+    limit: '3.075 KB'
   },
   {
     name: "import * from 'next-intl/server' (react-client)",
@@ -42,7 +42,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl/middleware'",
     path: 'dist/esm/production/middleware.js',
-    limit: '9.355 KB'
+    limit: '9.505 KB'
   },
   {
     name: "import * from 'next-intl/routing'",

--- a/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.test.tsx
+++ b/packages/next-intl/src/middleware/getAlternateLinksHeaderValue.test.tsx
@@ -103,7 +103,8 @@ describe.each([{basePath: undefined}, {basePath: '/base'}])(
           routing,
           request: getMockRequest('https://example.com/'),
           resolvedLocale: 'en',
-          localizedPathnames: pathnames['/']
+          localizedPathnames: pathnames['/'],
+          internalTemplateName: '/'
         }).split(', ')
       ).toEqual([
         `<https://example.com${
@@ -120,7 +121,8 @@ describe.each([{basePath: undefined}, {basePath: '/base'}])(
           routing,
           request: getMockRequest('https://example.com/about'),
           resolvedLocale: 'en',
-          localizedPathnames: pathnames['/about']
+          localizedPathnames: pathnames['/about'],
+          internalTemplateName: '/about'
         }).split(', ')
       ).toEqual([
         `<https://example.com${basePath}/about>; rel="alternate"; hreflang="en"`,
@@ -133,7 +135,8 @@ describe.each([{basePath: undefined}, {basePath: '/base'}])(
           routing,
           request: getMockRequest('https://example.com/de/ueber'),
           resolvedLocale: 'de',
-          localizedPathnames: pathnames['/about']
+          localizedPathnames: pathnames['/about'],
+          internalTemplateName: '/about'
         }).split(', ')
       ).toEqual([
         `<https://example.com${basePath}/about>; rel="alternate"; hreflang="en"`,
@@ -146,12 +149,42 @@ describe.each([{basePath: undefined}, {basePath: '/base'}])(
           routing,
           request: getMockRequest('https://example.com/users/2'),
           resolvedLocale: 'en',
-          localizedPathnames: pathnames['/users/[userId]']
+          localizedPathnames: pathnames['/users/[userId]'],
+          internalTemplateName: '/users/[userId]'
         }).split(', ')
       ).toEqual([
         `<https://example.com${basePath}/users/2>; rel="alternate"; hreflang="en"`,
         `<https://example.com${basePath}/de/benutzer/2>; rel="alternate"; hreflang="de"`,
         `<https://example.com${basePath}/users/2>; rel="alternate"; hreflang="x-default"`
+      ]);
+    });
+
+    it('works for partial pathnames with undefined and null entries', () => {
+      const routing = receiveRoutingConfig({
+        defaultLocale: 'en',
+        locales: ['en', 'de', 'ja'],
+        localePrefix: 'as-needed'
+      });
+      const pathnames = {
+        '/': '/',
+        '/about': {
+          de: '/ueber',
+          ja: null
+        }
+      };
+
+      expect(
+        getAlternateLinksHeaderValue({
+          routing,
+          request: getMockRequest('https://example.com/about'),
+          resolvedLocale: 'en',
+          localizedPathnames: pathnames['/about'],
+          internalTemplateName: '/about'
+        }).split(', ')
+      ).toEqual([
+        `<https://example.com${basePath}/about>; rel="alternate"; hreflang="en"`,
+        `<https://example.com${basePath}/de/ueber>; rel="alternate"; hreflang="de"`,
+        `<https://example.com${basePath}/about>; rel="alternate"; hreflang="x-default"`
       ]);
     });
 
@@ -404,25 +437,29 @@ describe.each([{basePath: undefined}, {basePath: '/base'}])(
           routing,
           request: getMockRequest('https://en.example.com/about'),
           resolvedLocale: 'en',
-          localizedPathnames: routing.pathnames!['/about']
+          localizedPathnames: routing.pathnames!['/about'],
+          internalTemplateName: '/about'
         }),
         getAlternateLinksHeaderValue({
           routing,
           request: getMockRequest('https://ca.example.com/about'),
           resolvedLocale: 'en',
-          localizedPathnames: routing.pathnames!['/about']
+          localizedPathnames: routing.pathnames!['/about'],
+          internalTemplateName: '/about'
         }),
         getAlternateLinksHeaderValue({
           routing,
           request: getMockRequest('https://ca.example.com/fr/a-propos'),
           resolvedLocale: 'fr',
-          localizedPathnames: routing.pathnames!['/about']
+          localizedPathnames: routing.pathnames!['/about'],
+          internalTemplateName: '/about'
         }),
         getAlternateLinksHeaderValue({
           routing,
           request: getMockRequest('https://fr.example.com/a-propos'),
           resolvedLocale: 'fr',
-          localizedPathnames: routing.pathnames!['/about']
+          localizedPathnames: routing.pathnames!['/about'],
+          internalTemplateName: '/about'
         })
       ]
         .map((links) => links.split(', '))
@@ -440,25 +477,29 @@ describe.each([{basePath: undefined}, {basePath: '/base'}])(
           routing,
           request: getMockRequest('https://en.example.com/users/42'),
           resolvedLocale: 'en',
-          localizedPathnames: routing.pathnames!['/users/[userId]']
+          localizedPathnames: routing.pathnames!['/users/[userId]'],
+          internalTemplateName: '/users/[userId]'
         }),
         getAlternateLinksHeaderValue({
           routing,
           request: getMockRequest('https://ca.example.com/users/42'),
           resolvedLocale: 'en',
-          localizedPathnames: routing.pathnames!['/users/[userId]']
+          localizedPathnames: routing.pathnames!['/users/[userId]'],
+          internalTemplateName: '/users/[userId]'
         }),
         getAlternateLinksHeaderValue({
           routing,
           request: getMockRequest('https://ca.example.com/fr/utilisateurs/42'),
           resolvedLocale: 'fr',
-          localizedPathnames: routing.pathnames!['/users/[userId]']
+          localizedPathnames: routing.pathnames!['/users/[userId]'],
+          internalTemplateName: '/users/[userId]'
         }),
         getAlternateLinksHeaderValue({
           routing,
           request: getMockRequest('https://fr.example.com/utilisateurs/42'),
           resolvedLocale: 'fr',
-          localizedPathnames: routing.pathnames!['/users/[userId]']
+          localizedPathnames: routing.pathnames!['/users/[userId]'],
+          internalTemplateName: '/users/[userId]'
         })
       ]
         .map((links) => links.split(', '))
@@ -601,7 +642,8 @@ describe('trailingSlash: true', () => {
             routing,
             request: new NextRequest(new URL('https://example.com' + pathname)),
             resolvedLocale: 'en',
-            localizedPathnames: pathnames['/about']
+            localizedPathnames: pathnames['/about'],
+            internalTemplateName: '/about'
           }).split(', ')
         ).toEqual([
           `<https://example.com/about/>; rel="alternate"; hreflang="en"`,
@@ -618,7 +660,8 @@ describe('trailingSlash: true', () => {
             routing,
             request: new NextRequest(new URL('https://example.com' + pathname)),
             resolvedLocale: 'en',
-            localizedPathnames: pathnames['/']
+            localizedPathnames: pathnames['/'],
+            internalTemplateName: '/'
           }).split(', ')
         ).toEqual([
           `<https://example.com/>; rel="alternate"; hreflang="en"`,

--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -426,72 +426,90 @@ describe('prefix-based routing', () => {
         pathnames: {
           '/': '/',
           '/about': {
-            en: '/about',
             de: '/ueber',
             'de-AT': '/ueber',
             ja: '/約'
           },
           '/users': {
-            en: '/users',
             de: '/benutzer',
             'de-AT': '/benutzer',
             ja: '/ユーザー'
           },
           '/users/[userId]': {
-            en: '/users/[userId]',
             de: '/benutzer/[userId]',
             'de-AT': '/benutzer/[userId]',
             ja: '/ユーザー/[userId]'
           },
           '/news/[articleSlug]-[articleId]': {
-            en: '/news/[articleSlug]-[articleId]',
             de: '/neuigkeiten/[articleSlug]-[articleId]',
             'de-AT': '/neuigkeiten/[articleSlug]-[articleId]',
             ja: '/ニュース/[articleSlug]-[articleId]'
           },
           '/articles/[category]/[articleSlug]': {
-            en: '/articles/[category]/[articleSlug]',
             de: '/artikel/[category]/[articleSlug]',
             'de-AT': '/artikel/[category]/[articleSlug]',
             ja: '/記事/[category]/[articleSlug]'
           },
           '/articles/[category]/just-in': {
-            en: '/articles/[category]/just-in',
             de: '/artikel/[category]/aktuell',
             'de-AT': '/artikel/[category]/aktuell',
             ja: '/記事/[category]/最新'
           },
           '/products/[...slug]': {
-            en: '/products/[...slug]',
             de: '/produkte/[...slug]',
             'de-AT': '/produkte/[...slug]',
             ja: '/製品/[...slug]'
           },
           '/products/[slug]': {
-            en: '/products/[slug]',
             de: '/produkte/[slug]',
             'de-AT': '/produkte/[slug]',
             ja: '/製品/[slug]'
           },
           '/products/add': {
-            en: '/products/add',
             de: '/produkte/hinzufuegen',
             'de-AT': '/produkte/hinzufuegen',
             ja: '/製品/追加'
           },
           '/categories/[[...slug]]': {
-            en: '/categories/[[...slug]]',
             de: '/kategorien/[[...slug]]',
             'de-AT': '/kategorien/[[...slug]]',
             ja: '/カテゴリー/[[...slug]]'
           },
           '/categories/new': {
-            en: '/categories/new',
             de: '/kategorien/neu',
             'de-AT': '/kategorien/neu',
             ja: '/カテゴリー/新着'
+          },
+          '/partially-available': {
+            de: '/teilweise-verfuegbar',
+            'de-AT': null
+            // (ja inherits en)
           }
         } satisfies Pathnames<ReadonlyArray<'en' | 'de' | 'de-AT' | 'ja'>>
+      });
+
+      describe('partially available locales', () => {
+        it('serves requests for available locales', () => {
+          middlewareWithPathnames(
+            createMockRequest('/de/teilweise-verfuegbar', 'de')
+          );
+          expect(MockedNextResponse.rewrite).toHaveBeenCalled();
+          expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/de/partially-available'
+          );
+        });
+
+        it('uses the internal default for undefined entries', () => {
+          middlewareWithPathnames(createMockRequest('/partially-available'));
+          middlewareWithPathnames(createMockRequest('/ja/partially-available'));
+          expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(2);
+          expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+            'http://localhost:3000/en/partially-available'
+          );
+          expect(MockedNextResponse.rewrite.mock.calls[1][0].toString()).toBe(
+            'http://localhost:3000/ja/partially-available'
+          );
+        });
       });
 
       it('serves requests for the default locale at the root', () => {

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -9,6 +9,7 @@ import type {
 import {HEADER_LOCALE_NAME} from '../shared/constants.js';
 import {
   getLocalePrefix,
+  getLocalizedTemplate,
   matchesPathname,
   normalizeTrailingSlash
 } from '../shared/utils.js';
@@ -180,10 +181,11 @@ export default function createMiddleware<
 
       if (internalTemplateName) {
         const pathnameConfig = pathnames[internalTemplateName];
-        const localeTemplate: string =
-          typeof pathnameConfig === 'string'
-            ? pathnameConfig
-            : pathnameConfig[locale];
+        const localeTemplate: string = getLocalizedTemplate(
+          pathnameConfig,
+          locale,
+          internalTemplateName
+        );
 
         if (matchesPathname(localeTemplate, unprefixedExternalPathname)) {
           unprefixedInternalPathname = formatTemplatePathname(
@@ -195,10 +197,11 @@ export default function createMiddleware<
           let sourceTemplate: string;
           if (resolvedTemplateLocale) {
             // A localized pathname from another locale has matched
-            sourceTemplate =
-              typeof pathnameConfig === 'string'
-                ? pathnameConfig
-                : pathnameConfig[resolvedTemplateLocale];
+            sourceTemplate = getLocalizedTemplate(
+              pathnameConfig,
+              resolvedTemplateLocale,
+              internalTemplateName
+            );
           } else {
             // An internal pathname has matched that
             // doesn't have a localized pathname
@@ -320,6 +323,7 @@ export default function createMiddleware<
         'Link',
         getAlternateLinksHeaderValue({
           routing: resolvedRouting,
+          internalTemplateName,
           localizedPathnames:
             internalTemplateName != null && pathnames
               ? pathnames[internalTemplateName]

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -9,6 +9,7 @@ import type {
 } from '../routing/types.js';
 import {
   getLocalePrefix,
+  getLocalizedTemplate,
   getSortedPathnames,
   matchesPathname,
   normalizeTrailingSlash,
@@ -49,8 +50,13 @@ export function getInternalTemplate<
         sortedEntries.unshift(sortedEntries.splice(curLocaleIndex, 1)[0]);
       }
 
-      for (const [entryLocale, entryPathname] of sortedEntries) {
-        if (matchesPathname(entryPathname as string, pathname)) {
+      for (const [entryLocale] of sortedEntries) {
+        const localizedTemplate = getLocalizedTemplate(
+          pathnames[internalPathname],
+          entryLocale,
+          internalPathname
+        );
+        if (matchesPathname(localizedTemplate, pathname)) {
           return [entryLocale, internalPathname];
         }
       }

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -10,6 +10,7 @@ import type {
 } from '../../routing/types.js';
 import {
   getLocalePrefix,
+  getLocalizedTemplate,
   getSortedPathnames,
   isLocalizableHref,
   matchesPathname,
@@ -132,10 +133,10 @@ export function compileLocalizedPathname<AppLocales extends Locales, Pathname>({
   }
 
   function compilePath(
-    namedPath: Pathnames<AppLocales>[keyof Pathnames<AppLocales>]
+    namedPath: Pathnames<AppLocales>[keyof Pathnames<AppLocales>],
+    internalPathname: string
   ) {
-    const template =
-      typeof namedPath === 'string' ? namedPath : namedPath[locale];
+    const template = getLocalizedTemplate(namedPath, locale, internalPathname);
     let compiled = template;
 
     if (params) {
@@ -176,12 +177,12 @@ export function compileLocalizedPathname<AppLocales extends Locales, Pathname>({
 
   if (typeof pathname === 'string') {
     const namedPath = getNamedPath(pathname);
-    const compiled = compilePath(namedPath);
+    const compiled = compilePath(namedPath, pathname);
     return compiled;
   } else {
-    const {pathname: href, ...rest} = pathname;
-    const namedPath = getNamedPath(href);
-    const compiled = compilePath(namedPath);
+    const {pathname: internalPathname, ...rest} = pathname;
+    const namedPath = getNamedPath(internalPathname);
+    const compiled = compilePath(namedPath, internalPathname);
     const result: UrlObject = {...rest, pathname: compiled};
     return result;
   }
@@ -203,7 +204,16 @@ export function getRoute<AppLocales extends Locales>(
         return internalPathname;
       }
     } else {
-      if (matchesPathname(localizedPathnamesOrPathname[locale], decoded)) {
+      if (
+        matchesPathname(
+          getLocalizedTemplate(
+            localizedPathnamesOrPathname,
+            locale,
+            internalPathname
+          ),
+          decoded
+        )
+      ) {
         return internalPathname;
       }
     }

--- a/packages/next-intl/src/routing/defineRouting.test.tsx
+++ b/packages/next-intl/src/routing/defineRouting.test.tsx
@@ -35,14 +35,26 @@ describe('pathnames', () => {
     routing.pathnames['/about'].en;
   });
 
-  it('ensures all locales have a value', () => {
+
+  it('accepts a partial config for only some locales', () => {
     defineRouting({
       locales: ['en', 'de'],
       defaultLocale: 'en',
       pathnames: {
-        // @ts-expect-error -- Missing de
         '/about': {
-          en: '/about'
+          de: '/ueber-uns'
+        }
+      }
+    });
+  });
+
+  it('allows to mark locales as not supported', () => {
+    defineRouting({
+      locales: ['en', 'de'],
+      defaultLocale: 'en',
+      pathnames: {
+        '/about': {
+          de: null
         }
       }
     });

--- a/packages/next-intl/src/routing/types.tsx
+++ b/packages/next-intl/src/routing/types.tsx
@@ -36,7 +36,7 @@ export type LocalePrefix<
 
 export type Pathnames<AppLocales extends Locales> = Record<
   Pathname,
-  Record<AppLocales[number], Pathname> | Pathname
+  Partial<Record<AppLocales[number], Pathname | null>> | Pathname
 >;
 
 export type DomainConfig<AppLocales extends Locales> = {

--- a/packages/next-intl/src/shared/utils.tsx
+++ b/packages/next-intl/src/shared/utils.tsx
@@ -2,7 +2,8 @@ import type {LinkProps} from 'next/link.js';
 import type {
   LocalePrefixConfigVerbose,
   LocalePrefixMode,
-  Locales
+  Locales,
+  Pathnames
 } from '../routing/types.js';
 
 type Href = LinkProps['href'];
@@ -56,6 +57,16 @@ function hasTrailingSlash() {
   } catch {
     return false;
   }
+}
+
+export function getLocalizedTemplate<AppLocales extends Locales>(
+  pathnameConfig: Pathnames<AppLocales>[keyof Pathnames<AppLocales>],
+  locale: AppLocales[number],
+  internalTemplate: string
+) {
+  return typeof pathnameConfig === 'string'
+    ? pathnameConfig
+    : pathnameConfig[locale] || internalTemplate;
 }
 
 export function normalizeTrailingSlash(pathname: string) {


### PR DESCRIPTION
[`pathnames`](https://next-intl.dev/docs/routing#pathnames) can now be declared partially:

