### PR TITLE
fix: Add friendly error message when failing to load current Next.js version

### DIFF
--- a/packages/next-intl/src/plugin/hasStableTurboConfig.tsx
+++ b/packages/next-intl/src/plugin/hasStableTurboConfig.tsx
@@ -7,7 +7,7 @@ function getCurrentVersion() {
     return pkg.version;
   } catch (error) {
     throw new Error(
-      'Failed to get current Next.js version. This can happen if next-intl/plugin is imported into your app code outside of your next.config.js.,
+      'Failed to get current Next.js version. This can happen if next-intl/plugin is imported into your app code outside of your next.config.js.',
       {cause: error}
     );
   }

--- a/packages/next-intl/src/plugin/hasStableTurboConfig.tsx
+++ b/packages/next-intl/src/plugin/hasStableTurboConfig.tsx
@@ -7,7 +7,7 @@ function getCurrentVersion() {
     return pkg.version;
   } catch (error) {
     throw new Error(
-      'Failed to get current Next.js version. This can happen if next-intl/plugin is imported outside of your next.config.js, like in your test setup',
+      'Failed to get current Next.js version. This can happen if next-intl/plugin is imported into your app code outside of your next.config.js.,
       {cause: error}
     );
   }

--- a/packages/next-intl/src/plugin/hasStableTurboConfig.tsx
+++ b/packages/next-intl/src/plugin/hasStableTurboConfig.tsx
@@ -1,8 +1,17 @@
-// eslint-disable-next-line import/order
 import {createRequire} from 'module';
 
-const require = createRequire(import.meta.url);
-const pkg = require('next/package.json');
+function getCurrentVersion() {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require('next/package.json');
+    return pkg.version;
+  } catch (error) {
+    throw new Error(
+      'Failed to get current Next.js version. This can happen if next-intl/plugin is imported outside of your next.config.js, like in your test setup',
+      {cause: error}
+    );
+  }
+}
 
 function compareVersions(version1: string, version2: string) {
   const v1Parts = version1.split('.').map(Number);
@@ -17,5 +26,6 @@ function compareVersions(version1: string, version2: string) {
   return 0;
 }
 
-const hasStableTurboConfig = compareVersions(pkg.version, '15.3.0') >= 0;
+const hasStableTurboConfig =
+  compareVersions(getCurrentVersion(), '15.3.0') >= 0;
 export default hasStableTurboConfig;


### PR DESCRIPTION
As discussed in https://github.com/amannn/next-intl/discussions/1943, this adds a flightly friendlier error message for when `createRequire` is accidentally ran in an unexpected environment.
