### PR TITLE
fix: Next-intl client manifest path

### DIFF
--- a/packages/next-intl/src/plugin/getNextConfig.tsx
+++ b/packages/next-intl/src/plugin/getNextConfig.tsx
@@ -34,7 +34,7 @@ function normalizeTurbopackAliasPath(pathname: string) {
 
 function getManifestAliasPath() {
   // We can't put this inside `.next` as Turbopack aliases can't target that.
-  return './node_modules/.cache/next-intl-client-manifest.json';
+  return './node_modules/.cache/next-intl/client-manifest.json';
 }
 
 function resolveI18nPath(providedPath?: string, cwd?: string) {

--- a/packages/next-intl/src/tree-shaking/Manifest.tsx
+++ b/packages/next-intl/src/tree-shaking/Manifest.tsx
@@ -17,8 +17,8 @@ export function createEmptyManifest(): Manifest {
 }
 
 export async function writeManifest(manifest: Manifest, projectRoot: string) {
-  const outDir = path.join(projectRoot, 'node_modules', '.cache');
-  const outFile = path.join(outDir, 'next-intl-client-manifest.json');
+  const outDir = path.join(projectRoot, 'node_modules', '.cache', 'next-intl');
+  const outFile = path.join(outDir, 'client-manifest.json');
   await fs.mkdir(outDir, {recursive: true});
   await fs.writeFile(outFile, JSON.stringify(manifest, null, 2), 'utf8');
 }

--- a/rfcs/003-tree-shaking.md
+++ b/rfcs/003-tree-shaking.md
@@ -283,7 +283,7 @@ app/[locale]/
 
 - A shared file watcher is reused by the extractor and the tree-shaking manifest generator to avoid duplicate watchers on the same roots.
 - We need an alias to link the manifest into layout files where it's imported. This ensures HMR works and the relevant messages are available.
-- The manifest must not live in `.next/`; Turbopack/Webpack aliases can’t target that folder. Writing it to `node_modules/.cache/next-intl-client-manifest.json` works however.
+- The manifest must not live in `.next/`; Turbopack/Webpack aliases can’t target that folder. Writing it to `node_modules/.cache/next-intl/client-manifest.json` works however.
 - Seeding an empty manifest on startup prevents “module not found” when the alias is resolved before the first analysis run.
 - The analyzer splits dotted namespaces/keys (e.g., `Nested.deep.key` or `t('nested.key')`) into nested objects in the manifest so pruning can match message JSON structure.
 - Provider detection currently lives in `layout.tsx` only; nested segments without a provider inherit from the nearest ancestor provider, and manifest entries include `hasProvider` to support this.


### PR DESCRIPTION
Rename `next-intl` client manifest path to `node_modules/.cache/next-intl/client-manifest.json` for better organization.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-40f5bc98-0275-451b-a5fd-10d023efb215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40f5bc98-0275-451b-a5fd-10d023efb215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Path-only change for where the manifest is written and aliased; risk is limited to potential breakage if any external tooling still expects the old filename.
> 
> **Overview**
> Updates the tree-shaking client manifest location from `node_modules/.cache/next-intl-client-manifest.json` to **`node_modules/.cache/next-intl/client-manifest.json`**, and aligns both the plugin alias target (`getManifestAliasPath`) and the manifest writer (`writeManifest`) to the new path.
> 
> Documentation in `rfcs/003-tree-shaking.md` is updated to reference the new manifest path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63d550b09186c4c36b614d389b0011698d752a1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->