### PR TITLE
docs: Remove unused createNavigation import in routing.ts setup example

### DIFF
--- a/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
+++ b/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
@@ -107,7 +107,6 @@ To share the configuration between these two places, we'll set up `routing.ts`:
 
 ```ts filename="src/i18n/routing.ts"
 import {defineRouting} from 'next-intl/routing';
-import {createNavigation} from 'next-intl/navigation';
 
 export const routing = defineRouting({
   // A list of all locales that are supported


### PR DESCRIPTION
Remove unused...

```ts
import {createNavigation} from 'next-intl/navigation';
```

...import in `routing.ts` setup example on _app-router -> with-18n-routing_ page.