### PR TITLE
feat: stack all descriptions from multiple files in PO extraction

### DIFF
--- a/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
+++ b/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
@@ -435,6 +435,502 @@ describe('po format', () => {
     expect(relativeSpy).toHaveBeenCalled();
   });
 
+  it('tracks all line numbers when same message appears multiple times in one file', async () => {
+    filesystem.project.src['Greeting.tsx'] =
+      `import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted();
+      return (
+        <div>
+          {t('Hello!')}
+          {t('Hey!')}
+          <span>{t('Hello!')}</span>
+        </div>
+      );
+    }
+    `;
+    filesystem.project.src['Greeting2.tsx'] =
+      `import {useExtracted} from 'next-intl';
+    function Greeting2() {
+      const t = useExtracted();
+      return t('Hello!');
+    }
+    `;
+    filesystem.project.messages = {};
+
+    using compiler = createCompiler();
+    await compiler.extractAll();
+    await waitForWriteFileCalls(1);
+    expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchInlineSnapshot(`
+      "msgid ""
+      msgstr ""
+      "Language: en\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #: src/Greeting.tsx:6
+      #: src/Greeting.tsx:8
+      #: src/Greeting2.tsx:4
+      msgid "OpKKos"
+      msgstr "Hello!"
+
+      #: src/Greeting.tsx:7
+      msgid "+YJVTi"
+      msgstr "Hey!"
+      "
+    `);
+  });
+
+  it('saves messages initially', async () => {
+    filesystem.project.src['Greeting.tsx'] =
+      `import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted();
+      return <div>{t('Hey!')}</div>;
+    }
+    `;
+    filesystem.project.messages = {
+      'en.po': `
+      #: src/Greeting.tsx:4
+      msgid "+YJVTi"
+      msgstr "Hey!"
+      `,
+      'de.po': `
+      #: src/Greeting.tsx:4
+      msgid "+YJVTi"
+      msgstr "Hallo!"
+      `
+    };
+
+    using compiler = createCompiler();
+    await compiler.extractAll();
+    expect(vi.mocked(fs.writeFile).mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "messages/en.po",
+          "msgid ""
+      msgstr ""
+      "Language: en\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #: src/Greeting.tsx:4
+      msgid "+YJVTi"
+      msgstr "Hey!"
+      ",
+        ],
+        [
+          "messages/de.po",
+          "msgid ""
+      msgstr ""
+      "Language: de\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #: src/Greeting.tsx:4
+      msgid "+YJVTi"
+      msgstr "Hallo!"
+      ",
+        ],
+      ]
+    `);
+  });
+
+  it('saves changes to descriptions', async () => {
+    filesystem.project.src['Greeting.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted();
+      return <div>{t('Hey!')}</div>;
+    }
+    `;
+    filesystem.project.messages = {
+      'en.po': `
+      #: src/Greeting.tsx:4
+      msgid "+YJVTi"
+      msgstr "Hey!"
+      `,
+      'de.po': `
+      #: src/Greeting.tsx:4
+      msgid "+YJVTi"
+      msgstr "Hallo!"
+      `
+    };
+
+    using compiler = createCompiler();
+    await compiler.extractAll();
+    await waitForWriteFileCalls(2);
+
+    await simulateSourceFileUpdate(
+      '/project/src/Greeting.tsx',
+      `
+      import {useExtracted} from 'next-intl';
+      function Greeting() {
+        const t = useExtracted();
+        return <div>{t({
+          message: 'Hey!',
+          description: 'Shown on home screen'
+        })}</div>;
+      }
+      `
+    );
+    await waitForWriteFileCalls(4);
+    expect(vi.mocked(fs.writeFile).mock.calls.slice(2)).toMatchInlineSnapshot(`
+      [
+        [
+          "messages/en.po",
+          "msgid ""
+      msgstr ""
+      "Language: en\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #. Shown on home screen
+      #: src/Greeting.tsx:5
+      msgid "+YJVTi"
+      msgstr "Hey!"
+      ",
+        ],
+        [
+          "messages/de.po",
+          "msgid ""
+      msgstr ""
+      "Language: de\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #. Shown on home screen
+      #: src/Greeting.tsx:5
+      msgid "+YJVTi"
+      msgstr "Hallo!"
+      ",
+        ],
+      ]
+    `);
+  });
+
+  it('combines references from multiple files', async () => {
+    filesystem.project.src['Greeting.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted();
+      return <div>{t('Hey!')}</div>;
+    }
+    `;
+    filesystem.project.messages = {
+      'en.po': `
+      #: src/Greeting.tsx:4
+      msgid "+YJVTi"
+      msgstr "Hey!"
+      `,
+      'de.po': `
+      #: src/Greeting.tsx:4
+      msgid "+YJVTi"
+      msgstr "Hallo!"
+      `
+    };
+
+    using compiler = createCompiler();
+    await compiler.extractAll();
+    await waitForWriteFileCalls(2);
+
+    await simulateSourceFileCreate(
+      '/project/src/Footer.tsx',
+      `
+      import {useExtracted} from 'next-intl';
+      function Footer() {
+        const t = useExtracted();
+        return <div>{t('Hey!')}</div>;
+      }
+      `
+    );
+
+    await waitForWriteFileCalls(4);
+
+    expect(vi.mocked(fs.writeFile).mock.calls.slice(2)).toMatchInlineSnapshot(`
+      [
+        [
+          "messages/en.po",
+          "msgid ""
+      msgstr ""
+      "Language: en\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #: src/Footer.tsx:5
+      #: src/Greeting.tsx:5
+      msgid "+YJVTi"
+      msgstr "Hey!"
+      ",
+        ],
+        [
+          "messages/de.po",
+          "msgid ""
+      msgstr ""
+      "Language: de\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #: src/Footer.tsx:5
+      #: src/Greeting.tsx:5
+      msgid "+YJVTi"
+      msgstr "Hallo!"
+      ",
+        ],
+      ]
+    `);
+  });
+
+  it('merges descriptions when message appears in multiple files with different descriptions', async () => {
+    filesystem.project.src['FileY.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function FileY() {
+      const t = useExtracted();
+      return <div>{t({message: 'Message', description: 'Description from FileY'})}</div>;
+    }
+    `;
+    filesystem.project.src['FileZ.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function FileZ() {
+      const t = useExtracted();
+      return (
+        <div>
+          {t('Message')}
+          {t({message: 'Message', description: 'Description from FileZ'})}
+        </div>
+      );
+    }
+    `;
+    filesystem.project.messages = {};
+
+    using compiler = createCompiler();
+    await compiler.extractAll();
+    await waitForWriteFileCalls(1);
+
+    expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchInlineSnapshot(`
+      "msgid ""
+      msgstr ""
+      "Language: en\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #. Description from FileY
+      #. Description from FileZ
+      #: src/FileY.tsx:5
+      #: src/FileZ.tsx:7
+      #: src/FileZ.tsx:8
+      msgid "T7Ry38"
+      msgstr "Message"
+      "
+    `);
+  });
+
+  it('updates references in all catalogs when message is reused in another file', async () => {
+    filesystem.project.src['Greeting.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted();
+      return <div>{t('Hey!')}</div>;
+    }
+    `;
+    filesystem.project.messages = {
+      'en.po': '',
+      'de.po': ''
+    };
+
+    using compiler = createCompiler();
+
+    // First compile: Only Greeting.tsx has the message
+    await compiler.extractAll();
+    await waitForWriteFileCalls(2);
+
+    expect(vi.mocked(fs.writeFile).mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "messages/en.po",
+          "msgid ""
+      msgstr ""
+      "Language: en\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #: src/Greeting.tsx:5
+      msgid "+YJVTi"
+      msgstr "Hey!"
+      ",
+        ],
+        [
+          "messages/de.po",
+          "msgid ""
+      msgstr ""
+      "Language: de\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #: src/Greeting.tsx:5
+      msgid "+YJVTi"
+      msgstr ""
+      ",
+        ],
+      ]
+    `);
+
+    // Second compile: Footer.tsx also uses the same message
+    await simulateSourceFileCreate(
+      '/project/src/Footer.tsx',
+      `
+      import {useExtracted} from 'next-intl';
+      function Footer() {
+        const t = useExtracted();
+        return <div>{t('Hey!')}</div>;
+      }
+      `
+    );
+    await waitForWriteFileCalls(4);
+
+    expect(vi.mocked(fs.writeFile).mock.calls.slice(2)).toMatchInlineSnapshot(`
+      [
+        [
+          "messages/en.po",
+          "msgid ""
+      msgstr ""
+      "Language: en\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #: src/Footer.tsx:5
+      #: src/Greeting.tsx:5
+      msgid "+YJVTi"
+      msgstr "Hey!"
+      ",
+        ],
+        [
+          "messages/de.po",
+          "msgid ""
+      msgstr ""
+      "Language: de\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #: src/Footer.tsx:5
+      #: src/Greeting.tsx:5
+      msgid "+YJVTi"
+      msgstr ""
+      ",
+        ],
+      ]
+    `);
+  });
+
+  it('removes references when a message is dropped from a single file', async () => {
+    filesystem.project.src['Greeting.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted();
+      return (
+        <div>
+          {t('Hey!')}
+          {t('Howdy!')}
+        </div>
+      );
+    }
+    `;
+    filesystem.project.src['Footer.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Footer() {
+      const t = useExtracted();
+      return <div>{t('Hey!')}</div>;
+    }
+    `;
+    filesystem.project.messages = {
+      'en.po': '',
+      'de.po': ''
+    };
+
+    using compiler = createCompiler();
+    await compiler.extractAll();
+    await waitForWriteFileCalls(2);
+
+    await simulateSourceFileUpdate(
+      '/project/src/Greeting.tsx',
+      `
+      import {useExtracted} from 'next-intl';
+      function Greeting() {
+        const t = useExtracted();
+        return <div>{t('Howdy!')}</div>;
+      }
+      `
+    );
+
+    await waitForWriteFileCalls(4);
+    expect(vi.mocked(fs.writeFile).mock.calls.slice(-2)).toMatchInlineSnapshot(`
+      [
+        [
+          "messages/en.po",
+          "msgid ""
+      msgstr ""
+      "Language: en\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #: src/Footer.tsx:5
+      msgid "+YJVTi"
+      msgstr "Hey!"
+
+      #: src/Greeting.tsx:5
+      msgid "4xqPlJ"
+      msgstr "Howdy!"
+      ",
+        ],
+        [
+          "messages/de.po",
+          "msgid ""
+      msgstr ""
+      "Language: de\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: next-intl\\n"
+      "X-Crowdin-SourceKey: msgstr\\n"
+
+      #: src/Footer.tsx:5
+      msgid "+YJVTi"
+      msgstr ""
+
+      #: src/Greeting.tsx:5
+      msgid "4xqPlJ"
+      msgstr ""
+      ",
+        ],
+      ]
+    `);
+  });
+
   it('removes obsolete messages during build', async () => {
     filesystem.project.messages = {
       'en.po': `

--- a/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
+++ b/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
@@ -316,8 +316,25 @@ export default class CatalogManager implements Disposable {
           );
         }
 
-        // Merge other properties like description, or unknown
-        // attributes like flags that are opaque to us
+        // Merge descriptions: accumulate all unique descriptions
+        if (prevMessage.description != null && message.description != null) {
+          const prevDescs = Array.isArray(prevMessage.description)
+            ? prevMessage.description
+            : [prevMessage.description];
+          const currDescs = Array.isArray(message.description)
+            ? message.description
+            : [message.description];
+          const merged = [...prevDescs];
+          for (const d of currDescs) {
+            if (!merged.includes(d)) {
+              merged.push(d);
+            }
+          }
+          merged.sort();
+          message.description = merged.length === 1 ? merged[0] : merged;
+        }
+
+        // Merge other unknown attributes like flags that are opaque to us
         for (const key of Object.keys(prevMessage)) {
           if (message[key] == null) {
             message[key] = prevMessage[key];
@@ -416,7 +433,7 @@ export default class CatalogManager implements Disposable {
     return (
       msg1.id === msg2.id &&
       msg1.message === msg2.message &&
-      msg1.description === msg2.description
+      JSON.stringify(msg1.description) === JSON.stringify(msg2.description)
     );
   }
 

--- a/packages/next-intl/src/extractor/format/codecs/POCodec.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/POCodec.tsx
@@ -32,19 +32,16 @@ export default defineCodec(() => {
       return messages.map((msg) => {
         const {extractedComments, msgctxt, msgid, msgstr, ...rest} = msg;
 
-        if (extractedComments && extractedComments.length > 1) {
-          throw new Error(
-            `Multiple extracted comments are not supported. Found ${extractedComments.length} comments for msgid "${msgid}".`
-          );
-        }
-
         return {
           ...rest,
           id: msgctxt ? [msgctxt, msgid].join(NAMESPACE_SEPARATOR) : msgid,
           message: msgstr,
           ...(extractedComments &&
             extractedComments.length > 0 && {
-              description: extractedComments[0]
+              description:
+                extractedComments.length === 1
+                  ? extractedComments[0]
+                  : extractedComments
             })
         };
       });
@@ -64,7 +61,11 @@ export default defineCodec(() => {
         return {
           msgid,
           msgstr: message,
-          ...(description && {extractedComments: [description]}),
+          ...(description && {
+            extractedComments: Array.isArray(description)
+              ? description
+              : [description]
+          }),
           ...(hasNamespace && {msgctxt: id.slice(0, lastDotIndex)}),
           ...rest
         };

--- a/packages/next-intl/src/extractor/format/codecs/fixtures/JSONCodecStructured.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/fixtures/JSONCodecStructured.tsx
@@ -1,6 +1,6 @@
 import {defineCodec} from '../../ExtractorCodec.js';
 
-type StoredMessage = {message: string; description?: string};
+type StoredMessage = {message: string; description?: string | Array<string>};
 
 export default defineCodec(() => ({
   decode(content) {

--- a/packages/next-intl/src/extractor/format/codecs/fixtures/POCodecSourceMessageKey.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/fixtures/POCodecSourceMessageKey.tsx
@@ -25,13 +25,7 @@ export default defineCodec(() => {
 
         // Necessary to restore the ID
         if (!msgctxt) {
-          throw new Error('msgctxt is required');
-        }
-
-        if (extractedComments && extractedComments.length > 1) {
-          throw new Error(
-            `Multiple extracted comments are not supported. Found ${extractedComments.length} comments for msgid "${msgid}".`
-          );
+          throw new Error(`msgctxt is required for msgid "${msgid}"`);
         }
 
         return {
@@ -40,7 +34,10 @@ export default defineCodec(() => {
           message: msgstr,
           ...(extractedComments &&
             extractedComments.length > 0 && {
-              description: extractedComments[0]
+              description:
+                extractedComments.length === 1
+                  ? extractedComments[0]
+                  : extractedComments
             })
         };
       });
@@ -58,7 +55,11 @@ export default defineCodec(() => {
         // Store the hashed ID in msgctxt so we can restore it during decode
         const {description, id, message, ...rest} = msg;
         return {
-          ...(description && {extractedComments: [description]}),
+          ...(description && {
+            extractedComments: Array.isArray(description)
+              ? description
+              : [description]
+          }),
           ...rest,
           msgctxt: id,
           msgid: sourceMessage,

--- a/packages/next-intl/src/extractor/types.tsx
+++ b/packages/next-intl/src/extractor/types.tsx
@@ -13,7 +13,7 @@ export type ExtractorMessageReference = {
 export type ExtractorMessage = {
   id: string;
   message: string;
-  description?: string;
+  description?: string | Array<string>;
   references?: Array<ExtractorMessageReference>;
   /** Allows for additional properties like .po flags to be read and later written. */
   [key: string]: unknown;


### PR DESCRIPTION
### Description

This PR fixes an issue where extracting identical messages with different descriptions into a .po file resulted in non-deterministic behavior. Previously, the extractor only kept one description (first-wins), which led to missing translator context and unnecessary git diffs depending on the extraction order.

### Changes in this PR:

- All unique descriptions for a given message are now accumulated.
- They are output as separate #.  lines above the translation block.
- The descriptions are sorted alphabetically to guarantee a deterministic .po file output every time.

###### Before:

```po
#. First description
msgid ""
msgstr ""
```


###### After:

```po
#. First description
#. Second description
msgid ""
msgstr ""
```

### Related Issue
Closes #2286