### PR TITLE
docs: clarify root layout requirements and `suppressHydrationWarning` usage with App Router

### DIFF
--- a/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
+++ b/docs/src/pages/docs/getting-started/app-router/with-i18n-routing.mdx
@@ -215,6 +215,28 @@ const withNextIntl = createNextIntlPlugin(
 
 </Details>
 
+### `src/app/layout.tsx` [#rootlayout]
+
+<Callout>
+<strong>Note on nested `<html>` and `<body>` tags:</strong>
+
+Next.js <strong>requires</strong> `<html>` and `<body>` in `app/layout.tsx`.
+If your `[locale]/layout.tsx` also contains them (it usually does so it can set `lang`), the tags are rendered twice and you’ll see hydration warnings in development.
+
+Add `suppressHydrationWarning` to <em>both</em> tags in <strong>both</strong> layouts
+
+</Callout>
+
+```tsx filename="app/layout.tsx"
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return (
+    <html suppressHydrationWarning>
+      <body suppressHydrationWarning>{children}</body>
+    </html>
+  );
+}
+```
+
 ### `src/app/[locale]/layout.tsx` [#layout]
 
 The `locale` that was matched by the middleware is available via the `locale` param and can be used to configure the document language. Additionally, we can use this place to pass configuration from `i18n/request.ts` to Client Components via `NextIntlClientProvider`.
@@ -238,8 +260,8 @@ export default async function LocaleLayout({
   }
 
   return (
-    <html lang={locale}>
-      <body>
+    <html lang={locale} suppressHydrationWarning>
+      <body suppressHydrationWarning>
         <NextIntlClientProvider>{children}</NextIntlClientProvider>
       </body>
     </html>


### PR DESCRIPTION
# ❓ Context
While working with `next-intl` and the App Router, I ran into hydration warnings due to `<html>` and `<body>` tags being duplicated in `app/layout.tsx` and `app/[locale]/layout.tsx`: 
```
Error: Missing <html> and <body> tags in the root layout. 
```

This issue was hard to track down until I found [issue #1385](https://github.com/amannn/next-intl/issues/1385), which explains the cause but doesn't currently link to a fix in the documentation.

# ✅ What This PR Does
This PR updates the documentation to:
- Clarify that `<html>` and `<body>` must exist in both layouts
- Show how to prevent hydration warnings by adding `suppressHydrationWarning`
- Provide full examples for both `app/layout.tsx` and `app/[locale]/layout.tsx`

# ✨ Wonderful Result
![image](https://github.com/user-attachments/assets/fa46ded6-8e0f-40a0-b900-29082c58e8ad)

