### PR TITLE
docs: missing vscode setting

### DIFF
--- a/docs/src/pages/docs/workflows/vscode-integration.mdx
+++ b/docs/src/pages/docs/workflows/vscode-integration.mdx
@@ -25,6 +25,7 @@ These extensions are known to support `next-intl`:
 2. Configure the extension in your project via [workspace settings](https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings)
 
 ```json filename=".vscode/settings.json"
+"i18n-ally.enabledFrameworks": ["next-intl"],
 "i18n-ally.localesPaths": ["./path/to/your/messages"], // E.g. "./messages"
 "i18n-ally.keystyle": "nested"
 ```


### PR DESCRIPTION
I was following the documentation to integrate the extension, but it wasn’t working. After checking the example here, I found that a setting was missing. Once I added it, everything started working correctly.

https://github.com/lokalise/i18n-ally/blob/main/examples/by-frameworks/next-intl/.vscode/settings.json