### PR TITLE
docs: fix plurality of other gender

### DIFF
--- a/docs/src/pages/docs/usage/extraction.mdx
+++ b/docs/src/pages/docs/usage/extraction.mdx
@@ -145,7 +145,7 @@ t(
 
 ```tsx
 // Select values
-t('{gender, select, female {She} male {He} other {They}} is online.', {
+t('{gender, select, female {She is} male {He is} other {They are}} online.', {
   gender: 'female'
 });
 ```

--- a/docs/src/pages/docs/usage/translations.mdx
+++ b/docs/src/pages/docs/usage/translations.mdx
@@ -289,7 +289,7 @@ To match a specific number, `next-intl` additionally supports the special `=valu
 To map identifiers to human readable labels, you can use the `select` argument that works similar to the `switch` statement in JavaScript:
 
 ```tsx filename="en.json"
-"message": "{gender, select, female {She} male {He} other {They}} is online."
+"message": "{gender, select, female {She is} male {He is} other {They are}} online."
 ```
 
 ```js

--- a/packages/use-intl/src/core/createTranslator.test.tsx
+++ b/packages/use-intl/src/core/createTranslator.test.tsx
@@ -353,7 +353,7 @@ describe('type safety', () => {
 
     it('validates selects', () => {
       const t = translateMessage(
-        '{gender, select, female {She} male {He} other {They}} is online.'
+        '{gender, select, female {She is} male {He is} other {They are}} online.'
       );
 
       t('msg', {gender: 'female'});
@@ -515,7 +515,7 @@ describe('type safety', () => {
           ordinalMessage:
             "It's your {year, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} birthday!",
           selectMessage:
-            '{gender, select, female {She} male {He} other {They}} is online.',
+            '{gender, select, female {She is} male {He is} other {They are}} online.',
           escapedParam:
             "Escape curly braces with single quotes (e.g. '{name'})",
           simpleRichText:

--- a/packages/use-intl/src/react/useTranslations.test.tsx
+++ b/packages/use-intl/src/react/useTranslations.test.tsx
@@ -190,7 +190,7 @@ it('supports pluralisation via tags like "zero" and "one" if the locale supports
 
 it('handles selects', () => {
   renderMessage(
-    '{gender, select, male {He} female {She} other {They}} is online.',
+    '{gender, select, male {He is} female {She is} other {They are}} online.',
     {gender: 'female'}
   );
   screen.getByText('She is online.');

--- a/rfcs/001-message-extraction.md
+++ b/rfcs/001-message-extraction.md
@@ -145,7 +145,7 @@ t(
 **Select values**
 
 ```tsx
-t('{gender, select, female {She} male {He} other {They}} is online.', {
+t('{gender, select, female {She is} male {He is} other {They are}} online.', {
   gender: 'female'
 });
 ```


### PR DESCRIPTION
If a person’s gender is unknown, the plural version is used to reference them. That also affects verbs.