### PR TITLE
docs: Fix typo

### DIFF
--- a/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
+++ b/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
@@ -237,7 +237,7 @@ Now you can use translations and other functionality from `next-intl` in your co
 
 ```tsx filename="app/[locale]/page.tsx"
 import {useTranslations} from 'next-intl';
-import {Link} from '@/i18n/routing';
+import {Link} from '@/i18n/navigation';
 
 export default function HomePage() {
   const t = useTranslations('HomePage');


### PR DESCRIPTION
there seems to be a minor error in the getting started page, in the provided page.tsx file for `src\app\[locale]` it tries to import:

```ts
import { Link } from "@/i18n/routing";
```

which does not exist, instead it exists in the navigation file"

```ts
import { Link } from "@/i18n/navigation";`
```