### PR TITLE
feat: Add `withFallback` method for per-message fallback control

### DIFF
--- a/packages/use-intl/src/core/createBaseTranslator.tsx
+++ b/packages/use-intl/src/core/createBaseTranslator.tsx
@@ -435,5 +435,41 @@ function createBaseTranslatorImpl<
     }
   };
 
+  translateFn.withFallback = (
+    key: string,
+    fallback: string | (() => string),
+    /** Whether to attempt to resolve fallback as a translation key. Defaults to true. */
+    translateFallback = true,
+    /** Key value pairs for values to interpolate into the message. */
+    values?: TranslationValues,
+    /** Provide custom formats for numbers, dates and times. */
+    formats?: Formats
+  ): string => {
+    if (translateFn.has(key)) {
+      const result = translateBaseFn(key, values, formats);
+      if (typeof result === 'string') {
+        return result;
+      }
+    }
+
+    const fallbackValue =
+      typeof fallback === 'function' ? fallback() : fallback;
+
+    if (translateFallback) {
+      if (!translateFn.has(fallbackValue)) {
+        if (process.env.NODE_ENV !== 'production') {
+          throw new Error(`Fallback key '${fallbackValue}' does not exist`);
+        }
+      }
+
+      const fallbackResult = translateBaseFn(fallbackValue);
+      if (typeof fallbackResult === 'string') {
+        return fallbackResult;
+      }
+    }
+
+    return fallbackValue;
+  };
+
   return translateFn;
 }

--- a/packages/use-intl/src/core/createTranslator.test.tsx
+++ b/packages/use-intl/src/core/createTranslator.test.tsx
@@ -882,3 +882,36 @@ describe('t.raw', () => {
     expect(t.raw('rich')).toBe('<b>Hello <i>{name}</i>!</b>');
   });
 });
+
+describe('t.withFallback', () => {
+  it('handles missing messages with fallbacks', () => {
+    const t = createTranslator({
+      locale: 'en',
+      messages: {
+        Home: {fallback: 'Default message'}
+      } as any
+    });
+
+    // Valid translation key fallback
+    expect(t.withFallback('Home.missing', 'Home.fallback')).toBe(
+      'Default message'
+    );
+
+    // Literal string fallback
+    expect(t.withFallback('Home.missing', 'Literal text', false)).toBe(
+      'Literal text'
+    );
+
+    // Invalid fallback key
+    expect(() => t.withFallback('Home.missing', 'Invalid.key')).toThrow();
+
+    // Dynamic function that resolves to a literal string
+    expect(t.withFallback('Home.missing', () => 'Dynamic', false)).toBe(
+      'Dynamic'
+    );
+    // Dynamic function that resolves to a valid translation key
+    expect(t.withFallback('Home.missing', () => 'Home.fallback')).toBe(
+      'Default message'
+    );
+  });
+});

--- a/packages/use-intl/src/core/createTranslator.tsx
+++ b/packages/use-intl/src/core/createTranslator.tsx
@@ -163,6 +163,19 @@ export default function createTranslator<
   has<TargetKey extends NamespacedMessageKeys<TranslatorMessages, Namespace>>(
     key: TargetKey
   ): boolean;
+
+  // `withFallback`
+  withFallback<
+    TargetKey extends NamespacedMessageKeys<TranslatorMessages, Namespace>
+  >(
+    key: TargetKey,
+    fallback: string | (() => string),
+    translateFallback?: boolean,
+    ...args: TranslateArgs<
+      NamespacedValue<TranslatorMessages, Namespace, TargetKey>,
+      RichTagsFunction
+    >
+  ): string;
 } {
   // We have to wrap the actual function so the type inference for the optional
   // namespace works correctly. See https://stackoverflow.com/a/71529575/343045

--- a/packages/use-intl/src/react/useTranslations.test.tsx
+++ b/packages/use-intl/src/react/useTranslations.test.tsx
@@ -605,6 +605,36 @@ describe('t.has', () => {
   });
 });
 
+describe('t.withFallback', () => {
+  function Component() {
+    const t = useTranslations();
+    return (
+      <>
+        <div data-testid="fallback-key">
+          {t.withFallback('missing', 'Home.fallback')}
+        </div>
+        <div data-testid="fallback-literal">
+          {t.withFallback('missing', 'Literal text', false)}
+        </div>
+        <div data-testid="fallback-function">
+          {t.withFallback('missing', () => 'Dynamic', false)}
+        </div>
+      </>
+    );
+  }
+
+  it('returns the fallback value when the message is missing', () => {
+    render(
+      <IntlProvider locale="en" messages={{Home: {fallback: 'Default message'}}}>
+        <Component />
+      </IntlProvider>
+    );
+    screen.getByText('Default message');
+    screen.getByText('Literal text');
+    screen.getByText('Dynamic');
+  });
+});
+
 describe('error handling', () => {
   it('allows to configure a fallback', () => {
     const onError = vi.fn();


### PR DESCRIPTION
This is an extension to an already closed issue #88

As far as I'm aware (as a newbie...), currently the only ways of "falling back" are passing a `getMessageFallback` to the provider, or getting messages from another locale. 
The former is too restrictive as it works on a global scale (unless I'm tripping), while the latter additionally may not always work (`MISSING_MESSAGE` for example occurs from the entire messages objects whether you're using a fallback locale or not, so merging messages doesn't do that much here if the message isn't available in other locales).
I thought it would be neat if we had a shorthand way of providing fallback on an individual message request basis, i.e.:
```js
t.withFallback("key", "some fallback")
```

For example, the code may fail to retrieve a message translation if the key does not exist (`MISSING_MESSAGE`). For my usage in the app I'm working on, I'm forced to call `t.has("key")` and conditionally render `t("key")` or a fallback if I don't want the code to just error out:
```js
someName = tItems.has(`${someId}.name`)
      ? t(`${someId}.name`)
      : `Hello ${someId}`;
```
If I want to provide specialized fallback for specific messages, this gets cumbersome with scale. So I had to use a custom hook:
```js
export function useAppTranslations(namespace?: string) {

  const t = useTranslations(namespace);

  const safeTranslate = (
    key: string,
    fallback?: unknown
  ): string => {
    if (!fallback) {
      fallback = "some fallback";
    }
    try {
      return t.has(key) ? t(key) : fallback;
    } catch {
      return fallback;
    }
  };

  return {
    safeTranslate
  };
}
```
Then I just get `safeTranslate` and use it everywhere I need. 
```js
someName = safeTranslate(`${someId}.name`, `Hello ${someId}`);
```
But this was just a hack and came with its own issues, such as breaking integration with VSCode intl extensions.

This PR adds a `withFallback` method that utilizes the `has` method to provide optional fallback in case an error occurs with receiving the message. It supports two arguments; 
- `fallback`: a `string` or a function that resolves to a string.
- `translateFallback`: a `boolean` that defaults to true, which controls whether the translator should attempt to use the `fallback` argument provided as a translation key then output it as fallback.

P.S. I kind of would have really liked for `fallback` to have been a standard optional argument of the base `t` call, but I felt like that would require me to dive deeper into the code to do.