### PR TITLE
fix: Only run extraction for `next dev` and `next build`

### DIFF
--- a/packages/next-intl/src/plugin/extractor/initExtractionCompiler.tsx
+++ b/packages/next-intl/src/plugin/extractor/initExtractionCompiler.tsx
@@ -14,10 +14,25 @@ export default function initExtractionCompiler(pluginConfig: PluginConfig) {
     return;
   }
 
-  runOnce(() => {
-    // Avoid rollup's `replace` plugin to compile this away
-    const isDevelopment = process.env['NODE_ENV'.trim()] === 'development';
+  // Avoid rollup's `replace` plugin to compile this away
+  const isDevelopment = process.env['NODE_ENV'.trim()] === 'development';
 
+  // Avoid running for:
+  // - info
+  // - start
+  // - typegen
+  //
+  // Doesn't consult Next.js config anyway:
+  // - telemetry
+  // - lint
+  //
+  // What remains are:
+  // - dev (NODE_ENV=development)
+  // - build (NODE_ENV=production)
+  const shouldRun = isDevelopment || process.argv.includes('build');
+  if (!shouldRun) return;
+
+  runOnce(() => {
     const extractorConfig: ExtractorConfig = {
       srcPath: experimental.srcPath!,
       sourceLocale: experimental.extract!.sourceLocale,


### PR DESCRIPTION
… and not e.g. for `next typegen`.

This is closely related to https://github.com/amannn/next-intl/pull/1992.

<details>
<summary>Debug logs from Next.js config</summary>

```

console.log(process.env.NODE_ENV, process.argv);

// Run with watcher: NODE_ENV=development
// Run once without watcher: NODE_ENV=production & includes('build')

// 'info',
// production [
//   '/usr/local/bin/node',
//   '/Users/jan/Projects/next-intl/next-intl/examples/example-app-router-extracted/node_modules/next/dist/bin/next',
//   'info'
// ]

// typegen
// production [
//   '/usr/local/bin/node',
//   '/Users/jan/Projects/next-intl/next-intl/examples/example-app-router-extracted/node_modules/next/dist/bin/next',
//   'typegen'
// ]

// dev
// development [
//   '/usr/local/bin/node',
//   '/Users/jan/Projects/next-intl/next-intl/node_modules/.pnpm/next@16.0.10_@babel+core@7.26.10_@playwright+test@1.55.0_react-dom@19.2.3_react@19.2.3__react@19.2.3/node_modules/next/dist/server/lib/start-server.js'
// ]

// build
// production [
//   '/usr/local/bin/node',
//   '/Users/jan/Projects/next-intl/next-intl/examples/example-app-router-extracted/node_modules/next/dist/bin/next',
//   'build'
// ]
// production [
//   '/usr/local/bin/node',
//   '/Users/jan/Projects/next-intl/next-intl/node_modules/.pnpm/next@16.0.10_@babel+core@7.26.10_@playwright+test@1.55.0_react-dom@19.2.3_react@19.2.3__react@19.2.3/node_modules/next/dist/compiled/jest-worker/threadChild.js'
// ]

// 'start'
// production [
//   '/usr/local/bin/node',
//   '/Users/jan/Projects/next-intl/next-intl/examples/example-app-router-extracted/node_modules/next/dist/bin/next',
//   'start'
// ]

// Note: These commands don't consult the
// Next.js config, so we can't detect them here.
// - telemetry
```

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts when the extraction compiler initializes and runs.
> 
> - Hoists `isDevelopment` detection and introduces `shouldRun` to gate execution to `next dev` and `next build`
> - Skips running during `info`, `start`, `typegen` and commands that don't consult Next.js config (`telemetry`, `lint`)
> - Keeps single-run guard via `runOnce` and existing extraction/watcher behavior unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6b2b0be8afb803f79ab2f78a6848dba5e69e0de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->