### PR TITLE
feat: Catalog loader message caching

### DIFF
--- a/packages/next-intl/src/plugin/catalog/catalogLoader.tsx
+++ b/packages/next-intl/src/plugin/catalog/catalogLoader.tsx
@@ -114,10 +114,8 @@ function precompileMessages(
 
     let compiledMessage;
     if (hasCacheMatch) {
-      console.log('cache hit', message.id);
       compiledMessage = cachedEntry.compiledMessage;
     } else {
-      console.log('compile', message.id);
       compiledMessage = compile(messageValue);
       cache.set(message.id, {compiledMessage, messageValue});
     }
@@ -127,7 +125,6 @@ function precompileMessages(
 
   // Evict unused cache entries
   for (const cachedId of cacheKeysToEvict) {
-    console.log('evict', cachedId);
     cache.delete(cachedId);
   }
 


### PR DESCRIPTION
Adds per-message caching to `catalogLoader` to avoid recompiling all messages when only a single message changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9caabc6-43c8-4f23-94ea-2d59ad589bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9caabc6-43c8-4f23-94ea-2d59ad589bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

