### PR TITLE
test: Explicit ID useExtracted page

### DIFF
--- a/e2e/tree-shaking/messages/en.po
+++ b/e2e/tree-shaking/messages/en.po
@@ -58,6 +58,11 @@ msgstr "Lazy imported client"
 msgid "mrNFad"
 msgstr "Dynamic slug page: {slug}"
 
+#: src/app/explicit-id/page.tsx:12
+msgctxt "carousel"
+msgid "next"
+msgstr "Right"
+
 #: src/app/feed/@modal/(..)photo/[id]/page.tsx:13
 msgid "Ax7uMP"
 msgstr "Intercepted photo modal: {id}"

--- a/e2e/tree-shaking/src/app/explicit-id/layout.tsx
+++ b/e2e/tree-shaking/src/app/explicit-id/layout.tsx
@@ -1,0 +1,9 @@
+import {NextIntlClientProvider} from 'next-intl';
+
+export default function ExplicitIdLayout({
+  children
+}: LayoutProps<'/explicit-id'>) {
+  return (
+    <NextIntlClientProvider messages="infer">{children}</NextIntlClientProvider>
+  );
+}

--- a/e2e/tree-shaking/src/app/explicit-id/page.tsx
+++ b/e2e/tree-shaking/src/app/explicit-id/page.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import {useExtracted} from 'next-intl';
+import ClientBoundary from '@/components/ClientBoundary';
+
+export default function ExplicitIdPage() {
+  const t = useExtracted();
+
+  return (
+    <ClientBoundary>
+      <p>
+        {t({
+          id: 'carousel.next',
+          message: 'Right'
+        })}
+      </p>
+    </ClientBoundary>
+  );
+}

--- a/e2e/tree-shaking/tests/client-messages.spec.ts
+++ b/e2e/tree-shaking/tests/client-messages.spec.ts
@@ -24,6 +24,13 @@ const routesMap = {
       mrNFad: ['Dynamic slug page: ', ['slug']]
     }
   ],
+  '/explicit-id': [
+    {
+      carousel: {
+        next: 'Right'
+      }
+    }
+  ],
   '/catch-all/a/b/c': [
     {
       xmCXAl: ['Catch-all page: ', ['segment']]

--- a/e2e/tree-shaking/tests/manifest.spec.ts
+++ b/e2e/tree-shaking/tests/manifest.spec.ts
@@ -55,6 +55,14 @@ const EXPECTED_MANIFEST = {
       mrNFad: true
     }
   },
+  '/explicit-id': {
+    hasLayoutProvider: true,
+    namespaces: {
+      carousel: {
+        next: true
+      }
+    }
+  },
   '/feed': {
     hasLayoutProvider: true,
     namespaces: {


### PR DESCRIPTION
Add an e2e test page for `/explicit-id` to verify tree-shaking inference of dotted explicit IDs with `useExtracted`.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-26482740-f5e7-4c1b-9208-c894fa837991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26482740-f5e7-4c1b-9208-c894fa837991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

