### PR TITLE
fix: Avoid double-encoding of already encoded params

### DIFF
--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -15,7 +15,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-server)",
     path: 'dist/esm/production/index.react-server.js',
-    limit: '14.095 KB'
+    limit: '14.105 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-client)",

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -560,6 +560,24 @@ describe.each([
         );
       });
 
+      it("doesn't double-encode already encoded params", () => {
+        const markup = renderToString(
+          <Link
+            href={{
+              pathname: '/news/[articleSlug]-[articleId]',
+              params: {
+                articleId: 3,
+                articleSlug: encodeURIComponent('launch / party')
+              }
+            }}
+            locale="en"
+          >
+            Create
+          </Link>
+        );
+        expect(markup).toContain('href="/en/news/launch%20%2F%20party-3"');
+      });
+
       it('handles relative pathnames', () => {
         // @ts-expect-error -- Validation is still on
         const markup = renderToString(<Link href="test">Test</Link>);

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -206,10 +206,7 @@ function encodePathname(pathname: string) {
   //
   // Therefore, the bottom line is that next-intl should take care of encoding non-ASCII
   // characters in all cases, but can rely on `new URL()` to not double-encode characters.
-  return pathname
-    .split('/')
-    .map((segment) => encodeURIComponent(segment))
-    .join('/');
+  return new URL(pathname, 'http://l').pathname;
 }
 
 export function getRoute<AppLocales extends Locales>(


### PR DESCRIPTION
… and allow users to encode params as they desire.

Fixes #2014