### PR TITLE
feat: add `devExtraction` option to skip catalog writes during dev

### DIFF
--- a/packages/next-intl/src/plugin/extractor/initExtractionCompiler.tsx
+++ b/packages/next-intl/src/plugin/extractor/initExtractionCompiler.tsx
@@ -25,9 +25,10 @@ export default function initExtractionCompiler(pluginConfig: PluginConfig) {
   // - lint
   //
   // What remains are:
-  // - dev (NODE_ENV=development)
+  // - dev (NODE_ENV=development), skipped when devExtraction is false
   // - build (NODE_ENV=production)
-  const shouldRun = isDevelopment || isNextBuild;
+  const devExtraction = experimental.extract?.devExtraction !== false;
+  const shouldRun = (isDevelopment && devExtraction) || isNextBuild;
   if (!shouldRun) return;
 
   runOnce(() => {

--- a/packages/next-intl/src/plugin/types.tsx
+++ b/packages/next-intl/src/plugin/types.tsx
@@ -27,6 +27,12 @@ export type PluginConfig = {
     /** Enables the usage of `useExtracted`, to be used in combination with `srcPath` and `messages`. */
     extract?: {
       sourceLocale: string;
+      /**
+       * Whether to automatically extract messages during `next dev`.
+       * The SWC transform for `useExtracted` runs regardless.
+       * @default true
+       */
+      devExtraction?: boolean;
     };
   };
 };


### PR DESCRIPTION
Add `devExtraction` option to the `extract` config. When set to `false`, the `ExtractionCompiler` (which scans source files and writes message catalogs) is skipped during `next dev`, while the SWC extraction loader (which compiles `useExtracted` into `useTranslations`) continues to run.

This enables a workflow where:
1. Developers use `useExtracted` in code as normal
2. `next dev` does not write PO/JSON files, keeping the working tree clean
3. Message extraction runs via `unstable_extractMessages` in CI or a separate script (e.g. a GitHub Action)
4. `next build` still runs extraction as before

Usage:
```ts
createNextIntlPlugin({
  experimental: {
    srcPath: './src',
    extract: {
      sourceLocale: 'en',
      devExtraction: false
    },
    messages: { path: './messages', format: 'po', locales: 'infer' }
  }
});
```

Defaults to `true` for full backwards compatibility.