### PR TITLE
fix: Move SWC cache to `node_modules`

### DIFF
--- a/packages/next-intl/src/extractor/extractor/MessageExtractor.tsx
+++ b/packages/next-intl/src/extractor/extractor/MessageExtractor.tsx
@@ -59,6 +59,7 @@ export default class MessageExtractor {
           decorators: true
         },
         experimental: {
+          cacheRoot: 'node_modules/.cache/swc',
           disableBuiltinTransformsForInternalTesting: true,
           disableAllLints: true,
           plugins: [


### PR DESCRIPTION
As mentioned [in the docs](https://swc.rs/docs/configuration/compilation#jscexperimentalcacheroot), avoids polluting the project root directory.