### PR TITLE
docs: Correct usage of quotes for escaping

### DIFF
--- a/docs/src/pages/docs/usage/translations.mdx
+++ b/docs/src/pages/docs/usage/translations.mdx
@@ -318,10 +318,10 @@ t('message', {locale: locale.replaceAll('-', '_')});
 
 ### Escaping
 
-Since curly braces are used for [interpolating arguments](/docs/usage/translations#arguments), you can escape them with the `'` marker to use the actual symbol in messages:
+Since curly braces are used for [interpolating arguments](/docs/usage/translations#arguments), you can wrap them in single quotes (`'`) to use the actual symbol in messages:
 
 ```json filename="en.json"
-"message": "Escape curly braces with single quotes (e.g. '{name'})"
+"message": "Escape curly braces with single quotes (e.g. '{name}')"
 ```
 
 ```js

--- a/packages/use-intl/src/core/createTranslator.test.tsx
+++ b/packages/use-intl/src/core/createTranslator.test.tsx
@@ -417,7 +417,7 @@ describe('type safety', () => {
 
     it('validates escaped', () => {
       const t = translateMessage(
-        "Escape curly braces with single quotes (e.g. '{name')"
+        "Escape curly braces with single quotes (e.g. '{name}')"
       );
 
       t('msg');

--- a/packages/use-intl/src/react/useTranslations.test.tsx
+++ b/packages/use-intl/src/react/useTranslations.test.tsx
@@ -75,13 +75,18 @@ it('handles basic interpolation', () => {
 });
 
 it('can escape curly brackets', () => {
-  renderMessage("Hello '{name'}");
+  renderMessage("Hello '{name}'");
   screen.getByText('Hello {name}');
+});
+
+it('can can use single quotes', () => {
+  renderMessage("Hello 'name'");
+  screen.getByText("Hello 'name'");
 });
 
 it('can escape curly brackets in production', () => {
   vi.stubEnv('NODE_ENV', 'production');
-  renderMessage("Hello '{name'}");
+  renderMessage("Hello '{name}'");
   screen.getByText('Hello {name}');
   vi.unstubAllEnvs();
 });


### PR DESCRIPTION
Fixes #2032
