### PR TITLE
docs: Fix typos in `useExtracted` blog post

### DIFF
--- a/docs/src/pages/blog/use-extracted.mdx
+++ b/docs/src/pages/blog/use-extracted.mdx
@@ -202,7 +202,7 @@ Oh and yes, Webpack is also supported.
 
 ## Ready to try it?
 
-I could probably go on, eg. about how `useExtracted` also works out-of-the-box in test environments without any compilation at all, but I think I've already made my point.
+I could probably go on, e.g. about how `useExtracted` also works out-of-the-box in test environments without any compilation at all, but I think I've already made my point.
 
 If you're excited about this as well, I'd really love to hear your feedback.
 


### PR DESCRIPTION
Hey @amannn, hope everything is good with you! 👋

Quick PR to fix the typos in the `useExtracted()` blog post