### PR TITLE
docs: Update Clerk example in middleware docs

### DIFF
--- a/docs/src/pages/docs/routing/middleware.mdx
+++ b/docs/src/pages/docs/routing/middleware.mdx
@@ -263,10 +263,10 @@ import {routing} from './i18n/routing';
 
 const handleI18nRouting = createMiddleware(routing);
 
-const isProtectedRoute = createRouteMatcher(['/:locale/dashboard(.*)']);
+const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/:locale/dashboard(.*)']);
 
-export default clerkMiddleware((auth, req) => {
-  if (isProtectedRoute(req)) auth().protect();
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) await auth.protect();
 
   return handleI18nRouting(req);
 });

--- a/docs/src/pages/docs/routing/middleware.mdx
+++ b/docs/src/pages/docs/routing/middleware.mdx
@@ -263,7 +263,7 @@ import {routing} from './i18n/routing';
 
 const handleI18nRouting = createMiddleware(routing);
 
-const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/:locale/dashboard(.*)']);
+const isProtectedRoute = createRouteMatcher(['/:locale/dashboard(.*)']);
 
 export default clerkMiddleware(async (auth, req) => {
   if (isProtectedRoute(req)) await auth.protect();

--- a/docs/src/pages/docs/routing/middleware.mdx
+++ b/docs/src/pages/docs/routing/middleware.mdx
@@ -277,7 +277,7 @@ export const config = {
 };
 ```
 
-(based on `@clerk/nextjs@^5.0.0`)
+(based on `@clerk/nextjs@^6.0.0`)
 
 ### Example: Integrating with Supabase Authentication
 


### PR DESCRIPTION
1. change `protect` usage to latest version
2. add locale prefix matcher and non locale prefix matcher at the same time to avoid infinite redirect

Fixes https://github.com/amannn/next-intl/issues/1458