### PR TITLE
fix(useExtracted): Fix inconsistent translation message ordering

### DIFF
--- a/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
+++ b/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
@@ -674,10 +674,13 @@ describe('json format', () => {
 
     await waitForWriteFileCalls(1);
 
-    expect(JSON.parse(filesystem.project.messages!['en.json'])).toEqual({
-      OpKKos: 'Hello!',
-      '7kKG3Q': 'World!'
-    });
+    expect(JSON.parse(filesystem.project.messages!['en.json']))
+      .toMatchInlineSnapshot(`
+        {
+          "7kKG3Q": "World!",
+          "OpKKos": "Hello!",
+        }
+      `);
 
     filesystem.project.messages!['de.json'] = '{}';
     simulateFileEvent('/project/messages', 'rename', 'de.json');

--- a/packages/next-intl/src/extractor/formatters/utils.test.tsx
+++ b/packages/next-intl/src/extractor/formatters/utils.test.tsx
@@ -1,26 +1,43 @@
-import {expect, it} from 'vitest';
-import type {ExtractedMessage} from '../types.js';
+import {describe, expect, it} from 'vitest';
 import {getSortedMessages} from './utils.js';
 
-it('uses message ids to break ties when reference paths match', () => {
-  const messages: Array<ExtractedMessage> = [
-    {id: 'beta', message: '', references: [{path: 'components/Footer.tsx'}]},
-    {id: 'alpha', message: '', references: [{path: 'components/Footer.tsx'}]},
-    {id: 'gamma', message: '', references: [{path: 'components/Header.tsx'}]}
-  ];
+describe('getSortedMessages', () => {
+  it('sorts by reference path', () => {
+    expect(
+      getSortedMessages([
+        {
+          id: 'a',
+          message: 'a',
+          references: [{path: 'components/B.tsx'}]
+        },
+        {
+          id: 'b',
+          message: 'b',
+          references: [{path: 'components/A.tsx'}]
+        }
+      ]).map((message) => message.id)
+    ).toEqual(['b', 'a']);
+  });
 
-  const sorted = getSortedMessages(messages).map((message) => message.id);
-
-  expect(sorted).toEqual(['alpha', 'beta', 'gamma']);
-});
-
-it('sorts by reference path before falling back to ids', () => {
-  const messages: Array<ExtractedMessage> = [
-    {id: 'beta', message: '', references: [{path: 'components/Header.tsx'}]},
-    {id: 'alpha', message: '', references: [{path: 'components/Footer.tsx'}]}
-  ];
-
-  const sorted = getSortedMessages(messages).map((message) => message.id);
-
-  expect(sorted).toEqual(['alpha', 'beta']);
+  it('uses message ids to break ties when reference paths match', () => {
+    expect(
+      getSortedMessages([
+        {
+          id: 'c',
+          message: 'b',
+          references: [{path: 'components/B.tsx'}]
+        },
+        {
+          id: 'b',
+          message: 'a',
+          references: [{path: 'components/A.tsx'}]
+        },
+        {
+          id: 'a',
+          message: 'c',
+          references: [{path: 'components/A.tsx'}]
+        }
+      ]).map((message) => message.id)
+    ).toEqual(['a', 'b', 'c']);
+  });
 });

--- a/packages/next-intl/src/extractor/formatters/utils.tsx
+++ b/packages/next-intl/src/extractor/formatters/utils.tsx
@@ -7,10 +7,10 @@ export function getSortedMessages(
     const pathA = messageA.references?.[0]?.path ?? '';
     const pathB = messageB.references?.[0]?.path ?? '';
 
-    if (pathA !== pathB) {
+    if (pathA === pathB) {
+      return messageA.id.localeCompare(messageB.id);
+    } else {
       return pathA.localeCompare(pathB);
     }
-
-    return messageA.id.localeCompare(messageB.id);
   });
 }


### PR DESCRIPTION
Use message ID as a tie-breaker in `getSortedMessages` in case reference paths match for a given message.

The previous tie-breaker, `a.message.localeCompare(b.message)`, was ineffective for untranslated messages (where `message` is an empty string), causing `getSortedMessages` to return `0` and rely on non-deterministic insertion order from parallel file extraction. Another issue is that `message` can be different across locales, therefore the order could vary across catalogs.

This fix ensures consistent ordering for messages, particularly those used in multiple files, by using a stable `message.id` for tie-breaking.
