### PR TITLE
docs: Middleware docs integration

### DIFF
--- a/docs/src/pages/docs/routing/middleware.mdx
+++ b/docs/src/pages/docs/routing/middleware.mdx
@@ -217,32 +217,17 @@ export const config = {
 
 You may wish to customize this based on your routing configuration and use case.
 
-### Further examples (auth, SaaS, tenants)
+### Starter templates (auth, saas, tenants)
 
-When composing middleware, the most important decision is where `next-intl` should run in the chain:
+🌐 [learn.next-intl.dev](https://learn.next-intl.dev) provides additional starter templates with middleware composition.
 
-- Run **auth first** when access control should apply to the incoming URL (including locale prefixes) and you only want i18n routing for requests that are allowed.
-- Run **`next-intl` first** when the downstream middleware expects a normalized locale or relies on the rewritten URL.
+**Including:**
 
-<Callout>
+- **`app-router-auth` with Better Auth**: Auth-protected app with locale from user settings.
+- **`app-router-saas` with Better Auth**: Locale prefixes on public routes with a login to a protected app.
+- **`app-router-tenants`**: An advanced composition pattern that routes between multiple tenants and a landing page while supporting multiple locales.
 
-**Production-style templates (middleware composition):**
-
-You can find complete, working middleware setups on [learn.next-intl.dev](https://learn.next-intl.dev/#project-code), including:
-
-<ul className="ml-4 list-disc">
-  <li>
-    <code>app-router-auth</code>: An app behind an auth layer where the locale is managed via a user setting (includes a Better Auth integration).
-  </li>
-  <li>
-    <code>app-router-saas</code>: Locale prefixes on public routes while reading the locale from settings when logged in (includes auth + proxy composition).
-  </li>
-  <li>
-    <code>app-router-tenants</code>: An advanced composition pattern that routes between multiple tenants and a landing page while supporting multiple locales (no auth).
-  </li>
-</ul>
-
-</Callout>
+[Source code](https://learn.next-intl.dev/#project-code)
 
 ## Usage without proxy / middleware (static export)
 


### PR DESCRIPTION
Replace specific auth middleware examples in `middleware.mdx` with a link to `learn.next-intl.dev` templates for comprehensive composition patterns.

The previous provider-specific examples were removed to streamline the documentation and direct users to production-ready, working examples of middleware composition, including advanced auth and proxy patterns, available on `learn.next-intl.dev`.

---
<a href="https://cursor.com/background-agent?bcId=bc-72030dde-0372-4911-99a7-208b9fc0a007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-72030dde-0372-4911-99a7-208b9fc0a007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

