### PR TITLE
fix(docs): improve company logo visibility in dark mode

### DIFF
--- a/docs/src/components/UserCompanies/UserCompanies.tsx
+++ b/docs/src/components/UserCompanies/UserCompanies.tsx
@@ -140,7 +140,7 @@ export default function UserCompanies() {
         >
           <Image
             alt={company.name}
-            className="max-h-8 w-auto max-w-24 object-contain lg:max-h-11 lg:max-w-36"
+            className="max-h-8 w-auto max-w-24 object-contain dark:invert lg:max-h-11 lg:max-w-36"
             src={company.logo}
             style={{transform: `scale(${company.scale || 1})`}}
             title={company.name}


### PR DESCRIPTION
 ## Summary

  Company logos on the homepage are barely visible in dark mode because many SVG logos use black (`#000`)
  fill colors.

  ## Problem

  When dark mode is enabled, logos with black fill become nearly invisible against the dark background.

  ## Solution

  Add `dark:invert` Tailwind class to the `<Image>` component in `UserCompanies.tsx`, which inverts the
  colors in dark mode making all logos visible.

  ## Before / After

  | Before | After |
  |--------|-------|
  |<img width="1468" height="582" alt="스크린샷 2026-01-15 오전 2 23 21" src="https://github.com/user-attachments/assets/c17b67d5-8f9b-4f21-8660-27471bc397f9" /> | <img width="1486" height="582" alt="스크린샷 2026-01-15 오전 2 23 28" src="https://github.com/user-attachments/assets/29f89e28-bbe4-4eaf-a225-42072023224d" /> |

  ## Testing

  Tested locally - logos are now visible in both light and dark modes.
