### PR TITLE
Docs: update way we import './messages/en.json'

### DIFF
--- a/docs/pages/docs/workflows/typescript.mdx
+++ b/docs/pages/docs/workflows/typescript.mdx
@@ -28,9 +28,8 @@ function About() {
 To enable this validation, add a global type definition file in your project root (e.g. `global.d.ts`):
 
 ```jsx filename="global.d.ts"
-import en from './messages/en.json';
 
-type Messages = typeof en;
+type Messages = typeof import("./messages/en.json");
 
 declare global {
   // Use type safe message keys with `next-intl`


### PR DESCRIPTION
Replaced top level import with typeof import, to avoid problems with top level imports in d.ts.file https://www.typescriptlang.org/docs/handbook/2/modules.html?utm_source=chatgpt.com#:~:text=file%20without%20any%20top%2Dlevel%20import%20or%20export%20declarations

`import en from './messages/en.json';` will almost turn off this `global.d.ts` file, better to use `typeof import()` as an example

Please update this post also https://next-intl.dev/blog/next-intl-4-0#revamped-augmented-types