### PR TITLE
fix: Don't create messages declaration file when running `next {start,info,telemetry}`

### DIFF
--- a/packages/next-intl/src/plugin/createMessagesDeclaration.tsx
+++ b/packages/next-intl/src/plugin/createMessagesDeclaration.tsx
@@ -14,6 +14,18 @@ function runOnce(fn: () => void) {
 export default function createMessagesDeclaration(
   messagesPaths: Array<string>
 ) {
+  const shouldRun = [
+    'dev',
+    'build',
+    'typegen'
+    // Note: The 'lint' task doesn't consult the
+    // Next.js config, so we can't detect it here.
+  ].some((arg) => process.argv.includes(arg));
+
+  if (!shouldRun) {
+    return;
+  }
+
   // Next.js can call the Next.js config multiple
   // times - ensure we only run once.
   runOnce(() => {


### PR DESCRIPTION
When using [`createMessagesDeclaration`](https://next-intl.dev/docs/workflows/typescript#messages-arguments), we previously created the declaration for all of these scenarios:

1. `next dev` (incl. a watcher)
2. `next build`
3. `next typegen` (new in Next.js 15.5)
4. `next start`
5. `next info`
6. `next telemetry`

(not for `next lint` though, because it doesn't consult `next.config.js`)

The last three items in this list don't really require creating a declaration, so as of this PR we no longer do this.

On the other hand, the newly introduced [`next typegen`](https://nextjs.org/docs/app/api-reference/cli/next#next-typegen-options) comes in really handy to continue creating the declaration.