### PR TITLE
fix: Only call `NextResponse.rewrite` if really necessary

### DIFF
--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -42,7 +42,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl/middleware'",
     path: 'dist/esm/production/middleware.js',
-    limit: '9.695 KB'
+    limit: '9.7 KB'
   },
   {
     name: "import * from 'next-intl/routing'",

--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -257,42 +257,30 @@ describe('prefix-based routing', () => {
 
     it('serves requests for other locales when prefixed', () => {
       middleware(createMockRequest('/de'));
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.next).toHaveBeenCalled();
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-        'http://localhost:3000/de'
-      );
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
     });
 
     it('serves requests for other locales when prefixed with a trailing slash', () => {
       middleware(createMockRequest('/de/'));
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-        'http://localhost:3000/de'
-      );
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.next).toHaveBeenCalled();
     });
 
     it('serves requests for other locales with query params at the root', () => {
       middleware(createMockRequest('/de?sort=asc'));
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.next).toHaveBeenCalled();
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-        'http://localhost:3000/de?sort=asc'
-      );
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
     });
 
     it('serves requests for other locales with query params at a nested path', () => {
       middleware(createMockRequest('/de/list?sort=asc'));
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
+      expect(MockedNextResponse.next).toHaveBeenCalled();
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-        'http://localhost:3000/de/list?sort=asc'
-      );
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
     });
 
     it('can turn off the cookie', () => {
@@ -334,10 +322,10 @@ describe('prefix-based routing', () => {
         })
       );
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+      expect(MockedNextResponse.next).toHaveBeenCalled();
       expect(
-        MockedNextResponse.rewrite.mock.calls[0][1]?.request?.headers?.get(
+        MockedNextResponse.next.mock.calls[0][0]?.request?.headers?.get(
           'x-test'
         )
       ).toBe('test');
@@ -502,12 +490,10 @@ describe('prefix-based routing', () => {
         it('uses the internal default for undefined entries', () => {
           middlewareWithPathnames(createMockRequest('/partially-available'));
           middlewareWithPathnames(createMockRequest('/ja/partially-available'));
-          expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(2);
+          expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(1);
+          expect(MockedNextResponse.next).toHaveBeenCalledTimes(1);
           expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
             'http://localhost:3000/en/partially-available'
-          );
-          expect(MockedNextResponse.rewrite.mock.calls[1][0].toString()).toBe(
-            'http://localhost:3000/ja/partially-available'
           );
         });
       });
@@ -560,12 +546,9 @@ describe('prefix-based routing', () => {
 
       it('serves requests for a non-default locale at the root', () => {
         middlewareWithPathnames(createMockRequest('/de', 'de'));
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.next).not.toHaveBeenCalled(); // We rewrite just in case
+        expect(MockedNextResponse.next).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://localhost:3000/de'
-        );
       });
 
       it('serves requests for a non-default locale at nested paths for "de"', () => {
@@ -1173,21 +1156,15 @@ describe('prefix-based routing', () => {
     it('serves requests for the default locale', () => {
       middleware(createMockRequest('/en'));
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-        'http://localhost:3000/en'
-      );
+      expect(MockedNextResponse.next).toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
     });
 
     it('serves requests for non-default locales', () => {
       middleware(createMockRequest('/de'));
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-        'http://localhost:3000/de'
-      );
+      expect(MockedNextResponse.next).toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
     });
 
     it('handles malformed urls', () => {
@@ -1324,11 +1301,8 @@ describe('prefix-based routing', () => {
       it('serves requests for the default locale at the root', () => {
         middlewareWithPathnames(createMockRequest('/en', 'en'));
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://localhost:3000/en'
-        );
+        expect(MockedNextResponse.next).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('serves requests for the default locale at nested paths', () => {
@@ -1342,30 +1316,15 @@ describe('prefix-based routing', () => {
         middlewareWithPathnames(createMockRequest('/en/categories/new', 'en'));
 
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(6);
-        expect(
-          MockedNextResponse.rewrite.mock.calls.map((call) =>
-            call[0].toString()
-          )
-        ).toEqual([
-          'http://localhost:3000/en/about',
-          'http://localhost:3000/en/users',
-          'http://localhost:3000/en/users/1',
-          'http://localhost:3000/en/news/happy-newyear-g5b116754',
-          'http://localhost:3000/en/categories',
-          'http://localhost:3000/en/categories/new'
-        ]);
+        expect(MockedNextResponse.next).toHaveBeenCalledTimes(6);
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('serves requests for a non-default locale at the root', () => {
         middlewareWithPathnames(createMockRequest('/de', 'de'));
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.next).toHaveBeenCalled();
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://localhost:3000/de'
-        );
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('serves requests for a non-default locale at nested paths', () => {
@@ -1398,15 +1357,9 @@ describe('prefix-based routing', () => {
       it('prioritizes static routes over dynamic and catch-all routes for the default locale', () => {
         middlewareWithPathnames(createMockRequest('/en/products/add', 'en'));
         middlewareWithPathnames(createMockRequest('/en/categories/new', 'en'));
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.next).toHaveBeenCalledTimes(2);
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(2);
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://localhost:3000/en/products/add'
-        );
-        expect(MockedNextResponse.rewrite.mock.calls[1][0].toString()).toBe(
-          'http://localhost:3000/en/categories/new'
-        );
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('prioritizes more specific, static routes over dynamic routes for the default locale', () => {
@@ -1416,15 +1369,9 @@ describe('prefix-based routing', () => {
         middlewareWithPathnames(
           createMockRequest('/en/articles/technology/latest-trends', 'en')
         );
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
+        expect(MockedNextResponse.next).toHaveBeenCalledTimes(2);
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(2);
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://localhost:3000/en/articles/technology/just-in'
-        );
-        expect(MockedNextResponse.rewrite.mock.calls[1][0].toString()).toBe(
-          'http://localhost:3000/en/articles/technology/latest-trends'
-        );
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('prioritizes static routes over dynamic and catch-all routes for the non-default locale', () => {
@@ -1696,15 +1643,17 @@ describe('prefix-based routing', () => {
           }
         );
 
+        it.each([['/en/products/t-shirts'], ['/en/products/t-shirts/']])(
+          'serves requests with dynamic params',
+          (pathname) => {
+            middlewareWithPathnames(createMockRequest(pathname));
+            expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
+            expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
+            expect(MockedNextResponse.next).toHaveBeenCalled();
+          }
+        );
+
         it.each([
-          [
-            '/en/products/t-shirts',
-            'http://localhost:3000/en/products/t-shirts/'
-          ],
-          [
-            '/en/products/t-shirts/',
-            'http://localhost:3000/en/products/t-shirts/'
-          ],
           [
             '/de/produkte/t-shirts',
             'http://localhost:3000/de/products/t-shirts/'
@@ -1713,7 +1662,7 @@ describe('prefix-based routing', () => {
             '/de/produkte/t-shirts/',
             'http://localhost:3000/de/products/t-shirts/'
           ]
-        ])('renders pages with dynamic params', (pathname, rewrite) => {
+        ])('rewrites requests with dynamic params', (pathname, rewrite) => {
           middlewareWithPathnames(createMockRequest(pathname));
           expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
           expect(MockedNextResponse.next).not.toHaveBeenCalled();
@@ -1743,11 +1692,8 @@ describe('prefix-based routing', () => {
       it('serves requests for the default locale at the root', () => {
         middlewareWithPrefixes(createMockRequest('/en'));
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://localhost:3000/en'
-        );
+        expect(MockedNextResponse.next).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('handles overlapping custom prefixes correctly', () => {
@@ -1779,10 +1725,8 @@ describe('prefix-based routing', () => {
 
       it('serves requests for the default locale at nested paths', () => {
         middlewareWithPrefixes(createMockRequest('/en/about'));
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://localhost:3000/en/about'
-        );
+        expect(MockedNextResponse.next).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('serves requests for a prefixed locale at nested paths', () => {
@@ -1891,11 +1835,8 @@ describe('prefix-based routing', () => {
       it('serves requests for the default locale at the root', () => {
         middlewareWithPrefixes(createMockRequest('/en', 'en'));
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://localhost:3000/en'
-        );
+        expect(MockedNextResponse.next).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('serves requests for a prefixed locale at the root', () => {
@@ -1914,10 +1855,8 @@ describe('prefix-based routing', () => {
 
       it('serves requests for the default locale at nested paths', () => {
         middlewareWithPrefixes(createMockRequest('/en/about'));
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://localhost:3000/en/about'
-        );
+        expect(MockedNextResponse.next).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('serves requests for a prefixed locale at nested paths', () => {
@@ -2511,31 +2450,22 @@ describe('domain-based routing', () => {
     it('serves requests for non-default locales at the locale root', () => {
       middleware(createMockRequest('/fr', 'fr', 'http://ca.example.com'));
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-        'http://ca.example.com/fr'
-      );
+      expect(MockedNextResponse.next).toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
     });
 
     it('serves requests for non-default locales at the locale root when the accept-language header points to the default locale', () => {
       middleware(createMockRequest('/fr', 'en', 'http://ca.example.com'));
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-        'http://ca.example.com/fr'
-      );
+      expect(MockedNextResponse.next).toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
     });
 
     it('serves requests for non-default locales at sub paths', () => {
       middleware(createMockRequest('/fr/about', 'fr', 'http://ca.example.com'));
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-        'http://ca.example.com/fr/about'
-      );
+      expect(MockedNextResponse.next).toHaveBeenCalled();
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
     });
 
     it('removes a superfluous locale prefix of a secondary locale that is the default locale of the domain', () => {
@@ -2624,21 +2554,15 @@ describe('domain-based routing', () => {
       it('serves requests for unknown hosts and non-default locales at the locale root', () => {
         middleware(createMockRequest('/fr', 'fr', 'http://localhost'));
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://localhost/fr'
-        );
+        expect(MockedNextResponse.next).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('serves requests for unknown hosts and non-default locales at sub paths', () => {
         middleware(createMockRequest('/fr/about', 'fr', 'http://localhost'));
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://localhost/fr/about'
-        );
+        expect(MockedNextResponse.next).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('keeps the host of an unknown domain for easier local development', () => {
@@ -2701,11 +2625,8 @@ describe('domain-based routing', () => {
       it('serves requests for non-default locales at the locale root', () => {
         middleware(createMockRequest('/fr', 'fr', 'http://ca.example.com'));
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://ca.example.com/fr'
-        );
+        expect(MockedNextResponse.next).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
 
       it('serves requests for non-default locales at sub paths', () => {
@@ -2713,11 +2634,8 @@ describe('domain-based routing', () => {
           createMockRequest('/fr/about', 'fr', 'http://ca.example.com')
         );
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://ca.example.com/fr/about'
-        );
+        expect(MockedNextResponse.next).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
       });
     });
 
@@ -2934,12 +2852,9 @@ describe('domain-based routing', () => {
         middlewareWithPathnames(
           createMockRequest('/fr', 'fr', 'http://ca.example.com')
         );
-        expect(MockedNextResponse.rewrite).toHaveBeenCalled();
-        expect(MockedNextResponse.next).not.toHaveBeenCalled(); // We rewrite just in case
+        expect(MockedNextResponse.next).toHaveBeenCalled();
+        expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-          'http://ca.example.com/fr'
-        );
       });
 
       it('serves requests for a non-default locale at nested paths', () => {
@@ -2974,9 +2889,9 @@ describe('domain-based routing', () => {
           )
         );
 
-        expect(MockedNextResponse.next).not.toHaveBeenCalled();
         expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-        expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(6);
+        expect(MockedNextResponse.next).toHaveBeenCalledTimes(1);
+        expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(5);
         expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
           'http://ca.example.com/fr/about'
         );
@@ -2991,9 +2906,6 @@ describe('domain-based routing', () => {
         );
         expect(MockedNextResponse.rewrite.mock.calls[4][0].toString()).toBe(
           'http://ca.example.com/fr/products/vetements/t-shirts'
-        );
-        expect(MockedNextResponse.rewrite.mock.calls[5][0].toString()).toBe(
-          'http://ca.example.com/fr/categories/femmes/t-shirts'
         );
       });
 
@@ -3507,14 +3419,8 @@ describe('domain-based routing', () => {
       middleware(createMockRequest('/en/about', 'en', 'http://ca.example.com'));
 
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(2);
-      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-        'http://ca.example.com/en'
-      );
-      expect(MockedNextResponse.rewrite.mock.calls[1][0].toString()).toBe(
-        'http://ca.example.com/en/about'
-      );
+      expect(MockedNextResponse.next).toHaveBeenCalledTimes(2);
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
     });
 
     it('serves requests for non-default locales', () => {
@@ -3522,14 +3428,8 @@ describe('domain-based routing', () => {
       middleware(createMockRequest('/fr/about', 'fr', 'http://ca.example.com'));
 
       expect(MockedNextResponse.redirect).not.toHaveBeenCalled();
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).toHaveBeenCalledTimes(2);
-      expect(MockedNextResponse.rewrite.mock.calls[0][0].toString()).toBe(
-        'http://ca.example.com/fr'
-      );
-      expect(MockedNextResponse.rewrite.mock.calls[1][0].toString()).toBe(
-        'http://ca.example.com/fr/about'
-      );
+      expect(MockedNextResponse.next).toHaveBeenCalledTimes(2);
+      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
     });
 
     it('keeps the port when there is a x-forwarded-host', () => {

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -76,7 +76,7 @@ export default function createMiddleware<
       ) || [];
     const hasUnknownHost = resolvedRouting.domains != null && !domain;
 
-    function rewrite(url: string) {
+    function next(url: string) {
       const urlObj = new URL(url, request.url);
 
       if (request.nextUrl.basePath) {
@@ -236,7 +236,7 @@ export default function createMiddleware<
     if (!response) {
       if (unprefixedInternalPathname === '/' && !hasLocalePrefix) {
         if (isUnprefixedRouting) {
-          response = rewrite(
+          response = next(
             formatPathname(
               unprefixedInternalPathname,
               getLocaleAsPrefix(locale),
@@ -294,10 +294,10 @@ export default function createMiddleware<
                 if (domain?.domain !== pathDomain?.domain && !hasUnknownHost) {
                   response = redirect(externalHref, pathDomain?.domain);
                 } else {
-                  response = rewrite(internalHref);
+                  response = next(internalHref);
                 }
               } else {
-                response = rewrite(internalHref);
+                response = next(internalHref);
               }
             }
           } else {
@@ -305,7 +305,7 @@ export default function createMiddleware<
           }
         } else {
           if (isUnprefixedRouting) {
-            response = rewrite(internalHref);
+            response = next(internalHref);
           } else {
             response = redirect(
               formatPathname(

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -88,7 +88,15 @@ export default function createMiddleware<
 
       const headers = new Headers(request.headers);
       headers.set(HEADER_LOCALE_NAME, locale);
-      return NextResponse.rewrite(urlObj, {request: {headers}});
+
+      const isRewriteNecessary =
+        normalizeTrailingSlash(request.nextUrl.pathname) !==
+        normalizeTrailingSlash(urlObj.pathname);
+      if (isRewriteNecessary) {
+        return NextResponse.rewrite(urlObj, {request: {headers}});
+      } else {
+        return NextResponse.next({request: {headers}});
+      }
     }
 
     function redirect(url: string, redirectDomain?: string) {


### PR DESCRIPTION
Previously, we always called `.rewrite` just in case since it did no harm, but it seems like this messes with Vercel observability tools. This cleans it up to only call this function when really necessary.