### PR TITLE
Add node engine to docs and examples

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -39,5 +39,8 @@
     "prettier": "^3.3.3",
     "typescript": "^5.5.3"
   },
-  "prettier": "eslint-config-molindo/.prettierrc.json"
+  "prettier": "eslint-config-molindo/.prettierrc.json",
+  "engines": {
+    "node": ">=20.0.0"
+  }
 }

--- a/examples/example-app-router-migration/package.json
+++ b/examples/example-app-router-migration/package.json
@@ -28,5 +28,8 @@
     "singleQuote": true,
     "bracketSpacing": false,
     "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/examples/example-app-router-mixed-routing/package.json
+++ b/examples/example-app-router-mixed-routing/package.json
@@ -31,5 +31,8 @@
     "singleQuote": true,
     "bracketSpacing": false,
     "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/examples/example-app-router-next-auth/package.json
+++ b/examples/example-app-router-next-auth/package.json
@@ -30,5 +30,8 @@
     "singleQuote": true,
     "bracketSpacing": false,
     "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/examples/example-app-router-playground/package.json
+++ b/examples/example-app-router-playground/package.json
@@ -54,5 +54,8 @@
     "singleQuote": true,
     "bracketSpacing": false,
     "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/examples/example-app-router-single-locale/package.json
+++ b/examples/example-app-router-single-locale/package.json
@@ -29,5 +29,8 @@
     "singleQuote": true,
     "bracketSpacing": false,
     "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/examples/example-app-router-without-i18n-routing/package.json
+++ b/examples/example-app-router-without-i18n-routing/package.json
@@ -38,5 +38,8 @@
     "singleQuote": true,
     "bracketSpacing": false,
     "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/examples/example-app-router/package.json
+++ b/examples/example-app-router/package.json
@@ -40,5 +40,8 @@
     "singleQuote": true,
     "bracketSpacing": false,
     "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/examples/example-pages-router-advanced/package.json
+++ b/examples/example-pages-router-advanced/package.json
@@ -35,5 +35,8 @@
     "singleQuote": true,
     "bracketSpacing": false,
     "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/examples/example-pages-router-legacy/package.json
+++ b/examples/example-pages-router-legacy/package.json
@@ -20,5 +20,8 @@
     "singleQuote": true,
     "bracketSpacing": false,
     "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/examples/example-pages-router/package.json
+++ b/examples/example-pages-router/package.json
@@ -29,5 +29,8 @@
     "singleQuote": true,
     "bracketSpacing": false,
     "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/examples/example-react-native/package.json
+++ b/examples/example-react-native/package.json
@@ -23,5 +23,8 @@
   "devDependencies": {
     "@babel/core": "^7.26.10"
   },
-  "private": true
+  "private": true,
+  "engines": {
+    "node": ">=20.0.0"
+  }
 }

--- a/examples/example-use-intl/package.json
+++ b/examples/example-use-intl/package.json
@@ -25,5 +25,8 @@
     "singleQuote": true,
     "bracketSpacing": false,
     "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }


### PR DESCRIPTION
Add Node.js engine requirement to `package.json` files in `docs` and `examples` to specify minimum compatible version.

---
<a href="https://cursor.com/background-agent?bcId=bc-499dfa1e-6067-43da-9271-6c521ca2c077">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-499dfa1e-6067-43da-9271-6c521ca2c077">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

