### PR TITLE
docs: Blog post language improvements

### DIFF
--- a/docs/src/pages/blog/precompilation.mdx
+++ b/docs/src/pages/blog/precompilation.mdx
@@ -11,7 +11,7 @@ import StayUpdated from '@/components/StayUpdated.mdx';
 
 **tl;dr:** By flipping a single `precompile` flag in your `next.config.ts`, you can **immediately drop ~9KB** of compressed JavaScript from your bundle size and also improve the runtime performance of your app.
 
-The cost of adding `next-intl` with a single client-side translation to an app now accounts to **~4KB** of compressed JavaScript.
+The cost of adding `next-intl` with a single client-side translation to an app now amounts to **~4KB** of compressed JavaScript.
 
 ## How we got here
 
@@ -19,21 +19,21 @@ When React Server Components were announced, I was pretty excited.
 
 I immediately saw [potential for `next-intl`](https://www.smashingmagazine.com/2023/03/internationalization-nextjs-13-react-server-components/) to improve performance for its users by moving more work to the server—leaving the client with less JavaScript to parse and evaluate.
 
-But I also have to admit, I got a bit carried away. While for very interactive apps this was never really an option in the first place, when working on apps with very sensitive performance requirements, I'd try to almost dogmatically avoid client-side translations entirely.
+But I also have to admit, I got a bit carried away. While for very interactive apps this was never really an option, when working on apps with very sensitive performance requirements, I'd try to almost dogmatically avoid client-side translations entirely.
 
-And while you can get pretty far with this approach, it can require quite some tricks like leaning heavily into [donut components](https://nextjs.org/docs/app/getting-started/server-and-client-components#interleaving-server-and-client-components) and other fancy patterns.
+And while you can get pretty far with this approach, it can require quite a few tricks like leaning heavily into [donut components](https://nextjs.org/docs/app/getting-started/server-and-client-components#interleaving-server-and-client-components) and other fancy patterns.
 
-It almost felt like a game of "the floor is lava", trying to find clever tricks to avoid touching the client with translations and ultimately avoiding shipping an ICU parser to the client. I know some of you did the same.
+It almost felt like a game of "the floor is lava", trying to find clever tricks to avoid touching the client with translations and ultimately avoid shipping an ICU parser to the client. I know some of you did the same.
 
 ## A different perspective
 
-About three years ago, I started a conversation with [Jan Nicklas](https://x.com/jantimon), about how we could best leverage the new Server Components paradigm for internationalization.
+About three years ago, I started a conversation with [Jan Nicklas](https://x.com/jantimon) about how we could best leverage the new Server Components paradigm for internationalization.
 
 At some point, he shared an idea with me that he'd implement in a prototype: `icu-to-json`, a fresh take on removing the ICU parser from the runtime. I always wanted to integrate this into `next-intl`, but for the longest time, it seemed like a big ask architecturally.
 
 But then, about two months ago, I shipped the first implementation of [`useExtracted`](/docs/usage/extraction), which happened to provide just the infrastructure that finally unlocked this feature.
 
-The loader I've implemented for processing `.po` files, and later [custom formats](/docs/usage/plugin#formats-custom), looked like a perfect fit to also precompile messages ahead of time.
+The loader I implemented for processing `.po` files and later for [custom formats](/docs/usage/plugin#formats-custom) looked like a perfect fit to precompile messages ahead of time.
 
 So it was time to get to work.
 
@@ -63,9 +63,9 @@ function hello(name) {
 }
 ```
 
-The problem with this approach however is that such functions can not be serialized across the RSC bridge when being passed to Client Components. Libraries that use this approach therefore resort to importing the generated function into components to avoid crossing the bridge.
+The problem with this approach, however, is that such functions cannot be serialized across the RSC bridge when passed to Client Components. Libraries that use this approach therefore resort to importing the generated function into components to avoid crossing the bridge.
 
-And in turn, this results in all locale-specific variants of a message being bundled with your code, therefore defeating the possibility to split messages by locale.
+And in turn, this results in all locale-specific variants of a message being bundled with your code, thereby defeating the possibility of splitting messages by locale.
 
 `next-intl` is used by websites like [Ethereum.org](https://ethereum.org), which currently ships in 67 languages. So the function-based approach is just not an option here.
 
@@ -73,9 +73,9 @@ And in turn, this results in all locale-specific variants of a message being bun
 
 Architecturally, precompiled ASTs are a better fit for `next-intl`—but they were too large.
 
-The core idea of Jan Nicklas's prototype was to minify ASTs, largely avoiding object properties in favor of arrays with positional entries. I took his idea and was able to even squeeze the size a bit further.
+The core idea of Jan Nicklas's prototype was to minify ASTs, largely avoiding object properties in favor of arrays with positional entries. I took his idea and was able to squeeze the size even further.
 
-So here's how it looks like:
+So here's what it looks like:
 
 ```tsx
 compile('Hello {name}!');
@@ -87,7 +87,7 @@ compile('Hello {name}!');
 ["Hello ", ["name"], "!"]
 ```
 
-… and from here, we can evaluate the AST with a minimal runtime:
+… and from there, we can evaluate the AST with a minimal runtime:
 
 ```tsx
 // "Hello World!"
@@ -102,7 +102,7 @@ And the best part is that this doesn't have any overhead at all for plain string
 
 Based on my experience, such plain strings often account for the majority of messages that typical apps ship with, so this is a big win.
 
-But that being said, this approach still scales up to more complex messages as well and supports the whole range of ICU features that you know from `next-intl`:
+That said, this approach scales up to more complex messages and supports the full range of ICU features that you know from `next-intl`:
 
 ```tsx
 compile(
@@ -134,19 +134,19 @@ compile('Hello <b>World</b>');
 
 ## Minimal runtime
 
-But so, what is this `format` function?
+So what is this `format` function?
 
 ```tsx
 format(compiled, 'en', {count: 2});
 ```
 
-It's a minimal runtime that efficiently evaluates the optimized AST and calls into native `Intl` APIs to format dates, numbers and more.
+It's a minimal runtime that efficiently evaluates the optimized AST and calls into native `Intl` APIs to format dates, numbers, and more.
 
 All that, in **~650 bytes** (compressed).
 
-So that means, if you make the switch to ahead-of-time compilation, this will **immediately drop ~9KB** of compressed JavaScript from both your server and client bundle. The cost of adding `next-intl` with a single client-side translation to an app now accounts to **~4KB** of compressed JavaScript.
+So if you make the switch to ahead-of-time compilation, this will **immediately drop ~9KB** of compressed JavaScript from both your server and client bundle. The cost of adding `next-intl` with a single client-side translation to an app now amounts to **~4KB** of compressed JavaScript.
 
-And additionally, formatting of messages will now be significantly faster, as the parsing overhead is gone from the runtime and evaluation of the optimized AST is very cheap.
+Additionally, formatting of messages will now be significantly faster, as the parsing overhead is gone from the runtime and evaluation of the optimized AST is very cheap.
 
 ## Turn on precompilation today
 
@@ -179,20 +179,20 @@ But that's it. Your existing calls to `useTranslations` and `useExtracted` will 
 
 One aspect to call out here is that [`t.raw`](/docs/usage/translations#raw-messages) is not supported with precompilation.
 
-As messages are parsed at build time, we can't know if you're planning to call `t.raw` on them later. Due to this, this feature will not be supported with precompiled messages.
+As messages are parsed at build time, we can't know if you're planning to call `t.raw` on them later, so this feature isn't supported with precompiled messages.
 
 But let's take a step back here.
 
-Historically, `t.raw` was added to support raw HTML content in your messages. However, time has shown that in practice, this is cumbersome for long-form content and that there are better alternatives:
+Historically, `t.raw` was added to support raw HTML content in your messages. However, time has shown that this is cumbersome in practice for long-form content and that there are better alternatives:
 
 1. **MDX for local content**: For imprint pages and similar, grouping your localized content into files like `content.en.mdx` and `content.es.mdx` is significantly easier to manage.
-2. **CMS for remote content**: Content management systems typically ship with a portable format that allows to express rich text in an HTML-agnostic way, enabling you to use the same content also for mobile apps and more (see e.g. [Sanity's Portable Text](https://www.sanity.io/docs/developer-guides/presenting-block-text)).
+2. **CMS for remote content**: Content management systems typically ship with a portable format that allows you to express rich text in an HTML-agnostic way, enabling you to use the same content for mobile apps and more (see, for example, [Sanity's Portable Text](https://www.sanity.io/docs/developer-guides/presenting-block-text)).
 
-The other use case that `t.raw` was traditionally (ab)used for, is to handle arrays of messages. The recommended pattern for this has always been to use individual messages for each string (see [arrays of messages](/docs/usage/translations#arrays-of-messages)). This pattern additionally has the benefit of being [statically analyzable](/docs/workflows/messages).
+The other use case that `t.raw` was traditionally (ab)used for is handling arrays of messages. The recommended pattern for this has always been to use individual messages for each string (see [arrays of messages](/docs/usage/translations#arrays-of-messages)). This pattern also has the benefit of being [statically analyzable](/docs/workflows/messages).
 
-Related to this, the recently introduced [`useExtracted`](/blog/use-extracted) doesn't support `t.raw` either, since it doesn't fit into this paradigm in the first place.
+Related to this, the recently introduced [`useExtracted`](/blog/use-extracted) doesn't support `t.raw` either, since it doesn't fit this paradigm in the first place.
 
-Due to this, it's recommended to migrate to one of the mentioned alternatives if you'd like to benefit from ahead-of-time compilation. If you're heavily using `t.raw`, you can of course also decide to leave the optimization off for now.
+Because of this, it's recommended to migrate to one of the mentioned alternatives if you'd like to benefit from ahead-of-time compilation. If you're heavily using `t.raw`, you can of course also decide to leave the optimization off for now.
 
 Potentially in a future release, `t.raw` might be deprecated entirely due to the downsides this API has—but this is still up for discussion.
 
@@ -200,9 +200,9 @@ Potentially in a future release, `t.raw` might be deprecated entirely due to the
 
 If you're excited about ahead-of-time compilation as well, I'd really love to hear your feedback.
 
-Give it a try in your app with `next-intl@4.8` and share your [feedback](https://github.com/amannn/next-intl/discussions/2209) with me. Please note that this feature is currently considered experimental, so changes should be expected.
+Give it a try in your app with `next-intl@4.8` and share your [feedback](https://github.com/amannn/next-intl/discussions/2209) with me. Please note that this feature is currently considered experimental, so changes are expected.
 
-On a closing note, the final frontier in regard to performance optimization for `next-intl` is automatic tree shaking of messages. I hope to have more to share on this later this year!
+As a closing note, the final frontier for `next-intl` performance optimization is automatic tree shaking of messages. I hope to have more to share on this later this year!
 
 — Jan
 


### PR DESCRIPTION
Fix typos and grammar in the `precompilation.mdx` blog post to improve clarity and readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-6bb003e4-8256-4dfa-b5ac-353cea932829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6bb003e4-8256-4dfa-b5ac-353cea932829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

