### PR TITLE
fix: Fix null type check

### DIFF
--- a/packages/next-intl/src/extractor/format/codecs/JSONCodec.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/JSONCodec.tsx
@@ -42,7 +42,7 @@ function traverseMessages(
     const value = obj[key];
     if (typeof value === 'string') {
       callback(value, newPath);
-    } else if (typeof value === 'object') {
+    } else if (value !== null && typeof value === 'object') {
       traverseMessages(value, callback, newPath);
     }
   }


### PR DESCRIPTION
Fix `traverseMessages` to guard against `null` values to prevent a `TypeError` crash.

---
<a href="https://cursor.com/background-agent?bcId=bc-46163226-9fc9-4593-b5c8-6d952565dbe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46163226-9fc9-4593-b5c8-6d952565dbe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

