### PR TITLE
feat: Add `displayName` to `useFormatter`

### DIFF
--- a/docs/src/pages/docs/environments/runtime-requirements.mdx
+++ b/docs/src/pages/docs/environments/runtime-requirements.mdx
@@ -14,6 +14,7 @@ Based on the features you're using, you have to make sure your target browsers s
 - Pluralization: `Intl.PluralRules` ([compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules#browser_compatibility))
 - Relative time formatting: `Intl.RelativeTimeFormat` ([compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat#browser_compatibility))
 - List formatting: `Intl.ListFormat` ([compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat#browser_compatibility))
+- Display name formatting: `Intl.DisplayNames` ([compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames#browser_compatibility))
 
 If you target a browser that doesn't support all the required APIs, consider using polyfills.
 
@@ -40,7 +41,9 @@ function IntlPolyfills() {
     'Intl.RelativeTimeFormat',
     `Intl.RelativeTimeFormat.~locale.${locale}`,
     'Intl.ListFormat',
-    `Intl.ListFormat.~locale.${locale}`
+    `Intl.ListFormat.~locale.${locale}`,
+    'Intl.DisplayNames',
+    `Intl.DisplayNames.~locale.${locale}`
   ];
 
   return (

--- a/docs/src/pages/docs/usage/_meta.tsx
+++ b/docs/src/pages/docs/usage/_meta.tsx
@@ -3,6 +3,7 @@ export default {
   numbers: 'Numbers',
   'dates-times': 'Dates and times',
   lists: 'Lists',
+  'display-names': 'Display names',
   configuration: 'Request configuration',
   extraction: 'useExtracted',
   plugin: 'Next.js plugin'

--- a/docs/src/pages/docs/usage/_meta.tsx
+++ b/docs/src/pages/docs/usage/_meta.tsx
@@ -3,7 +3,7 @@ export default {
   numbers: 'Numbers',
   'dates-times': 'Dates and times',
   lists: 'Lists',
-  'display-names': 'Display names',
+  'display-name': 'Display names',
   configuration: 'Request configuration',
   extraction: 'useExtracted',
   plugin: 'Next.js plugin'

--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -536,9 +536,9 @@ export default getRequestConfig(async () => {
           year: 'numeric'
         }
       },
-      displayName: {
-        region: {
-          type: 'region'
+      number: {
+        precise: {
+          maximumFractionDigits: 5
         }
       },
       list: {
@@ -547,9 +547,9 @@ export default getRequestConfig(async () => {
           type: 'conjunction'
         }
       },
-      number: {
-        precise: {
-          maximumFractionDigits: 5
+      displayName: {
+        region: {
+          type: 'region'
         }
       }
     }
@@ -572,9 +572,9 @@ export default getRequestConfig(async () => {
         year: 'numeric'
       }
     },
-    displayName: {
-      region: {
-        type: 'region'
+    number: {
+      precise: {
+        maximumFractionDigits: 5
       }
     },
     list: {
@@ -583,9 +583,9 @@ export default getRequestConfig(async () => {
         type: 'conjunction'
       }
     },
-    number: {
-      precise: {
-        maximumFractionDigits: 5
+    displayName: {
+      region: {
+        type: 'region'
       }
     }
   }}
@@ -606,9 +606,9 @@ function Component() {
   const format = useFormatter();
 
   format.dateTime(new Date('2020-11-20T10:36:01.516Z'), 'short');
-  format.displayName('US', 'region');
-  format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
   format.number(47.414329182, 'precise');
+  format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
+  format.displayName('US', 'region');
 }
 ```
 

--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -518,7 +518,7 @@ Prefer to watch a video?
   title="Global formats"
 />
 
-To achieve consistent date, time, number and list formatting, you can define a set of global formats.
+To achieve consistent date, time, number, list, and display name formatting, you can define a set of global formats.
 
 <Tabs items={['i18n/request.ts', 'Provider']}>
 <Tabs.Tab>
@@ -545,6 +545,11 @@ export default getRequestConfig(async () => {
         enumeration: {
           style: 'long',
           type: 'conjunction'
+        }
+      },
+      displayNames: {
+        region: {
+          type: 'region'
         }
       }
     }
@@ -577,6 +582,11 @@ export default getRequestConfig(async () => {
         style: 'long',
         type: 'conjunction'
       }
+    },
+    displayNames: {
+      region: {
+        type: 'region'
+      }
     }
   }}
 >
@@ -598,6 +608,7 @@ function Component() {
   format.dateTime(new Date('2020-11-20T10:36:01.516Z'), 'short');
   format.number(47.414329182, 'precise');
   format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
+  format.displayNames('US', 'region');
 }
 ```
 

--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -536,9 +536,9 @@ export default getRequestConfig(async () => {
           year: 'numeric'
         }
       },
-      number: {
-        precise: {
-          maximumFractionDigits: 5
+      displayName: {
+        region: {
+          type: 'region'
         }
       },
       list: {
@@ -547,9 +547,9 @@ export default getRequestConfig(async () => {
           type: 'conjunction'
         }
       },
-      displayName: {
-        region: {
-          type: 'region'
+      number: {
+        precise: {
+          maximumFractionDigits: 5
         }
       }
     }
@@ -572,9 +572,9 @@ export default getRequestConfig(async () => {
         year: 'numeric'
       }
     },
-    number: {
-      precise: {
-        maximumFractionDigits: 5
+    displayName: {
+      region: {
+        type: 'region'
       }
     },
     list: {
@@ -583,9 +583,9 @@ export default getRequestConfig(async () => {
         type: 'conjunction'
       }
     },
-    displayName: {
-      region: {
-        type: 'region'
+    number: {
+      precise: {
+        maximumFractionDigits: 5
       }
     }
   }}
@@ -606,9 +606,9 @@ function Component() {
   const format = useFormatter();
 
   format.dateTime(new Date('2020-11-20T10:36:01.516Z'), 'short');
-  format.number(47.414329182, 'precise');
-  format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
   format.displayName('US', 'region');
+  format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
+  format.number(47.414329182, 'precise');
 }
 ```
 

--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -547,7 +547,7 @@ export default getRequestConfig(async () => {
           type: 'conjunction'
         }
       },
-      displayNames: {
+      displayName: {
         region: {
           type: 'region'
         }
@@ -583,7 +583,7 @@ export default getRequestConfig(async () => {
         type: 'conjunction'
       }
     },
-    displayNames: {
+    displayName: {
       region: {
         type: 'region'
       }
@@ -608,7 +608,7 @@ function Component() {
   format.dateTime(new Date('2020-11-20T10:36:01.516Z'), 'short');
   format.number(47.414329182, 'precise');
   format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
-  format.displayNames('US', 'region');
+  format.displayName('US', 'region');
 }
 ```
 

--- a/docs/src/pages/docs/usage/display-name.mdx
+++ b/docs/src/pages/docs/usage/display-name.mdx
@@ -2,7 +2,7 @@ import Callout from '@/components/Callout';
 
 # Display names
 
-When you need to display locale-aware names for regions, languages, currencies, or scripts, you can use the `displayNames` function from the `useFormatter` hook.
+When you need to display locale-aware names for regions, languages, currencies, or scripts, you can use the `displayName` function from the `useFormatter` hook.
 
 The output adapts to the current locale automatically:
 
@@ -19,20 +19,20 @@ function Component() {
   const format = useFormatter();
 
   // Renders "United States"
-  format.displayNames('US', {type: 'region'});
+  format.displayName('US', {type: 'region'});
 
   // Renders "English"
-  format.displayNames('en', {type: 'language'});
+  format.displayName('en', {type: 'language'});
 
   // Renders "US Dollar"
-  format.displayNames('USD', {type: 'currency'});
+  format.displayName('USD', {type: 'currency'});
 
   // Renders "Latin"
-  format.displayNames('Latn', {type: 'script'});
+  format.displayName('Latn', {type: 'script'});
 }
 ```
 
-See the MDN docs about [`DisplayNames`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) to learn more about the options you can pass to the `displayNames` function.
+See the MDN docs about [`DisplayNames`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) to learn more about the options you can pass to the `displayName` function.
 
 Note that `type` is a required option. The accepted values depend on the runtime, but commonly supported types are: `region`, `language`, `currency`, and `script`.
 
@@ -40,10 +40,10 @@ If you have [global formats](/docs/usage/configuration#formats) configured, you 
 
 ```js
 // Use a global format
-format.displayNames('US', 'region');
+format.displayName('US', 'region');
 
 // Optionally override some options
-format.displayNames('US', 'region', {style: 'narrow'});
+format.displayName('US', 'region', {style: 'narrow'});
 ```
 
 <Callout>

--- a/docs/src/pages/docs/usage/display-names.mdx
+++ b/docs/src/pages/docs/usage/display-names.mdx
@@ -1,0 +1,52 @@
+import Callout from '@/components/Callout';
+
+# Display names
+
+When you need to display locale-aware names for regions, languages, currencies, or scripts, you can use the `displayNames` function from the `useFormatter` hook.
+
+The output adapts to the current locale automatically:
+
+- "United States" in `en-US`
+- "États-Unis" in `fr-FR`
+- "Vereinigte Staaten" in `de-DE`
+
+## Formatting display names
+
+```js
+import {useFormatter} from 'next-intl';
+
+function Component() {
+  const format = useFormatter();
+
+  // Renders "United States"
+  format.displayNames('US', {type: 'region'});
+
+  // Renders "English"
+  format.displayNames('en', {type: 'language'});
+
+  // Renders "US Dollar"
+  format.displayNames('USD', {type: 'currency'});
+
+  // Renders "Latin"
+  format.displayNames('Latn', {type: 'script'});
+}
+```
+
+See the MDN docs about [`DisplayNames`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) to learn more about the options you can pass to the `displayNames` function.
+
+Note that `type` is a required option. The accepted values depend on the runtime, but commonly supported types are: `region`, `language`, `currency`, and `script`.
+
+If you have [global formats](/docs/usage/configuration#formats) configured, you can reference them by passing a name as the second argument:
+
+```js
+// Use a global format
+format.displayNames('US', 'region');
+
+// Optionally override some options
+format.displayNames('US', 'region', {style: 'narrow'});
+```
+
+<Callout>
+  Display names can currently only be formatted via `useFormatter`. There is no
+  equivalent inline syntax for messages.
+</Callout>

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -247,7 +247,7 @@ Please consider upvoting [`TypeScript#32063`](https://github.com/microsoft/TypeS
 
 ## `Formats`
 
-If you're using [global formats](/docs/usage/configuration#formats), you can strictly type the format names that are referenced in calls to `format.dateTime`, `format.number`, `format.list` and `format.displayName`.
+If you're using [global formats](/docs/usage/configuration#formats), you can strictly type the format names that are referenced in calls to `format.dateTime`, `format.displayName`, `format.list` and `format.number`.
 
 ```tsx
 function Component() {
@@ -260,13 +260,13 @@ function Component() {
   format.dateTime(new Date(), 'short');
 
   // ✅ Valid format
-  format.number(2, 'precise');
+  format.displayName('US', 'region');
 
   // ✅ Valid format
   format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
 
   // ✅ Valid format
-  format.displayName('US', 'region');
+  format.number(2, 'precise');
 }
 ```
 
@@ -283,9 +283,9 @@ export const formats = {
       year: 'numeric'
     }
   },
-  number: {
-    precise: {
-      maximumFractionDigits: 5
+  displayName: {
+    region: {
+      type: 'region'
     }
   },
   list: {
@@ -294,9 +294,9 @@ export const formats = {
       type: 'conjunction'
     }
   },
-  displayName: {
-    region: {
-      type: 'region'
+  number: {
+    precise: {
+      maximumFractionDigits: 5
     }
   }
 } satisfies Formats;

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -247,7 +247,7 @@ Please consider upvoting [`TypeScript#32063`](https://github.com/microsoft/TypeS
 
 ## `Formats`
 
-If you're using [global formats](/docs/usage/configuration#formats), you can strictly type the format names that are referenced in calls to `format.dateTime`, `format.number` and `format.list`.
+If you're using [global formats](/docs/usage/configuration#formats), you can strictly type the format names that are referenced in calls to `format.dateTime`, `format.number`, `format.list` and `format.displayNames`.
 
 ```tsx
 function Component() {
@@ -264,6 +264,9 @@ function Component() {
 
   // ✅ Valid format
   format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
+
+  // ✅ Valid format
+  format.displayNames('US', 'region');
 }
 ```
 
@@ -289,6 +292,11 @@ export const formats = {
     enumeration: {
       style: 'long',
       type: 'conjunction'
+    }
+  },
+  displayNames: {
+    region: {
+      type: 'region'
     }
   }
 } satisfies Formats;

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -247,7 +247,7 @@ Please consider upvoting [`TypeScript#32063`](https://github.com/microsoft/TypeS
 
 ## `Formats`
 
-If you're using [global formats](/docs/usage/configuration#formats), you can strictly type the format names that are referenced in calls to `format.dateTime`, `format.number`, `format.list` and `format.displayNames`.
+If you're using [global formats](/docs/usage/configuration#formats), you can strictly type the format names that are referenced in calls to `format.dateTime`, `format.number`, `format.list` and `format.displayName`.
 
 ```tsx
 function Component() {
@@ -266,7 +266,7 @@ function Component() {
   format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
 
   // ✅ Valid format
-  format.displayNames('US', 'region');
+  format.displayName('US', 'region');
 }
 ```
 
@@ -294,7 +294,7 @@ export const formats = {
       type: 'conjunction'
     }
   },
-  displayNames: {
+  displayName: {
     region: {
       type: 'region'
     }

--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -247,7 +247,7 @@ Please consider upvoting [`TypeScript#32063`](https://github.com/microsoft/TypeS
 
 ## `Formats`
 
-If you're using [global formats](/docs/usage/configuration#formats), you can strictly type the format names that are referenced in calls to `format.dateTime`, `format.displayName`, `format.list` and `format.number`.
+If you're using [global formats](/docs/usage/configuration#formats), you can strictly type the format names that are referenced in calls to `format.dateTime`, `format.number`, `format.list` and `format.displayName`.
 
 ```tsx
 function Component() {
@@ -260,13 +260,13 @@ function Component() {
   format.dateTime(new Date(), 'short');
 
   // ✅ Valid format
-  format.displayName('US', 'region');
+  format.number(2, 'precise');
 
   // ✅ Valid format
   format.list(['HTML', 'CSS', 'JavaScript'], 'enumeration');
 
   // ✅ Valid format
-  format.number(2, 'precise');
+  format.displayName('US', 'region');
 }
 ```
 
@@ -283,9 +283,9 @@ export const formats = {
       year: 'numeric'
     }
   },
-  displayName: {
-    region: {
-      type: 'region'
+  number: {
+    precise: {
+      maximumFractionDigits: 5
     }
   },
   list: {
@@ -294,9 +294,9 @@ export const formats = {
       type: 'conjunction'
     }
   },
-  number: {
-    precise: {
-      maximumFractionDigits: 5
+  displayName: {
+    region: {
+      type: 'region'
     }
   }
 } satisfies Formats;

--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -4,7 +4,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-client)",
     path: 'dist/esm/production/index.react-client.js',
-    limit: '11.685 KB'
+    limit: '11.7 KB'
   },
   {
     name: "import {NextIntlClientProvider} from 'next-intl' (react-client)",
@@ -15,7 +15,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-server)",
     path: 'dist/esm/production/index.react-server.js',
-    limit: '12.665 KB'
+    limit: '12.69 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-client)",
@@ -37,7 +37,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl/server' (react-server)",
     path: 'dist/esm/production/server.react-server.js',
-    limit: '11.925 KB'
+    limit: '11.95 KB'
   },
   {
     name: "import * from 'next-intl/middleware'",

--- a/packages/use-intl/.size-limit.ts
+++ b/packages/use-intl/.size-limit.ts
@@ -5,14 +5,14 @@ const config: SizeLimitConfig = [
     name: "import * from 'use-intl' (production)",
     import: '*',
     path: 'dist/esm/production/index.js',
-    limit: '11.61 kB'
+    limit: '11.66 kB'
   },
   {
     name: "import {IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter} from 'use-intl' (production)",
     path: 'dist/esm/production/index.js',
     import:
       '{IntlProvider, useLocale, useNow, useTimeZone, useMessages, useFormatter}',
-    limit: '2.025 kB'
+    limit: '2.04 kB'
   }
 ];
 

--- a/packages/use-intl/src/core/AppConfig.tsx
+++ b/packages/use-intl/src/core/AppConfig.tsx
@@ -17,17 +17,21 @@ export type FormatNames = AppConfig extends {
       dateTime: AppFormats extends {dateTime: infer AppDateTimeFormats}
         ? keyof AppDateTimeFormats
         : string;
-      number: AppFormats extends {number: infer AppNumberFormats}
-        ? keyof AppNumberFormats
+      displayNames: AppFormats extends {displayNames: infer AppDisplayNamesFormats}
+        ? keyof AppDisplayNamesFormats
         : string;
       list: AppFormats extends {list: infer AppListFormats}
         ? keyof AppListFormats
         : string;
+      number: AppFormats extends {number: infer AppNumberFormats}
+        ? keyof AppNumberFormats
+        : string;
     }
   : {
       dateTime: string;
-      number: string;
+      displayNames: string;
       list: string;
+      number: string;
     };
 
 export type Messages = AppConfig extends {

--- a/packages/use-intl/src/core/AppConfig.tsx
+++ b/packages/use-intl/src/core/AppConfig.tsx
@@ -17,8 +17,8 @@ export type FormatNames = AppConfig extends {
       dateTime: AppFormats extends {dateTime: infer AppDateTimeFormats}
         ? keyof AppDateTimeFormats
         : string;
-      displayNames: AppFormats extends {displayNames: infer AppDisplayNamesFormats}
-        ? keyof AppDisplayNamesFormats
+      displayName: AppFormats extends {displayName: infer AppDisplayNameFormats}
+        ? keyof AppDisplayNameFormats
         : string;
       list: AppFormats extends {list: infer AppListFormats}
         ? keyof AppListFormats
@@ -29,7 +29,7 @@ export type FormatNames = AppConfig extends {
     }
   : {
       dateTime: string;
-      displayNames: string;
+      displayName: string;
       list: string;
       number: string;
     };

--- a/packages/use-intl/src/core/Formats.tsx
+++ b/packages/use-intl/src/core/Formats.tsx
@@ -3,7 +3,7 @@ import type NumberFormatOptions from './NumberFormatOptions.js';
 
 type Formats = {
   dateTime?: Record<string, DateTimeFormatOptions>;
-  displayNames?: Record<string, Intl.DisplayNamesOptions>;
+  displayName?: Record<string, Intl.DisplayNamesOptions>;
   list?: Record<string, Intl.ListFormatOptions>;
   number?: Record<string, NumberFormatOptions>;
 };

--- a/packages/use-intl/src/core/Formats.tsx
+++ b/packages/use-intl/src/core/Formats.tsx
@@ -2,9 +2,10 @@ import type DateTimeFormatOptions from './DateTimeFormatOptions.js';
 import type NumberFormatOptions from './NumberFormatOptions.js';
 
 type Formats = {
-  number?: Record<string, NumberFormatOptions>;
   dateTime?: Record<string, DateTimeFormatOptions>;
+  displayNames?: Record<string, Intl.DisplayNamesOptions>;
   list?: Record<string, Intl.ListFormatOptions>;
+  number?: Record<string, NumberFormatOptions>;
 };
 
 export default Formats;

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -423,5 +423,5 @@ export default function createFormatter(props: Props) {
     );
   }
 
-  return {dateTime, dateTimeRange, displayName, list, number, relativeTime};
+  return {dateTime, number, relativeTime, list, dateTimeRange, displayName};
 }

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -423,5 +423,5 @@ export default function createFormatter(props: Props) {
     );
   }
 
-  return {dateTime, number, relativeTime, list, dateTimeRange, displayName};
+  return {dateTime, dateTimeRange, displayName, list, number, relativeTime};
 }

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -418,8 +418,8 @@ export default function createFormatter(props: Props) {
       (options) =>
         // `options` is guaranteed non-null because our overloads require
         // either inline options or a named format that resolves to options.
-        formatters.getDisplayNames(locale, options!).of(value) ?? String(value),
-      () => String(value)
+        formatters.getDisplayNames(locale, options!).of(value),
+      () => value
     );
   }
 

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -397,5 +397,32 @@ export default function createFormatter(props: Props) {
     );
   }
 
-  return {dateTime, number, relativeTime, list, dateTimeRange};
+  function displayNames(
+    value: string,
+    options: Intl.DisplayNamesOptions
+  ): string;
+  function displayNames(
+    value: string,
+    format: FormatNames['displayNames'],
+    options?: Intl.DisplayNamesOptions
+  ): string;
+  function displayNames(
+    value: string,
+    formatOrOptions: FormatNames['displayNames'] | Intl.DisplayNamesOptions,
+    overrides?: Intl.DisplayNamesOptions
+  ) {
+    return getFormattedValue(
+      formatOrOptions,
+      overrides,
+      formats?.displayNames,
+      (options) =>
+        // `options` is guaranteed non-null because our overloads require
+        // either inline options or a named format that resolves to options.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        formatters.getDisplayNames(locale, options!).of(value) ?? String(value),
+      () => String(value)
+    );
+  }
+
+  return {dateTime, number, relativeTime, list, dateTimeRange, displayNames};
 }

--- a/packages/use-intl/src/core/createFormatter.tsx
+++ b/packages/use-intl/src/core/createFormatter.tsx
@@ -397,32 +397,31 @@ export default function createFormatter(props: Props) {
     );
   }
 
-  function displayNames(
+  function displayName(
     value: string,
     options: Intl.DisplayNamesOptions
   ): string;
-  function displayNames(
+  function displayName(
     value: string,
-    format: FormatNames['displayNames'],
+    format: FormatNames['displayName'],
     options?: Intl.DisplayNamesOptions
   ): string;
-  function displayNames(
+  function displayName(
     value: string,
-    formatOrOptions: FormatNames['displayNames'] | Intl.DisplayNamesOptions,
+    formatOrOptions: FormatNames['displayName'] | Intl.DisplayNamesOptions,
     overrides?: Intl.DisplayNamesOptions
   ) {
     return getFormattedValue(
       formatOrOptions,
       overrides,
-      formats?.displayNames,
+      formats?.displayName,
       (options) =>
         // `options` is guaranteed non-null because our overloads require
         // either inline options or a named format that resolves to options.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         formatters.getDisplayNames(locale, options!).of(value) ?? String(value),
       () => String(value)
     );
   }
 
-  return {dateTime, number, relativeTime, list, dateTimeRange, displayNames};
+  return {dateTime, number, relativeTime, list, dateTimeRange, displayName};
 }

--- a/packages/use-intl/src/react/useFormatter.test.tsx
+++ b/packages/use-intl/src/react/useFormatter.test.tsx
@@ -771,14 +771,14 @@ describe('list', () => {
   });
 });
 
-describe('displayNames', () => {
-  function renderDisplayNames(
+describe('displayName', () => {
+  function renderDisplayName(
     value: string,
     options: Intl.DisplayNamesOptions
   ) {
     function Component() {
       const format = useFormatter();
-      return <>{format.displayNames(value, options)}</>;
+      return <>{format.displayName(value, options)}</>;
     }
 
     render(
@@ -789,28 +789,28 @@ describe('displayNames', () => {
   }
 
   it('formats a region', () => {
-    renderDisplayNames('US', {type: 'region'});
+    renderDisplayName('US', {type: 'region'});
     screen.getByText('United States');
   });
 
   it('formats a language', () => {
-    renderDisplayNames('en', {type: 'language'});
+    renderDisplayName('en', {type: 'language'});
     screen.getByText('English');
   });
 
   it('formats a currency', () => {
-    renderDisplayNames('USD', {type: 'currency'});
+    renderDisplayName('USD', {type: 'currency'});
     screen.getByText('US Dollar');
   });
 
   it('can use a global format', () => {
     function Component() {
       const format = useFormatter();
-      return <>{format.displayNames('US', 'region')}</>;
+      return <>{format.displayName('US', 'region')}</>;
     }
 
     render(
-      <MockProvider formats={{displayNames: {region: {type: 'region'}}}}>
+      <MockProvider formats={{displayName: {region: {type: 'region'}}}}>
         <Component />
       </MockProvider>
     );
@@ -828,10 +828,10 @@ describe('displayNames', () => {
       function Component() {
         const format = useFormatter();
         return [
-          format.displayNames('US', {type: 'region'}),
-          format.displayNames('CA', {type: 'region'}),
-          format.displayNames('USD', {type: 'currency'}),
-          format.displayNames('CAD', {type: 'currency'})
+          format.displayName('US', {type: 'region'}),
+          format.displayName('CA', {type: 'region'}),
+          format.displayName('USD', {type: 'currency'}),
+          format.displayName('CAD', {type: 'currency'})
         ].join(';');
       }
 

--- a/packages/use-intl/src/react/useFormatter.test.tsx
+++ b/packages/use-intl/src/react/useFormatter.test.tsx
@@ -770,3 +770,78 @@ describe('list', () => {
     });
   });
 });
+
+describe('displayNames', () => {
+  function renderDisplayNames(
+    value: string,
+    options: Intl.DisplayNamesOptions
+  ) {
+    function Component() {
+      const format = useFormatter();
+      return <>{format.displayNames(value, options)}</>;
+    }
+
+    render(
+      <MockProvider>
+        <Component />
+      </MockProvider>
+    );
+  }
+
+  it('formats a region', () => {
+    renderDisplayNames('US', {type: 'region'});
+    screen.getByText('United States');
+  });
+
+  it('formats a language', () => {
+    renderDisplayNames('en', {type: 'language'});
+    screen.getByText('English');
+  });
+
+  it('formats a currency', () => {
+    renderDisplayNames('USD', {type: 'currency'});
+    screen.getByText('US Dollar');
+  });
+
+  it('can use a global format', () => {
+    function Component() {
+      const format = useFormatter();
+      return <>{format.displayNames('US', 'region')}</>;
+    }
+
+    render(
+      <MockProvider formats={{displayNames: {region: {type: 'region'}}}}>
+        <Component />
+      </MockProvider>
+    );
+
+    screen.getByText('United States');
+  });
+
+  describe('performance', () => {
+    let DisplayNames: SpyImpl;
+    beforeEach(() => {
+      DisplayNames = spyOn(globalThis.Intl, 'DisplayNames');
+    });
+
+    it('caches `Intl.DisplayNames` instances', () => {
+      function Component() {
+        const format = useFormatter();
+        return [
+          format.displayNames('US', {type: 'region'}),
+          format.displayNames('CA', {type: 'region'}),
+          format.displayNames('USD', {type: 'currency'}),
+          format.displayNames('CAD', {type: 'currency'})
+        ].join(';');
+      }
+
+      render(
+        <MockProvider>
+          <Component />
+        </MockProvider>
+      );
+
+      expect(DisplayNames.callCount).toBe(2);
+    });
+  });
+});

--- a/packages/use-intl/src/react/useFormatter.test.tsx
+++ b/packages/use-intl/src/react/useFormatter.test.tsx
@@ -772,10 +772,7 @@ describe('list', () => {
 });
 
 describe('displayName', () => {
-  function renderDisplayName(
-    value: string,
-    options: Intl.DisplayNamesOptions
-  ) {
+  function renderDisplayName(value: string, options: Intl.DisplayNamesOptions) {
     function Component() {
       const format = useFormatter();
       return <>{format.displayName(value, options)}</>;


### PR DESCRIPTION
## Description

Exposes `Intl.DisplayNames` through the `useFormatter` hook as a new singular `displayName` formatter, consistent with existing formatter APIs while matching the underlying `Intl.DisplayNames` naming.

## Why

`Intl.DisplayNames` was already wired in the internal formatter cache (`createIntlFormatters`) but was never surfaced via `useFormatter`. This PR adds the missing public API and keeps naming/docs aligned.

## What changed

- `packages/use-intl/src/core/createFormatter.tsx`
  - Adds `displayName(value, options)` and `displayName(value, format, options?)` overloads.
  - Reuses `formatters.getDisplayNames` cache-backed instances.
- `packages/use-intl/src/core/Formats.tsx`
  - Adds `displayName?: Record<string, Intl.DisplayNamesOptions>` to global formats.
- `packages/use-intl/src/core/AppConfig.tsx`
  - Adds `displayName` format-name typing support in `FormatNames` augmentation.
- `packages/use-intl/src/react/useFormatter.test.tsx`
  - Adds coverage for region/language/currency formatting, named global formats, and `Intl.DisplayNames` instance caching.
- Documentation updates:
  - `docs/src/pages/docs/usage/display-name.mdx` (renamed from `display-names.mdx`) with singular API examples.
  - `docs/src/pages/docs/usage/_meta.tsx` route key updated to `display-name`.
  - `docs/src/pages/docs/usage/configuration.mdx` and `docs/src/pages/docs/workflows/typescript.mdx` updated to singular key/API usage.
  - `docs/src/pages/docs/environments/runtime-requirements.mdx` now explicitly lists `Intl.DisplayNames` and corresponding polyfill entries.

## Test plan

- [x] `format.displayName('US', {type: 'region'})` -> "United States"
- [x] `format.displayName('en', {type: 'language'})` -> "English"
- [x] `format.displayName('USD', {type: 'currency'})` -> "US Dollar"
- [x] Named global format: `format.displayName('US', 'region')` with `formats.displayName.region = {type: 'region'}`
- [x] `Intl.DisplayNames` instances are cached for equivalent options

## Verification run

- `pnpm --filter use-intl test -- run src/react/useFormatter.test.tsx` (pass)
- Docs formatting checked with Prettier on changed docs files
