### PR TITLE
fix: Extractor description logic fix

### DIFF
--- a/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
+++ b/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
@@ -1336,7 +1336,7 @@ describe('po format', () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #. Description from FileZ
+      #. Description from FileY
       #: src/FileY.tsx:5
       #: src/FileZ.tsx:7
       #: src/FileZ.tsx:8

--- a/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
+++ b/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
@@ -313,6 +313,11 @@ export default class CatalogManager implements Disposable {
         // Merge other properties like description, or unknown
         // attributes like flags that are opaque to us
         for (const key of Object.keys(prevMessage)) {
+          if (key === 'description' && prevMessage[key]) {
+            message[key] = prevMessage[key];
+            continue;
+          }
+
           if (message[key] == null) {
             message[key] = prevMessage[key];
           }


### PR DESCRIPTION
Corrects message description merging logic to ensure "first description wins" behavior.

The previous merging logic for message descriptions would overwrite an existing description if a later-processed file also had one, violating the intended "first description wins" rule. This change ensures that if a description already exists from a previously processed file, it is preserved.

---
<a href="https://cursor.com/background-agent?bcId=bc-2cbe132d-e79b-4f85-a02b-b56653c03435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2cbe132d-e79b-4f85-a02b-b56653c03435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

