### PR TITLE
fix: Skip `accept-language` parsing when locale cookie is already present

### DIFF
--- a/packages/next-intl/src/middleware/syncCookie.tsx
+++ b/packages/next-intl/src/middleware/syncCookie.tsx
@@ -38,19 +38,26 @@ export default function syncCookie<
   if (!routing.localeCookie) return;
 
   const {name, ...rest} = routing.localeCookie;
-  const acceptLanguageLocale = getAcceptLanguageLocale(
-    request.headers,
-    domain?.locales || routing.locales,
-    routing.defaultLocale
-  );
   const hasLocaleCookie = request.cookies.has(name);
   const hasOutdatedCookie =
     hasLocaleCookie && request.cookies.get(name)?.value !== locale;
 
-  if (hasLocaleCookie ? hasOutdatedCookie : acceptLanguageLocale !== locale) {
+  if (hasOutdatedCookie) {
     response.cookies.set(name, locale, {
       path: request.nextUrl.basePath || undefined,
       ...rest
     });
+  } else if (!hasLocaleCookie) {
+    const acceptLanguageLocale = getAcceptLanguageLocale(
+      request.headers,
+      domain?.locales || routing.locales,
+      routing.defaultLocale
+    );
+    if (acceptLanguageLocale !== locale) {
+      response.cookies.set(name, locale, {
+        path: request.nextUrl.basePath || undefined,
+        ...rest
+      });
+    }
   }
 }


### PR DESCRIPTION
Fixes #2116

### Description
This PR addresses a severe performance bottleneck in the `syncCookie` middleware logic where `getAcceptLanguageLocale` (and consequently locale negotiation) was called unconditionally on every request.

As detailed in the linked issue, this caused linear performance degradation as the number of locales increased (~130ms overhead for ~140 locales).

### Changes
I optimized the `syncCookie` function to verify the cookie state *before* attempting to derive the locale from headers.
- **Before:** Header parsing & locale negotiation ran on every request.
- **After:** Header parsing only runs if:
1. No locale cookie exists.
2. OR the cookie is outdated/invalid.

### Benchmarks
Tested with ~140 locales in the reproduction repository provided in the issue.

**Before:**
```text
[next-intl-timing] syncCookie: 130ms
[next-intl-timing] total: 132ms
```
**After:**
```text
[next-intl-timing] syncCookie: 1ms
[next-intl-timing] total: 3ms
```

**Checklist**
- [x] I have verified that the issue is resolved locally.
- [x] I have verified that existing tests pass.