### PR TITLE
test: Fix flaky `useExtracted` test

### DIFF
--- a/packages/next-intl/src/extractor/catalog/SaveScheduler.tsx
+++ b/packages/next-intl/src/extractor/catalog/SaveScheduler.tsx
@@ -26,12 +26,13 @@ export default class SaveScheduler<Value> {
       if (!this.isSaving && !this.saveTimeout) {
         // Not currently saving and no scheduled save, save immediately
         this.executeSave();
-      } else if (!this.isSaving && this.saveTimeout) {
-        // A save is scheduled but not running, reschedule to debounce
+      } else if (this.saveTimeout) {
+        // A save is already scheduled, reschedule to debounce
         this.scheduleSave();
       }
-      // If isSaving is true, the current save will check for pending
-      // resolvers when it completes and schedule another save if needed
+      // If isSaving is true and no timeout is scheduled, the current save
+      // will check for pending resolvers when it completes and schedule
+      // another save if needed (see finally block in executeSave)
     });
   }
 


### PR DESCRIPTION
Fixes a race condition in `SaveScheduler` to prevent flaky test results.

The `SaveScheduler` was prematurely resolving promises for save requests that had not yet executed, and had a missing scheduling case, leading to a race condition where tests would sometimes read stale data or fail due to incorrect save ordering. The fix ensures that each `schedule()` call's promise is resolved only after its specific save task has completed, making the scheduler robust against concurrent save requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-23e316ea-66af-47a6-b976-aa1f6529db2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23e316ea-66af-47a6-b976-aa1f6529db2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `SaveScheduler` to debounce saves, execute the latest task, and resolve/reject only the promises tied to that save, preventing race conditions.
> 
> - **SaveScheduler (`packages/next-intl/src/extractor/catalog/SaveScheduler.tsx`)**:
>   - Introduces `nextSaveTask` and captures resolvers per save; resolves/rejects only those for the running save.
>   - Refactors `schedule`/`executeSave` to no longer pass tasks directly; runs immediately when idle, debounces via `scheduleSave`, and guards concurrent runs.
>   - Clears and resets timeouts appropriately; after a save, schedules another if new requests arrived during execution.
>   - `destroy` now also clears `nextSaveTask`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d04ceb1c50c7e29a8593056f85914301009b9e5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->