### PR TITLE
fix: Avoid throwing config errors for non-Next.js consumers of `next.config.ts`

### DIFF
--- a/packages/next-intl/src/plugin/config.tsx
+++ b/packages/next-intl/src/plugin/config.tsx
@@ -1,0 +1,9 @@
+// Avoid rollup's `replace` plugin to compile this away
+const nodeEnvKey = 'NODE_ENV'.trim();
+
+// We avoid reading `argv.includes('dev')` related to
+// https://github.com/amannn/next-intl/issues/2006
+export const isDevelopment = process.env[nodeEnvKey] === 'development';
+
+export const isNextBuild = process.argv.includes('build');
+export const isDevelopmentOrNextBuild = isDevelopment || isNextBuild;

--- a/packages/next-intl/src/plugin/extractor/initExtractionCompiler.tsx
+++ b/packages/next-intl/src/plugin/extractor/initExtractionCompiler.tsx
@@ -1,5 +1,6 @@
 import ExtractionCompiler from '../../extractor/ExtractionCompiler.js';
 import type {ExtractorConfig} from '../../extractor/types.js';
+import {isDevelopment, isNextBuild} from '../config.js';
 import type {PluginConfig} from '../types.js';
 import {once} from '../utils.js';
 
@@ -14,9 +15,6 @@ export default function initExtractionCompiler(pluginConfig: PluginConfig) {
     return;
   }
 
-  // Avoid rollup's `replace` plugin to compile this away
-  const isDevelopment = process.env['NODE_ENV'.trim()] === 'development';
-
   // Avoid running for:
   // - info
   // - start
@@ -29,7 +27,7 @@ export default function initExtractionCompiler(pluginConfig: PluginConfig) {
   // What remains are:
   // - dev (NODE_ENV=development)
   // - build (NODE_ENV=production)
-  const shouldRun = isDevelopment || process.argv.includes('build');
+  const shouldRun = isDevelopment || isNextBuild;
   if (!shouldRun) return;
 
   runOnce(() => {


### PR DESCRIPTION
Fixes https://github.com/amannn/next-intl/discussions/2209

Nx’s `@nx/next/plugin` builds the project graph by importing `next.config.ts` directly, outside of a real `next dev`/`next build` invocation. Since `next-intl/plugin` now configures Turbopack more broadly (`shouldConfigureTurbo` via `isNextJs16OrHigher`), the plugin runs early during this analysis step and `resolveI18nPath()` validates `i18n/request` relative to the current CWD (often the monorepo root). In Nx monorepos this can’t be resolved and breaks the graph/build with “Could not locate request configuration module”, even though the app works when Next.js actually runs.

This change makes the plugin only throw config-path errors when Next.js is actually running (`next dev`/`next build`). For other consumers that merely import the config (Nx graph, tooling), it avoids throwing while still returning a stable alias target.