### PR TITLE
feat: Encode non-ASCII characters in pathnames returned from navigation APIs

### DIFF
--- a/examples/example-app-router-playground/src/app/[locale]/client/ClientContent.tsx
+++ b/examples/example-app-router-playground/src/app/[locale]/client/ClientContent.tsx
@@ -1,17 +1,28 @@
 'use client';
 
 import {useLocale, useNow, useTimeZone} from 'next-intl';
-import {Link, usePathname} from '@/i18n/navigation';
+import {Link, usePathname, useRouter} from '@/i18n/navigation';
 
 export default function ClientContent() {
   const now = useNow();
   const timeZone = useTimeZone();
   const locale = useLocale();
+  const router = useRouter();
 
   return (
     <>
       <p data-testid="NowFromClient">{now.toISOString()}</p>
-      <Link href="/">Go to home</Link>
+      <p>
+        <Link href="/">Go to home</Link>
+      </p>
+      <p>
+        <Link href="/nested">Go to nested (with link)</Link>
+      </p>
+      <p>
+        <button onClick={() => router.push('/nested')}>
+          Go to nested (with router)
+        </button>
+      </p>
       <p data-testid="UnlocalizedPathname">{usePathname()}</p>
       <p data-testid="TimeZone">{timeZone}</p>
       <p data-testid="Locale">{locale}</p>

--- a/examples/example-app-router-playground/tests/main.spec.ts
+++ b/examples/example-app-router-playground/tests/main.spec.ts
@@ -735,6 +735,45 @@ it.skip('provides a `Link` that works with Radix Primitives', async ({
   await expect(page.getByText('Link to about')).toBeFocused();
 });
 
+describe('encoding of non-ASCII characters in URLs', () => {
+  it('renders a page with encoded characters in the pathname', async ({
+    page
+  }) => {
+    await page.goto('/ja/' + encodeURIComponent('ネスト'));
+    await expect(page).toHaveURL('/ja/%E3%83%8D%E3%82%B9%E3%83%88');
+    page.getByRole('heading', {name: 'ネステッド'});
+  });
+
+  it('renders a page with non-encoded characters in the pathname', async ({
+    page
+  }) => {
+    await page.goto('/ja/ネスト');
+    await expect(page).toHaveURL('/ja/%E3%83%8D%E3%82%B9%E3%83%88');
+    page.getByRole('heading', {name: 'ネステッド'});
+  });
+
+  it('can use `Link` to go to an encoded pathname', async ({page}) => {
+    await page.goto('/ja/client');
+    const link = page.getByRole('link', {name: 'Go to nested'});
+    await expect(link).toHaveAttribute(
+      'href',
+      '/ja/%E3%83%8D%E3%82%B9%E3%83%88'
+    );
+    await link.click();
+    await expect(page).toHaveURL('/ja/%E3%83%8D%E3%82%B9%E3%83%88');
+    page.getByRole('heading', {name: 'ネステッド'});
+  });
+
+  it('can use `useRouter` to go to an encoded pathname', async ({page}) => {
+    await page.goto('/ja/client');
+    await page
+      .getByRole('button', {name: 'Go to nested (with router)'})
+      .click();
+    await expect(page).toHaveURL('/ja/%E3%83%8D%E3%82%B9%E3%83%88');
+    page.getByRole('heading', {name: 'ネステッド'});
+  });
+});
+
 describe('server actions', () => {
   it('can use `getTranslations` in server actions', async ({page}) => {
     await page.goto('/actions');

--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -605,7 +605,7 @@ describe('prefix-based routing', () => {
         );
       });
 
-      it('serves requests for a non-default locale at nested paths for "ja"', () => {
+      it('serves requests for non-ascii characters that are not encoded', () => {
         middlewareWithPathnames(createMockRequest('/ja/約', 'ja'));
         middlewareWithPathnames(createMockRequest('/ja/ユーザー', 'ja'));
         middlewareWithPathnames(createMockRequest('/ja/ユーザー/1', 'ja'));
@@ -617,6 +617,75 @@ describe('prefix-based routing', () => {
         );
         middlewareWithPathnames(
           createMockRequest('/ja/カテゴリー/女性/ティーシャツ', 'ja')
+        );
+
+        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(6);
+        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
+          'http://localhost:3000/ja/about'
+        );
+        expect(MockedNextResponse.rewrite.mock.calls[1][0].toString()).toBe(
+          'http://localhost:3000/ja/users'
+        );
+        expect(MockedNextResponse.rewrite.mock.calls[2][0].toString()).toBe(
+          'http://localhost:3000/ja/users/1'
+        );
+        expect(MockedNextResponse.rewrite.mock.calls[3][0].toString()).toBe(
+          'http://localhost:3000/ja/news/happy-newyear-g5b116754'
+        );
+
+        // Dynamic segments are expected to be encoded
+        expect(MockedNextResponse.rewrite.mock.calls[4][0].toString()).toBe(
+          'http://localhost:3000/ja/products/%E3%82%A2%E3%83%91%E3%83%AC%E3%83%AB/%E3%83%86%E3%82%A3%E3%83%BC%E3%82%B7%E3%83%A3%E3%83%84'
+        );
+        expect(MockedNextResponse.rewrite.mock.calls[5][0].toString()).toBe(
+          'http://localhost:3000/ja/categories/%E5%A5%B3%E6%80%A7/%E3%83%86%E3%82%A3%E3%83%BC%E3%82%B7%E3%83%A3%E3%83%84'
+        );
+      });
+
+      it('serves requests for non-ascii characters that are encoded', () => {
+        middlewareWithPathnames(
+          createMockRequest('/ja/' + encodeURIComponent('約'), 'ja')
+        );
+        middlewareWithPathnames(
+          createMockRequest('/ja/' + encodeURIComponent('ユーザー'), 'ja')
+        );
+        middlewareWithPathnames(
+          createMockRequest(
+            '/ja/' + encodeURIComponent('ユーザー') + '/1',
+            'ja'
+          )
+        );
+        middlewareWithPathnames(
+          createMockRequest(
+            '/ja/' +
+              encodeURIComponent('ニュース') +
+              '/happy-newyear-g5b116754',
+            'ja'
+          )
+        );
+        middlewareWithPathnames(
+          createMockRequest(
+            '/ja/' +
+              encodeURIComponent('製品') +
+              '/' +
+              encodeURIComponent('アパレル') +
+              '/' +
+              encodeURIComponent('ティーシャツ'),
+            'ja'
+          )
+        );
+        middlewareWithPathnames(
+          createMockRequest(
+            '/ja/' +
+              encodeURIComponent('カテゴリー') +
+              '/' +
+              encodeURIComponent('女性') +
+              '/' +
+              encodeURIComponent('ティーシャツ'),
+            'ja'
+          )
         );
 
         expect(MockedNextResponse.next).not.toHaveBeenCalled();

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -537,6 +537,29 @@ describe.each([
         ).toBe('/de/neuigkeiten/launch-party-3');
       });
 
+      it('handles UTF-8 encoded pathnames', () => {
+        const markup = renderToString(
+          <Link
+            href={{
+              pathname: '/news/[articleSlug]-[articleId]',
+              params: {
+                articleId: 3,
+                articleSlug: 'launch-party'
+              },
+              query: {
+                foo: 'こんにちは'
+              }
+            }}
+            locale="ja"
+          >
+            Create
+          </Link>
+        );
+        expect(markup).toContain(
+          'href="/ja/%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9/launch-party-3?foo=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF"'
+        );
+      });
+
       it('handles relative pathnames', () => {
         // @ts-expect-error -- Validation is still on
         const markup = renderToString(<Link href="test">Test</Link>);
@@ -603,6 +626,26 @@ describe.each([
         // @ts-expect-error -- Validation is still on
         expect(getPathname({locale: 'en', href: 'about'})).toBe('about');
       });
+
+      it('handles UTF-8 encoded pathnames', () => {
+        expect(
+          getPathname({
+            locale: 'ja',
+            href: {
+              pathname: '/news/[articleSlug]-[articleId]',
+              params: {
+                articleId: 3,
+                articleSlug: 'launch-party'
+              },
+              query: {
+                foo: 'こんにちは'
+              }
+            }
+          })
+        ).toBe(
+          '/ja/%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9/launch-party-3?foo=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF'
+        );
+      });
     });
 
     describe.each([
@@ -654,6 +697,27 @@ describe.each([
         // @ts-expect-error -- Validation is still on
         runInRender(() => redirectFn({href: 'about', locale: 'en'}));
         expect(nextRedirectFn).toHaveBeenLastCalledWith('about');
+      });
+
+      it('handles UTF-8 encoded pathnames', () => {
+        runInRender(() =>
+          redirectFn({
+            href: {
+              pathname: '/news/[articleSlug]-[articleId]',
+              params: {
+                articleId: 3,
+                articleSlug: 'launch-party'
+              },
+              query: {
+                foo: 'こんにちは'
+              }
+            },
+            locale: 'ja'
+          })
+        );
+        expect(nextRedirectFn).toHaveBeenLastCalledWith(
+          '/ja/%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9/launch-party-3?foo=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF'
+        );
       });
     });
   });

--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -412,6 +412,27 @@ describe("localePrefix: 'always', with `pathnames`", () => {
         // Still works
         expect(useNextRouter()[method]).toHaveBeenCalledWith('/en/unknown');
       });
+
+      it('handles UTF-8 encoded pathnames', () => {
+        invokeRouter((router) =>
+          router[method](
+            {
+              pathname: '/news/[articleSlug]-[articleId]',
+              params: {
+                articleId: 3,
+                articleSlug: 'launch-party'
+              },
+              query: {
+                foo: 'こんにちは'
+              }
+            },
+            {locale: 'ja'}
+          )
+        );
+        expect(useNextRouter()[method]).toHaveBeenCalledWith(
+          '/ja/%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9/launch-party-3?foo=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF'
+        );
+      });
     });
   });
 


### PR DESCRIPTION
TODO
- [ ] Docs