### PR TITLE
refactor: Tree shaking provider flag

### DIFF
--- a/e2e/tree-shaking/src/app/layout.tsx
+++ b/e2e/tree-shaking/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default async function LocaleLayout({children}: Props) {
   const messages = await getMessages({locale});
   const segment = '/';
   const filteredMessages =
-    manifest?.[segment]?.hasProvider === true
+    manifest?.[segment]?.hasLayoutProvider === true
       ? pruneMessages(
           collectNamespacesForSegment(segment, manifest) ?? {},
           messages
@@ -54,7 +54,7 @@ export default async function LocaleLayout({children}: Props) {
 
 type ManifestSegmentEntry = true | Record<string, true | Record<string, true>>;
 type ManifestEntry = {
-  hasProvider: boolean;
+  hasLayoutProvider: boolean;
   namespaces: ManifestSegmentEntry;
 };
 type Messages = Awaited<ReturnType<typeof getMessages>>;
@@ -140,7 +140,7 @@ function collectNamespacesForSegment(
 
   const prefix = segment === '/' ? '/' : `${segment}/`;
   for (const [key, entry] of Object.entries(manifest)) {
-    if (!entry || entry.hasProvider) continue;
+    if (!entry || entry.hasLayoutProvider) continue;
     if (key === segment) continue;
     if (!key.startsWith(prefix)) continue;
     merged = mergeNamespaces(merged, entry.namespaces);

--- a/packages/next-intl/src/tree-shaking/Analyzer.tsx
+++ b/packages/next-intl/src/tree-shaking/Analyzer.tsx
@@ -146,18 +146,18 @@ function hasTranslationUsage(namespaces: ManifestNamespaces): boolean {
 function ensureManifestEntry(
   manifest: Manifest,
   segmentId: string,
-  hasProvider: boolean
+  hasLayoutProvider: boolean
 ): ManifestEntry {
   const existing = manifest[segmentId];
   if (existing) {
-    if (hasProvider && !existing.hasProvider) {
-      existing.hasProvider = true;
+    if (hasLayoutProvider && !existing.hasLayoutProvider) {
+      existing.hasLayoutProvider = true;
     }
     return existing;
   }
 
   const entry: ManifestEntry = {
-    hasProvider,
+    hasLayoutProvider,
     namespaces: {}
   };
   manifest[segmentId] = entry;
@@ -261,9 +261,9 @@ export default class TreeShakingAnalyzer {
     const segmentMap = new Map<string, boolean>();
     for (const entry of entryFiles) {
       const existing = segmentMap.get(entry.segmentId);
-      const hasProvider =
+      const hasLayoutProvider =
         existing === true ? true : providerSegments.has(entry.segmentId);
-      segmentMap.set(entry.segmentId, hasProvider);
+      segmentMap.set(entry.segmentId, hasLayoutProvider);
     }
 
     let entriesToAnalyze = entryFilePaths;

--- a/packages/next-intl/src/tree-shaking/Manifest.tsx
+++ b/packages/next-intl/src/tree-shaking/Manifest.tsx
@@ -6,7 +6,7 @@ export type ManifestNamespaceMap = Record<string, true | Record<string, true>>;
 export type ManifestNamespaces = true | ManifestNamespaceMap;
 
 export type ManifestEntry = {
-  hasProvider: boolean;
+  hasLayoutProvider: boolean;
   namespaces: ManifestNamespaces;
 };
 

--- a/rfcs/003-tree-shaking.md
+++ b/rfcs/003-tree-shaking.md
@@ -286,7 +286,7 @@ app/[locale]/
 - The manifest must not live in `.next/`; Turbopack/Webpack aliases can’t target that folder. Writing it to `node_modules/.cache/next-intl-client-manifest.json` works however.
 - Seeding an empty manifest on startup prevents “module not found” when the alias is resolved before the first analysis run.
 - The analyzer splits dotted namespaces/keys (e.g., `Nested.deep.key` or `t('nested.key')`) into nested objects in the manifest so pruning can match message JSON structure.
-- Provider detection currently lives in `layout.tsx` only; nested segments without a provider inherit from the nearest ancestor provider, and manifest entries include `hasProvider` to support this.
+- Provider detection currently lives in `layout.tsx` only; nested segments without a provider inherit from the nearest ancestor provider, and manifest entries include `hasLayoutProvider` to support this.
 - Incremental runs: When a file changes, we only want to re-analyze affected files to be quick to emit an updated manifest.
 - We're using `@swc/core` (for now) to parse code and evaluate the AST in JS.
 - To observe the module graph of an entry point, we should use the `dependency-tree` package. One critical point is that this supports `tsconfig.json` with potential alias configuration.


### PR DESCRIPTION
Rename `hasProvider` flag to `hasLayoutProvider` to clarify its specific role in tree-shaking for layout providers.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-10f5a24d-5dfe-4424-a58b-4b33bd816433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10f5a24d-5dfe-4424-a58b-4b33bd816433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that renames a manifest flag used for layout provider detection; main risk is missed references causing incorrect message pruning or manifest compatibility issues.
> 
> **Overview**
> Renames the tree-shaking manifest flag from `hasProvider` to **`hasLayoutProvider`** across the analyzer, manifest type, and e2e layout pruning logic to clarify that the flag specifically tracks provider presence in `layout.tsx`.
> 
> Updates the namespace collection logic to skip descendant segments that define their own layout provider using the new flag, and refreshes the RFC text to match the renamed field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc92620b111a550e71d0e189e6be0a156af8b7c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->