### PR TITLE
fix: type checking for union message types

### DIFF
--- a/docs/src/pages/docs/workflows/typescript.mdx
+++ b/docs/src/pages/docs/workflows/typescript.mdx
@@ -129,6 +129,21 @@ declare module 'next-intl' {
 }
 ```
 
+If some of your locales have different keys (e.g., a key exists in `en.json` but is missing in `es.json`), you can use a union type to catch these inconsistencies at the call site.
+With this setup, only keys that are present in **all** locale files are accessible via the translator — using a key missing in any locale will result in a TypeScript error.
+
+```ts filename="global.ts"
+import messagesEn from './messages/en.json';
+import messagesEs from './messages/es.json';
+
+declare module 'next-intl' {
+  interface AppConfig {
+    // ...
+    Messages: typeof messagesEn | typeof messagesEs;
+  }
+}
+```
+
 You can freely define the interface, but if you have your messages available locally, it can be helpful to automatically create the type based on the messages from your default locale.
 
 <Details id="messages-performance-tsc">

--- a/packages/use-intl/src/core/MessageKeys.tsx
+++ b/packages/use-intl/src/core/MessageKeys.tsx
@@ -1,9 +1,9 @@
-export type NestedKeyOf<ObjectType> = ObjectType extends object
+export type NestedKeyOf<ObjectType> = [ObjectType] extends [object]
   ? {
-      [Property in keyof ObjectType]:
-        | `${Property & string}`
-        | `${Property & string}.${NestedKeyOf<ObjectType[Property]>}`;
-    }[keyof ObjectType]
+      [Property in keyof ObjectType & string]:
+        | Property
+        | `${Property}.${NestedKeyOf<ObjectType[Property]>}`;
+    }[keyof ObjectType & string]
   : never;
 
 export type NestedValueOf<
@@ -30,7 +30,9 @@ export type MessageKeys<ObjectType, AllKeys extends string> = {
   [PropertyPath in AllKeys]: NestedValueOf<
     ObjectType,
     PropertyPath
-  > extends string
-    ? PropertyPath
+  > extends infer V
+    ? V extends string
+      ? PropertyPath
+      : never
     : never;
 }[AllKeys];

--- a/packages/use-intl/src/core/createTranslator.test.tsx
+++ b/packages/use-intl/src/core/createTranslator.test.tsx
@@ -228,6 +228,75 @@ describe('type safety', () => {
     });
   });
 
+  describe('keys, union messages type', () => {
+    type MessagesEn = {meta: {title: 'title'; description: 'description'}};
+    type MessagesEs = {meta: {title: 'title-es'}};
+    type MessagesUnion = MessagesEn | MessagesEs;
+
+    it('allows keys present in all union members', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      () => {
+        const t = createTranslator<MessagesUnion>({
+          locale: 'en',
+          messages: {meta: {title: 'title', description: 'description'}}
+        });
+        t('meta.title');
+
+        const tMeta = createTranslator<MessagesUnion, 'meta'>({
+          locale: 'en',
+          namespace: 'meta',
+          messages: {meta: {title: 'title', description: 'description'}}
+        });
+        tMeta('title');
+      };
+    });
+
+    it('requires params from all union members when a key has different args', () => {
+      type MessagesWithParamsEn = {title: 'Hello {name}'};
+      type MessagesWithParamsEs = {title: 'Hola {count, number}'};
+      type MessagesWithParamsUnion =
+        | MessagesWithParamsEn
+        | MessagesWithParamsEs;
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      () => {
+        const t = createTranslator<MessagesWithParamsUnion>({
+          locale: 'en',
+          messages: {title: 'Hello {name}'}
+        });
+
+        // Providing all params from all union members is valid
+        t('title', {name: 'John', count: 5});
+
+        // Providing only some params is an error
+        // @ts-expect-error
+        t('title', {name: 'John'});
+        // @ts-expect-error
+        t('title', {count: 5});
+      };
+    });
+
+    it('disallows keys missing in some union members', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      () => {
+        const t = createTranslator<MessagesUnion>({
+          locale: 'en',
+          messages: {meta: {title: 'title', description: 'description'}}
+        });
+        // @ts-expect-error
+        t('meta.description');
+
+        const tMeta = createTranslator<MessagesUnion, 'meta'>({
+          locale: 'en',
+          namespace: 'meta',
+          messages: {meta: {title: 'title', description: 'description'}}
+        });
+        // @ts-expect-error
+        tMeta('description');
+      };
+    });
+  });
+
   describe('params, strictly-typed', () => {
     function translateMessage<const T extends string>(msg: T) {
       return createTranslator({


### PR DESCRIPTION
# Fix type-safe message key resolution for union message schemas

## Summary

This PR fixes a type inference issue in message key resolution when the messages object is defined as a union type.

Previously, keys that were not present in all union members could be incorrectly accepted by the type system, which weakened compile-time safety and allowed invalid translation keys to pass unnoticed.

## Example of the issue

Given a union of message schemas such as:

- `MessagesEn` includes `meta.title` and `meta.description`
- `MessagesEs` includes only `meta.title`

the key `meta.description` should be rejected, because it does not exist in every union member.

However, before this fix, TypeScript could incorrectly treat such a key as valid in some cases.

## Root cause

The key resolution logic did not properly exclude paths that evaluated to `never` for some union members. As a result, keys that were missing in part of the union could still be considered valid due to TypeScript’s distributive behavior.

## What changed

The message key filtering logic was updated to explicitly detect `never`-resolved paths and exclude them from the allowed key set.

This ensures that:

- only keys present in all union members are accepted
- invalid keys are rejected at compile time
- type safety remains consistent for both strictly typed and union-based message schemas

## Impact

- Stronger compile-time validation for translation keys
- Fewer false positives in TypeScript
- Better developer experience when working with heterogeneous message schemas

## Validation

The change is covered by type-level test cases that verify:

- valid keys shared across union members remain accepted
- keys missing in at least one union member are rejected

---