### PR TITLE
docs: Clarify prefixed link `href` with `localePrefix: 'as-needed'`

### DIFF
--- a/docs/src/pages/docs/routing.mdx
+++ b/docs/src/pages/docs/routing.mdx
@@ -65,7 +65,7 @@ export const routing = defineRouting({
 
 #### `localePrefix: 'as-needed'` [#locale-prefix-as-needed]
 
-If you want to use no prefix for the default locale (e.g. `/about`), you can configure your routing accordingly:
+If you want to use no prefix for the default locale (e.g. `/about`) while keeping it for other locales (e.g. `/de/about`), you can configure your routing accordingly:
 
 ```tsx filename="routing.ts" {5}
 import {defineRouting} from 'next-intl/routing';
@@ -79,7 +79,8 @@ export const routing = defineRouting({
 **Note that:**
 
 1. If you use this routing strategy, make sure that your [middleware matcher](/docs/routing/middleware#matcher-config) detects unprefixed pathnames.
-2. If a superfluous locale prefix like `/en/about` is requested, the middleware will automatically redirect to the unprefixed version `/about`. This can be helpful in case you're redirecting from another locale and you want to update a potential cookie value first (e.g. [`<Link />`](/docs/routing/navigation#link) relies on this mechanism).
+2. The middleware will by default set a [cookie](#locale-cookie) to remember the user's locale preference. If no explicit locale prefix is present in the pathname, then [locale detection](/docs/routing/middleware#locale-detection-prefix) will potentially redirect users to the latest locale that was matched based on the cookie value (e.g. `/` → `/de`).
+3. If a superfluous locale prefix like `/en/about` is requested, the middleware will automatically redirect to the unprefixed version `/about`. This can be helpful in case you're redirecting from another locale and you want to update a potential cookie value first (e.g. [`<Link />`](/docs/routing/navigation#link) relies on this mechanism).
 
 #### `localePrefix: 'never'` [#locale-prefix-never]
 

--- a/docs/src/pages/docs/routing/navigation.mdx
+++ b/docs/src/pages/docs/routing/navigation.mdx
@@ -152,6 +152,28 @@ In case you're using the [`pathnames`](/docs/routing#pathnames) setting, the `hr
 
 </Details>
 
+<Details id="link-locale">
+<summary>Why does `<Link />` always set a locale prefix when using the `locale` prop?</summary>
+
+If you're providing a `locale` prop, typically to change the locale of the target page, you might notice that the link's `href` will always include a locale prefix, even if you're using a [`localePrefix`](/docs/routing#locale-prefix) setting other than `always`.
+
+**Example:**
+
+If you're using [`localePrefix: 'as-needed'`](/docs/routing#locale-prefix-as-needed) and `en` is your default locale, then the `href` for this link will still be `/en/about`:
+
+```tsx
+// Links to `/en/about`
+<Link href="/about" locale="en">
+  About
+</Link>
+```
+
+The reason for this is that a potential [cookie](/docs/routing#locale-cookie) may need to be updated before the user can visit the unprefixed route at `/about`. The prefixed pathname will take care of this and will subsequently redirect to the unprefixed route. This behavior is necessary because links might be interacted with before your page is hydrated and client-side code would have a chance to update the cookie.
+
+If you'd like to avoid this behavior, you can instead use [`useRouter`](#userouter) to switch the locale, which can rely on updating the cookie on the client side before navigating to the target page.
+
+</Details>
+
 <Details id="link-unknown-routes">
 <summary>How can I link to unknown routes when using the `pathnames` setting?</summary>
 


### PR DESCRIPTION
[Ref](https://github.com/amannn/next-intl/discussions/1807)