### PR TITLE
feat: Use `numeric: 'auto'` for relative times that don't need to be rounded for a given unit

### DIFF
--- a/docs/src/pages/docs/usage/dates-times.mdx
+++ b/docs/src/pages/docs/usage/dates-times.mdx
@@ -168,9 +168,9 @@ function Component() {
 }
 ```
 
-### Customizing the unit [#relative-times-unit]
+### `unit` [#relative-times-unit]
 
-By default, `relativeTime` will pick a unit based on the difference between the passed date and `now` like "3 seconds" or "5 days".
+By default, `relativeTime` will pick an appropriate unit based on the difference between the passed date and `now` like "3 seconds", "5 days" or "1 year".
 
 If you want to use a specific unit, you can provide options via the second argument:
 
@@ -185,6 +185,33 @@ function Component() {
   // Renders "247 days ago"
   format.relativeTime(dateTime, {now, unit: 'day'});
 }
+```
+
+Furthermore, `relativeTime` will automatically use [`numeric: 'auto'`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat#numeric) when the time difference divided by the unit is a whole number without a fractional part (e.g. exactly one day). This enables natural phrases like "yesterday" instead of "1 day ago" when appropriate.
+
+You can use utility functions like [`startOfDay`](https://date-fns.org/docs/startOfDay) to ensure that the time difference is a whole number:
+
+```js
+import {useFormatter, useTimeZone} from 'next-intl';
+import {startOfDay} from 'date-fns';
+import {tz} from '@date-fns/tz';
+
+const format = useFormatter();
+const timeZone = useTimeZone();
+
+const now = new Date('2020-12-23T10:36:00.000Z');
+const dateTime = new Date('2020-12-22T08:23:00.000Z');
+
+function normalize(date) {
+  // The "start of a day" depends on a time zone
+  return startOfDay(date, {in: tz(timeZone)});
+}
+
+// Renders "yesterday" instead of "1 day ago"
+const result = format.relativeTime(normalize(dateTime), {
+  now: normalize(now),
+  unit: 'day'
+});
 ```
 
 ## Formatting date and time ranges [#date-time-ranges]

--- a/docs/src/pages/docs/usage/dates-times.mdx
+++ b/docs/src/pages/docs/usage/dates-times.mdx
@@ -196,22 +196,24 @@ import {useFormatter, useTimeZone} from 'next-intl';
 import {startOfDay} from 'date-fns';
 import {tz} from '@date-fns/tz';
 
-const format = useFormatter();
-const timeZone = useTimeZone();
+function Component() {
+  const format = useFormatter();
+  const timeZone = useTimeZone();
 
-const now = new Date('2020-12-23T10:36:00.000Z');
-const dateTime = new Date('2020-12-22T08:23:00.000Z');
+  const now = new Date('2020-12-23T10:36:00.000Z');
+  const dateTime = new Date('2020-12-22T08:23:00.000Z');
 
-function normalize(date) {
-  // The "start of a day" depends on a time zone
-  return startOfDay(date, {in: tz(timeZone)});
+  function normalize(date) {
+    // The "start of a day" depends on a time zone
+    return startOfDay(date, {in: tz(timeZone)});
+  }
+
+  // Renders "yesterday" instead of "1 day ago"
+  format.relativeTime(normalize(dateTime), {
+    now: normalize(now),
+    unit: 'day'
+  });
 }
-
-// Renders "yesterday" instead of "1 day ago"
-const result = format.relativeTime(normalize(dateTime), {
-  now: normalize(now),
-  unit: 'day'
-});
 ```
 
 ## Formatting date and time ranges [#date-time-ranges]

--- a/examples/example-app-router-playground/tests/main.spec.ts
+++ b/examples/example-app-router-playground/tests/main.spec.ts
@@ -237,7 +237,7 @@ it('can use `getMessageFallback`', async ({page}) => {
 it('can use the core library', async ({page}) => {
   await page.goto('/en');
   const element = page.getByTestId('CoreLibrary');
-  await expect(element).toHaveText('Relative time: in 1 day');
+  await expect(element).toHaveText('Relative time: tomorrow');
 });
 
 it('can use `Link` on the server', async ({page}) => {

--- a/packages/use-intl/.size-limit.ts
+++ b/packages/use-intl/.size-limit.ts
@@ -5,7 +5,7 @@ const config: SizeLimitConfig = [
     name: "import * from 'use-intl' (production)",
     import: '*',
     path: 'dist/esm/production/index.js',
-    limit: '13.015 kB'
+    limit: '12.975 kB'
   },
   {
     name: "import {IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter} from 'use-intl' (production)",

--- a/packages/use-intl/src/core/createFormatter.test.tsx
+++ b/packages/use-intl/src/core/createFormatter.test.tsx
@@ -305,25 +305,6 @@ describe('relativeTime', () => {
     ).toBe('3 quarters ago');
   });
 
-  it('uses the `auto` representation if no rounding is needed', () => {
-    const formatter = createFormatter({
-      locale: 'en',
-      timeZone: 'Europe/Berlin'
-    });
-    expect(
-      formatter.relativeTime(parseISO('2020-11-20T00:00:00.000Z'), {
-        now: parseISO('2020-11-21T00:00:00.000Z'),
-        unit: 'day'
-      })
-    ).toBe('yesterday');
-    expect(
-      formatter.relativeTime(parseISO('2020-11-21T00:00:00.000Z'), {
-        now: parseISO('2020-11-20T00:00:00.000Z'),
-        unit: 'day'
-      })
-    ).toBe('tomorrow');
-  });
-
   it('formats a relative time with a globally defined `now`', () => {
     const formatter = createFormatter({
       locale: 'en',
@@ -338,7 +319,7 @@ describe('relativeTime', () => {
   });
 
   describe('choosing the `auto` representation', () => {
-    it('uses `auto` for times <1 second', () => {
+    it('uses `auto` for times <=1 second', () => {
       const formatter = createFormatter({
         locale: 'en',
         timeZone: 'Europe/Berlin'

--- a/packages/use-intl/src/core/createFormatter.test.tsx
+++ b/packages/use-intl/src/core/createFormatter.test.tsx
@@ -201,23 +201,21 @@ describe('relativeTime', () => {
     it.each([
       ['2022-07-10T15:00:00.000Z', '2 years ago'],
       ['2022-07-11T15:00:00.000Z', '1 year ago'],
-      ['2023-01-09T15:00:00.000Z', '1 year ago'],
+      ['2023-01-08T15:00:00.000Z', '1 year ago'],
       ['2023-01-10T15:00:00.000Z', '12 months ago'],
       ['2023-07-09T15:00:00.000Z', '6 months ago'],
       ['2023-12-09T15:00:00.000Z', '1 month ago'],
       ['2023-12-10T15:00:00.000Z', '4 weeks ago'],
-      ['2024-01-02T15:00:00.000Z', '1 week ago'],
+      ['2024-01-01T15:00:00.000Z', '1 week ago'],
       ['2024-01-03T15:00:00.000Z', '6 days ago'],
-      ['2024-01-08T15:00:00.000Z', '1 day ago'],
+      ['2024-01-08T14:00:00.000Z', '1 day ago'],
       ['2024-01-08T15:01:00.000Z', '24 hours ago'],
       ['2024-01-09T14:00:00.000Z', '1 hour ago'],
       ['2024-01-09T14:01:00.000Z', '59 minutes ago'],
       ['2024-01-09T14:59:00.000Z', '1 minute ago'],
       ['2024-01-09T14:59:01.000Z', '59 seconds ago'],
       ['2024-01-09T14:59:59.000Z', '1 second ago'],
-      ['2024-01-09T14:59:59.999Z', 'now'],
 
-      ['2024-01-09T15:00:00.001Z', 'now'],
       ['2024-01-09T15:00:01.000Z', 'in 1 second'],
       ['2024-01-09T15:00:59.000Z', 'in 59 seconds'],
       ['2024-01-09T15:01:00.000Z', 'in 1 minute'],
@@ -226,7 +224,7 @@ describe('relativeTime', () => {
       ['2024-01-09T23:59:00.000Z', 'in 9 hours'],
       ['2024-01-10T00:00:00.000Z', 'in 9 hours'],
       ['2024-01-10T14:59:00.000Z', 'in 24 hours'],
-      ['2024-01-10T15:00:00.000Z', 'in 1 day'],
+      ['2024-01-10T16:00:00.000Z', 'in 1 day'],
       ['2024-01-10T23:59:00.000Z', 'in 1 day'],
       ['2024-01-11T00:00:00.000Z', 'in 1 day'],
       ['2024-01-11T01:00:00.000Z', 'in 1 day'],
@@ -237,7 +235,7 @@ describe('relativeTime', () => {
       ['2024-02-06T00:00:00.000Z', 'in 4 weeks'],
       ['2024-02-06T15:00:00.000Z', 'in 4 weeks'],
       ['2024-02-09T00:00:00.000Z', 'in 4 weeks'],
-      ['2024-02-09T01:00:00.000Z', 'in 1 month'],
+      ['2024-02-10T01:00:00.000Z', 'in 1 month'],
       ['2024-04-09T00:00:00.000Z', 'in 3 months'],
       ['2024-12-09T00:00:00.000Z', 'in 11 months'],
       ['2024-12-31T00:00:00.000Z', 'in 12 months'],
@@ -307,6 +305,25 @@ describe('relativeTime', () => {
     ).toBe('3 quarters ago');
   });
 
+  it('uses the `auto` representation if no rounding is needed', () => {
+    const formatter = createFormatter({
+      locale: 'en',
+      timeZone: 'Europe/Berlin'
+    });
+    expect(
+      formatter.relativeTime(parseISO('2020-11-20T00:00:00.000Z'), {
+        now: parseISO('2020-11-21T00:00:00.000Z'),
+        unit: 'day'
+      })
+    ).toBe('yesterday');
+    expect(
+      formatter.relativeTime(parseISO('2020-11-21T00:00:00.000Z'), {
+        now: parseISO('2020-11-20T00:00:00.000Z'),
+        unit: 'day'
+      })
+    ).toBe('tomorrow');
+  });
+
   it('formats a relative time with a globally defined `now`', () => {
     const formatter = createFormatter({
       locale: 'en',
@@ -318,6 +335,55 @@ describe('relativeTime', () => {
         unit: 'day'
       })
     ).toBe('in 2 days');
+  });
+
+  describe('choosing the `auto` representation', () => {
+    it('uses `auto` for times <1 second', () => {
+      const formatter = createFormatter({
+        locale: 'en',
+        timeZone: 'Europe/Berlin'
+      });
+      const now = parseISO('2020-11-20T00:00:00.000Z');
+      expect(
+        formatter.relativeTime(parseISO('2020-11-20T00:00:00.200Z'), {
+          now
+        })
+      ).toBe('now');
+      expect(
+        formatter.relativeTime(parseISO('2020-11-19T23:59:59.900Z'), {
+          now
+        })
+      ).toBe('now');
+    });
+
+    it('can accept an explicit `unit`', () => {
+      const formatter = createFormatter({
+        locale: 'en',
+        timeZone: 'Europe/Berlin'
+      });
+      expect(
+        formatter.relativeTime(parseISO('2020-11-20T00:00:00.000Z'), {
+          now: parseISO('2020-11-20T00:00:00.000Z'),
+          unit: 'day'
+        })
+      ).toBe('today');
+    });
+
+    it.each([
+      ['last week', parseISO('2020-11-13T00:00:00.000Z')],
+      ['yesterday', parseISO('2020-11-19T00:00:00.000Z')],
+      ['tomorrow', parseISO('2020-11-21T00:00:00.000Z')]
+    ])('formats %s correctly', (expected, date) => {
+      const formatter = createFormatter({
+        locale: 'en',
+        timeZone: 'Europe/Berlin'
+      });
+      expect(
+        formatter.relativeTime(date, {
+          now: parseISO('2020-11-20T00:00:00.000Z')
+        })
+      ).toBe(expected);
+    });
   });
 });
 


### PR DESCRIPTION
This allows to use idiomatic phrasing like "yesterday" in case a date is provided that doesn't have a fractional part when converted to the target unit.

See the [updated docs](https://next-intl-docs-git-feat-1056-relativetimeauton-a219f0-next-intl.vercel.app/docs/usage/dates-times#relative-times-unit).


([ref](https://github.com/amannn/next-intl/issues/1056#issuecomment-2843281594))

