### PR TITLE
fix: Don't encode hashes in unknown pathnames

### DIFF
--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -21,13 +21,13 @@ const config: SizeLimitConfig = [
     name: "import {createNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/esm/production/navigation.react-client.js',
     import: '{createNavigation}',
-    limit: '2.325 KB'
+    limit: '2.335 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-server)",
     path: 'dist/esm/production/navigation.react-server.js',
     import: '{createNavigation}',
-    limit: '3.095 KB'
+    limit: '3.115 KB'
   },
   {
     name: "import * from 'next-intl/server' (react-client)",
@@ -42,7 +42,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl/middleware'",
     path: 'dist/esm/production/middleware.js',
-    limit: '9.645 KB'
+    limit: '9.695 KB'
   },
   {
     name: "import * from 'next-intl/routing'",

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -572,6 +572,12 @@ describe.each([
         expect(markup).toContain('href="/en/test"');
       });
 
+      it('handles unknown pathnames with a hash', () => {
+        // @ts-expect-error -- Validation is still on
+        const markup = renderToString(<Link href="/test#foo">Test</Link>);
+        expect(markup).toContain('href="/en/test#foo"');
+      });
+
       it('handles external links correctly', () => {
         const markup = renderToString(
           // @ts-expect-error -- Validation is still on

--- a/packages/next-intl/src/shared/utils.test.tsx
+++ b/packages/next-intl/src/shared/utils.test.tsx
@@ -221,9 +221,9 @@ describe('normalizeTrailingSlash', () => {
     });
 
     it('should handle pathnames with multiple segments', () => {
-      expect(normalizeTrailingSlash('/articles/tech/react-hooks/')).toBe(
-        '/articles/tech/react-hooks'
-      );
+      expect(
+        normalizeTrailingSlash('/categories/development/programming/')
+      ).toBe('/categories/development/programming');
     });
 
     it('handles pathnames that contain a hash', () => {

--- a/packages/next-intl/src/shared/utils.test.tsx
+++ b/packages/next-intl/src/shared/utils.test.tsx
@@ -1,8 +1,9 @@
-import {describe, expect, it} from 'vitest';
+import {beforeEach, describe, expect, it} from 'vitest';
 import {
   getSortedPathnames,
   hasPathnamePrefixed,
   matchesPathname,
+  normalizeTrailingSlash,
   prefixPathname,
   unprefixPathname
 } from './utils.js';
@@ -171,5 +172,62 @@ describe('getSortedPathnames', () => {
       '/articles/[category]/new',
       '/articles/[category]/[...articleSlug]'
     ]);
+  });
+});
+
+describe('normalizeTrailingSlash', () => {
+  describe('with trailing slash enabled', () => {
+    beforeEach(() => {
+      process.env._next_intl_trailing_slash = 'true';
+      return () => {
+        delete process.env._next_intl_trailing_slash;
+      };
+    });
+
+    it('should add trailing slash when pathname does not end with slash', () => {
+      expect(normalizeTrailingSlash('/about')).toBe('/about/');
+    });
+
+    it('should not modify pathname when it already ends with slash', () => {
+      expect(normalizeTrailingSlash('/about/')).toBe('/about/');
+    });
+
+    it('should not modify root path', () => {
+      expect(normalizeTrailingSlash('/')).toBe('/');
+    });
+
+    it('should handle pathnames with multiple segments', () => {
+      expect(
+        normalizeTrailingSlash('/categories/development/programming/')
+      ).toBe('/categories/development/programming/');
+    });
+
+    it('handles pathnames that contain a hash', () => {
+      expect(normalizeTrailingSlash('/about#section')).toBe('/about/#section');
+    });
+  });
+
+  describe('with trailing slash disabled', () => {
+    it('should remove trailing slash when pathname ends with slash', () => {
+      expect(normalizeTrailingSlash('/about/')).toBe('/about');
+    });
+
+    it('should not modify pathname when it already has no trailing slash', () => {
+      expect(normalizeTrailingSlash('/about')).toBe('/about');
+    });
+
+    it('should not modify root path', () => {
+      expect(normalizeTrailingSlash('/')).toBe('/');
+    });
+
+    it('should handle pathnames with multiple segments', () => {
+      expect(normalizeTrailingSlash('/articles/tech/react-hooks/')).toBe(
+        '/articles/tech/react-hooks'
+      );
+    });
+
+    it('handles pathnames that contain a hash', () => {
+      expect(normalizeTrailingSlash('/about#section')).toBe('/about#section');
+    });
   });
 });

--- a/packages/next-intl/src/shared/utils.tsx
+++ b/packages/next-intl/src/shared/utils.tsx
@@ -72,16 +72,24 @@ export function getLocalizedTemplate<AppLocales extends Locales>(
 export function normalizeTrailingSlash(pathname: string) {
   const trailingSlash = hasTrailingSlash();
 
-  if (pathname !== '/') {
-    const pathnameEndsWithSlash = pathname.endsWith('/');
+  const [path, ...hashParts] = pathname.split('#');
+  const hash = hashParts.join('#');
+
+  let normalizedPath = path;
+  if (normalizedPath !== '/') {
+    const pathnameEndsWithSlash = normalizedPath.endsWith('/');
     if (trailingSlash && !pathnameEndsWithSlash) {
-      pathname += '/';
+      normalizedPath += '/';
     } else if (!trailingSlash && pathnameEndsWithSlash) {
-      pathname = pathname.slice(0, -1);
+      normalizedPath = normalizedPath.slice(0, -1);
     }
   }
 
-  return pathname;
+  if (hash) {
+    normalizedPath += '#' + hash;
+  }
+
+  return normalizedPath;
 }
 
 export function matchesPathname(


### PR DESCRIPTION
Addresses https://github.com/amannn/next-intl/discussions/1932

**Prerelease:**

```
npm install next-intl@0.0.0-canary-4ada87c
```