### PR TITLE
fix intergrating with clerk example correct

### DIFF
--- a/docs/src/pages/docs/routing/middleware.mdx
+++ b/docs/src/pages/docs/routing/middleware.mdx
@@ -265,10 +265,11 @@ const handleI18nRouting = createMiddleware(routing);
 
 const isProtectedRoute = createRouteMatcher(['/:locale/dashboard(.*)']);
 
-export default clerkMiddleware((auth, req) => {
-  if (isProtectedRoute(req)) auth().protect();
+export default clerkMiddleware(async (auth, req) => {
+  const intlResponse = handleI18nRouting(req);
+  if (intlResponse) return intlResponse;
 
-  return handleI18nRouting(req);
+  if (isProtectedRoute(req)) await auth.protect();
 });
 
 export const config = {


### PR DESCRIPTION
1. change clerkMiddleware auth use to latest version [clerk doc](https://clerk.com/docs/references/nextjs/clerk-middleware#protect-all-routes)
2. use intl before clerk to avoid infinite redirect