### PR TITLE
chore: add MDX files to tsconfig include pattern

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -24,6 +24,12 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.mdx",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This makes MDX files part of the TypeScript program in the editor. As a result, MDX IntelliSense uses the same configuration as the rest of the program. This also means TypeScript only needs to provide IntelliSense for one program instead of using a default fallback for MDX. This improves performance.

Before:

![An import is unresolved on hover](https://github.com/user-attachments/assets/053bb928-d538-460f-9875-6eb3d463160f)

After:

![The former import is resolved on hover](https://github.com/user-attachments/assets/0133f3fc-c810-415f-87d4-c09d92cd1448)
