### PR TITLE
docs: Fix navbar background

### DIFF
--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -4,7 +4,7 @@
 
 :root {
   --color-text-primary: #0073e6;
-  --nextra-bg: white;
+  --nextra-bg: 255, 255, 255;
   --docsearch-text-color: black;
   --logo-color: #008fd6;
 }

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -10,6 +10,7 @@
 }
 
 .dark {
+  --nextra-bg: 17, 17, 17;
   --logo-color: #70d1ff;
 }
 


### PR DESCRIPTION
I noticed that the logotype was not visible so I investigated.
It looks like the CSS variables were specified incorrectly.

**Target page:** [Examples – Internationalization (i18n) for Next.js](https://next-intl.dev/examples)

**Screenshots:**

<kbd> ![image](https://github.com/user-attachments/assets/1aac7c8f-e613-42dc-8f92-af49a15c8212)

Before | After
-|-
![image](https://github.com/user-attachments/assets/d69b0b7e-bc5b-4b64-adc0-7d71688d6d86) | ![image](https://github.com/user-attachments/assets/c15f057c-1230-45aa-93c2-f0fd920a1f42)
