### PR TITLE
Fix alias pattern for use-intl package path

### DIFF
--- a/packages/icu-minify/rollup.config.js
+++ b/packages/icu-minify/rollup.config.js
@@ -7,7 +7,7 @@ export default getBuildConfig({
     format: 'src/format.tsx'
   },
   external: [
-    ...Object.keys(pkg.dependencies),
-    ...Object.keys(pkg.peerDependencies)
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {})
   ]
 });

--- a/packages/next-intl/src/plugin/getNextConfig.tsx
+++ b/packages/next-intl/src/plugin/getNextConfig.tsx
@@ -143,8 +143,17 @@ export default function getNextConfig(
 
     // Add alias for precompiled message formatting
     if (pluginConfig.experimental?.messages?.precompile) {
-      resolveAlias['use-intl/format-message'] =
-        'use-intl/format-message/format-only';
+      // Use require.resolve to get the actual file path, since
+      // bundlers don't properly resolve package subpath exports
+      // when used as alias targets.
+      // For Turbopack, we need a relative path (it doesn't support absolute paths)
+      const formatOnlyPath = require.resolve(
+        'use-intl/format-message/format-only'
+      );
+      const relativePath = path.relative(process.cwd(), formatOnlyPath);
+      resolveAlias['use-intl/format-message'] = relativePath.startsWith('.')
+        ? relativePath
+        : './' + relativePath;
     }
 
     // Add loaders
@@ -236,9 +245,12 @@ export default function getNextConfig(
 
       // Add alias for precompiled message formatting
       if (pluginConfig.experimental?.messages?.precompile) {
+        // Use require.resolve to get the actual file path, since
+        // bundlers don't properly resolve package subpath exports
+        // when used as alias targets
         (config.resolve.alias as Record<string, string>)[
           'use-intl/format-message'
-        ] = 'use-intl/format-message/format-only';
+        ] = require.resolve('use-intl/format-message/format-only');
       }
 
       // Add loader for extractor


### PR DESCRIPTION
…

The alias for `use-intl/format-message` to `use-intl/format-message/format-only` was not working because bundlers (webpack/turbopack) don't properly resolve package subpath exports when used as alias targets.

The fix uses `require.resolve()` to get the actual file path of the format-only module. For Turbopack, which doesn't support absolute paths in aliases, the path is converted to a relative path from the current working directory.

Also fixes icu-minify rollup config to handle missing peerDependencies.