### PR TITLE
fix: Always set locale cookie when missing to ensure stable locale detection and preserve performance optimizations

### DIFF
--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -319,7 +319,7 @@ export default function createMiddleware<
       }
     }
 
-    syncCookie(request, response, locale, resolvedRouting, domain);
+    syncCookie(request, response, locale, resolvedRouting);
 
     if (
       !hasRedirected &&

--- a/packages/next-intl/src/middleware/syncCookie.tsx
+++ b/packages/next-intl/src/middleware/syncCookie.tsx
@@ -5,13 +5,11 @@ import type {
   ResolvedRoutingConfig
 } from '../routing/config.js';
 import type {
-  DomainConfig,
   DomainsConfig,
   LocalePrefixMode,
   Locales,
   Pathnames
 } from '../routing/types.js';
-import {getAcceptLanguageLocale} from './resolveLocale.js';
 
 export default function syncCookie<
   AppLocales extends Locales,
@@ -32,32 +30,16 @@ export default function syncCookie<
     'locales' | 'defaultLocale'
   > & {
     localeCookie: InitializedLocaleCookieConfig;
-  },
-  domain?: DomainConfig<AppLocales>
+  }
 ) {
   if (!routing.localeCookie) return;
 
   const {name, ...rest} = routing.localeCookie;
-  const hasLocaleCookie = request.cookies.has(name);
-  const hasOutdatedCookie =
-    hasLocaleCookie && request.cookies.get(name)?.value !== locale;
 
-  if (hasOutdatedCookie) {
+  if (request.cookies.get(name)?.value !== locale) {
     response.cookies.set(name, locale, {
       path: request.nextUrl.basePath || undefined,
       ...rest
     });
-  } else if (!hasLocaleCookie) {
-    const acceptLanguageLocale = getAcceptLanguageLocale(
-      request.headers,
-      domain?.locales || routing.locales,
-      routing.defaultLocale
-    );
-    if (acceptLanguageLocale !== locale) {
-      response.cookies.set(name, locale, {
-        path: request.nextUrl.basePath || undefined,
-        ...rest
-      });
-    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/amannn/next-intl/issues/2171

## Description
This PR fixes a logic gap in `syncCookie` where the locale cookie was not being written if:
- No locale cookie existed, and
- The resolved locale matched the locale derived from the `Accept-Language` header.
This resulted in a situation where users whose browser language matched the app’s current locale (e.g. browser fr-FR and route /fr-FR) would never receive a locale cookie.

### Impact
Because no cookie was set in this scenario:
- Locale negotiation (`getAcceptLanguageLocale`) had to run on every request
- The performance benefit introduced in my previous PR (https://github.com/amannn/next-intl/pull/2143) — was lost for these users

This became especially visible in setups with many locales where the `Accept-Language` negotiation cost grows linearly.``

## Changes
### Before
`syncCookie` only set the cookie if:
```tsx
acceptLanguageLocale !== locale
```
This prevented cookie creation whenever the header matched the active locale, which is a common and valid case.
### After
`syncCookie` now sets the cookie whenever it is missing, regardless of the Accept-Language header value:
- If cookie is outdated → update it
- If cookie is missing → write it
- No header logic involved in this decision
This aligns with the fact that the locale has already been resolved before reaching syncCookie, and the cookie must simply reflect that final state.

The `domain` parameter is also removed since it became unused after simplifying the logic.

### Result
- Stable locale persistence
- Correct behavior for first-time visitors
- Performance optimization preserved for all users
- Simpler and more predictable code

### Checklist
- [x] I have verified that the fix behaves correctly across all routing modes (always, never, as-needed).
- [x] I have confirmed that performance improvements from the previous PR remain active in all scenarios.
- [x] Existing tests pass successfully.