### PR TITLE
feat: add perf tests

### DIFF
--- a/.github/workflows/type-perf.yml
+++ b/.github/workflows/type-perf.yml
@@ -1,0 +1,36 @@
+name: type-perf
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      # Run only when files that affect type instantiation counts change
+      - "packages/use-intl/src/core/**"
+      - "packages/use-intl/perf/**"
+
+jobs:
+  check:
+    name: TypeScript instantiation regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so `git show origin/<base>:…` works
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: "pnpm"
+
+      - run: pnpm install
+
+      - name: Fetch base branch for comparison
+        run: git fetch origin ${{ github.base_ref }}
+
+      - name: Check for TypeScript instantiation regression
+        run: pnpm --filter use-intl perf:types:ci
+        # GITHUB_BASE_REF is set automatically by GitHub Actions on pull_request events
+        # The script uses it to compare against origin/<base_ref>

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 node_modules/
 .vscode
+.idea
 .vercel
 .turbo/
 dist/

--- a/packages/use-intl/package.json
+++ b/packages/use-intl/package.json
@@ -24,7 +24,9 @@
     "lint:package": "publint && attw --pack --ignore-rules=cjs-resolves-to-esm",
     "lint:prettier": "prettier src --check",
     "prepublishOnly": "turbo build",
-    "size": "size-limit"
+    "size": "size-limit",
+    "perf:types": "tsc --noEmit --extendedDiagnostics -p tsconfig.perf.json",
+    "perf:types:ci": "node perf/check-type-perf.mjs"
   },
   "type": "module",
   "main": "./dist/esm/production/index.js",

--- a/packages/use-intl/perf/ICUArgs.perf-test.ts
+++ b/packages/use-intl/perf/ICUArgs.perf-test.ts
@@ -1,0 +1,130 @@
+/**
+ * Performance test for `ICUArgs<Message, Options>`.
+ *
+ * Two layers of coverage:
+ *  - Spot checks — one canonical message per ICU variant; each `Assert`
+ *    resolving to `never` signals a type regression.
+ *  - Bulk instantiation — 100 unique ICU strings per variant via `TwoDigit`;
+ *    unique param names prevent structural caching in `GetICUArgs`.
+ */
+
+import type ICUArgs from '../src/core/ICUArgs.js';
+import type {Assert, ICUArgOpts, TwoDigit} from './helpers.js';
+
+// ── Spot checks ───────────────────────────────────────────────────────────────
+
+type AssertPlain = Assert<
+  ICUArgs<'Hello, {name}!', ICUArgOpts>,
+  {name: string}
+>;
+type AssertPlural = Assert<
+  ICUArgs<
+    '{count, plural, =0 {nothing} one {# item} other {# items}}',
+    ICUArgOpts
+  >,
+  {count: number | bigint}
+>;
+type AssertSelect = Assert<
+  ICUArgs<'{gender, select, male {He} female {She} other {They}}', ICUArgOpts>,
+  {gender: string}
+>;
+type AssertOrdinal = Assert<
+  ICUArgs<
+    '{n, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}',
+    ICUArgOpts
+  >,
+  {n: number | bigint}
+>;
+type AssertNumber = Assert<
+  ICUArgs<'Progress: {value, number, percent}', ICUArgOpts>,
+  {value: number | bigint}
+>;
+type AssertDate = Assert<
+  ICUArgs<'Scheduled: {date, date, full}', ICUArgOpts>,
+  {date: Date}
+>;
+type AssertTime = Assert<
+  ICUArgs<'At {time, time, short}', ICUArgOpts>,
+  {time: Date}
+>;
+type AssertDateSkeleton = Assert<
+  ICUArgs<'Born: {date, date, ::yyyyMMMd}', ICUArgOpts>,
+  {date: Date}
+>;
+type AssertCombined = Assert<
+  ICUArgs<
+    '{count, plural, one {{name} won # item} other {{name} won # items}}',
+    ICUArgOpts
+  >,
+  {count: number | bigint; name: string}
+>;
+type AssertNested = Assert<
+  ICUArgs<
+    '{count, plural, one {{gender, select, male {He won} female {She won} other {They won}} # item} other {# items}}',
+    ICUArgOpts
+  >,
+  {count: number | bigint; gender: string}
+>;
+
+// ── Bulk instantiation ────────────────────────────────────────────────────────
+
+type BulkPlain = {[K in TwoDigit]: ICUArgs<`Hello, {name${K}}!`, ICUArgOpts>};
+type BulkPlural = {
+  [K in TwoDigit]: ICUArgs<
+    `{count${K}, plural, =0 {nothing} one {# item} other {# items}}`,
+    ICUArgOpts
+  >;
+};
+type BulkSelect = {
+  [K in TwoDigit]: ICUArgs<
+    `{gender${K}, select, male {He} female {She} other {They}}`,
+    ICUArgOpts
+  >;
+};
+type BulkOrdinal = {
+  [K in TwoDigit]: ICUArgs<
+    `{n${K}, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}`,
+    ICUArgOpts
+  >;
+};
+type BulkNumber = {
+  [K in TwoDigit]: ICUArgs<
+    `Progress: {value${K}, number, percent}`,
+    ICUArgOpts
+  >;
+};
+type BulkDate = {
+  [K in TwoDigit]: ICUArgs<`Scheduled: {date${K}, date, full}`, ICUArgOpts>;
+};
+type BulkTime = {
+  [K in TwoDigit]: ICUArgs<`At {time${K}, time, short}`, ICUArgOpts>;
+};
+type BulkCombined = {
+  [K in TwoDigit]: ICUArgs<
+    `{count${K}, plural, one {{name${K}} won # item} other {{name${K}} won # items}}`,
+    ICUArgOpts
+  >;
+};
+
+type _ = [
+  AssertPlain,
+  AssertPlural,
+  AssertSelect,
+  AssertOrdinal,
+  AssertNumber,
+  AssertDate,
+  AssertTime,
+  AssertDateSkeleton,
+  AssertCombined,
+  AssertNested,
+  BulkPlain,
+  BulkPlural,
+  BulkSelect,
+  BulkOrdinal,
+  BulkNumber,
+  BulkDate,
+  BulkTime,
+  BulkCombined
+] extends unknown
+  ? true
+  : false;

--- a/packages/use-intl/perf/ICUTags.perf-test.ts
+++ b/packages/use-intl/perf/ICUTags.perf-test.ts
@@ -1,0 +1,101 @@
+/**
+ * Performance test for `ICUTags<MessageString, TagsFn>`.
+ *
+ * Two layers of coverage:
+ *  - Spot checks — one message per structural tag pattern; each `Assert`
+ *    resolving to `never` signals a type regression.
+ *  - Bulk instantiation — 100 unique tag names per pattern via `TwoDigit`;
+ *    distinct tag names force a fresh recursive conditional per message.
+ */
+
+import type ICUTags from '../src/core/ICUTags.js';
+import type {
+  MarkupTagsFunction,
+  RichTagsFunction
+} from '../src/core/TranslationValues.js';
+import type {Assert, TwoDigit} from './helpers.js';
+
+// ── Spot checks ───────────────────────────────────────────────────────────────
+
+type AssertSingleTag = Assert<
+  ICUTags<'Click <link>here</link> for help.', RichTagsFunction>,
+  {link: RichTagsFunction}
+>;
+type AssertSiblingTags = Assert<
+  ICUTags<'<b>Bold</b> and <i>italic</i> text.', RichTagsFunction>,
+  {b: RichTagsFunction; i: RichTagsFunction}
+>;
+type AssertNestedTags = Assert<
+  ICUTags<'<outer><inner>text</inner></outer>', RichTagsFunction>,
+  {outer: RichTagsFunction; inner: RichTagsFunction}
+>;
+type AssertTagWithParam = Assert<
+  ICUTags<'Hello <strong>{name}</strong>!', RichTagsFunction>,
+  {strong: RichTagsFunction}
+>;
+type AssertTagInPlural = Assert<
+  ICUTags<
+    '{count, plural, one {<b># item</b>} other {<b># items</b>}}',
+    RichTagsFunction
+  >,
+  {b: RichTagsFunction}
+>;
+type AssertTripleTags = Assert<
+  ICUTags<'<a>one</a>, <b>two</b>, and <c>three</c>.', RichTagsFunction>,
+  {a: RichTagsFunction; b: RichTagsFunction; c: RichTagsFunction}
+>;
+type AssertMarkupTags = Assert<
+  ICUTags<
+    'Accept the <bold>terms</bold> and <em>conditions</em>.',
+    MarkupTagsFunction
+  >,
+  {bold: MarkupTagsFunction; em: MarkupTagsFunction}
+>;
+type AssertNoTags = Assert<
+  ICUTags<'Plain text with {param} only.', RichTagsFunction>,
+  Record<string, never>
+>;
+
+// ── Bulk instantiation ────────────────────────────────────────────────────────
+
+type BulkSingleTag = {
+  [K in TwoDigit]: ICUTags<
+    `Click <link${K}>here</link${K}>.`,
+    RichTagsFunction
+  >;
+};
+type BulkSiblingTags = {
+  [K in TwoDigit]: ICUTags<
+    `<a${K}>first</a${K}> and <b${K}>second</b${K}>.`,
+    RichTagsFunction
+  >;
+};
+type BulkNestedTags = {
+  [K in TwoDigit]: ICUTags<
+    `<outer${K}><inner${K}>deep</inner${K}></outer${K}>`,
+    RichTagsFunction
+  >;
+};
+type BulkTagWithParam = {
+  [K in TwoDigit]: ICUTags<
+    `Hello <em${K}>{name${K}}</em${K}>!`,
+    RichTagsFunction
+  >;
+};
+
+type _ = [
+  AssertSingleTag,
+  AssertSiblingTags,
+  AssertNestedTags,
+  AssertTagWithParam,
+  AssertTagInPlural,
+  AssertTripleTags,
+  AssertMarkupTags,
+  AssertNoTags,
+  BulkSingleTag,
+  BulkSiblingTags,
+  BulkNestedTags,
+  BulkTagWithParam
+] extends unknown
+  ? true
+  : false;

--- a/packages/use-intl/perf/MessageKeys.perf-test.ts
+++ b/packages/use-intl/perf/MessageKeys.perf-test.ts
@@ -1,0 +1,51 @@
+/**
+ * Performance test for `NestedKeyOf`, `MessageKeys`, and `NamespaceKeys`.
+ *
+ * `BigMessages` has 1 200+ leaf keys across 11 ICU-variant sections and
+ * three nesting levels. Values are concrete ICU string literals rather
+ * than generic `string` so the type realistically mirrors a real-world
+ * next-intl message catalog produced by `typeof messages`.
+ */
+
+import type {MessageKeys, NamespaceKeys, NestedKeyOf} from '../src/core/MessageKeys.js';
+import type {TwoDigit} from './helpers.js';
+
+/**
+ * Canonical large message catalog used across perf tests.
+ * Each section represents a distinct ICU notation variant; each has 100
+ * keys generated via `TwoDigit` (00–99).
+ */
+export type BigMessages = {
+  plain: {[K in TwoDigit as `msg_${K}`]: 'Hello, {name}!'};
+  plural: {
+    [K in TwoDigit as `msg_${K}`]: '{count, plural, =0 {nothing} one {# item} other {# items}}';
+  };
+  select: {
+    [K in TwoDigit as `msg_${K}`]: '{gender, select, male {He} female {She} other {They}}';
+  };
+  ordinal: {
+    [K in TwoDigit as `msg_${K}`]: '{n, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}';
+  };
+  number: {[K in TwoDigit as `msg_${K}`]: 'Progress: {value, number, percent}'};
+  date: {[K in TwoDigit as `msg_${K}`]: 'Scheduled: {date, date, full}'};
+  time: {[K in TwoDigit as `msg_${K}`]: 'At {time, time, short}'};
+  rich: {[K in TwoDigit as `msg_${K}`]: 'Click <link>here</link> for details.'};
+  markup: {[K in TwoDigit as `msg_${K}`]: '<b>Important</b>: {message}'};
+  nested: {
+    alpha: {
+      [K in TwoDigit as `msg_${K}`]: '{alphaCount, plural, one {# alpha} other {# alphas}}';
+    };
+    beta: {[K in TwoDigit as `msg_${K}`]: '{betaValue, number}'};
+  };
+  deepNested: {
+    level1: {
+      level2: {[K in TwoDigit as `msg_${K}`]: 'Deep: {deepVal, date, short}'};
+    };
+  };
+};
+
+type AllPaths = NestedKeyOf<BigMessages>;
+type MessageLeafKeys = MessageKeys<BigMessages, AllPaths>;
+type NamespaceKeys_ = NamespaceKeys<BigMessages, AllPaths>;
+
+type _ = [MessageLeafKeys, NamespaceKeys_] extends unknown ? true : false;

--- a/packages/use-intl/perf/README.md
+++ b/packages/use-intl/perf/README.md
@@ -1,0 +1,120 @@
+# Type-performance tests
+
+This directory contains TypeScript type-performance tests for `use-intl`. They measure how many times the TypeScript
+compiler instantiates generic types (`Instantiations` in `tsc --extendedDiagnostics`) and detect regressions
+automatically in CI.
+
+## Why `Instantiations`, not `Total time`
+
+`Total time` varies with CPU load, caching, and machine temperature. `Instantiations` is a pure, deterministic count:
+the same source always produces the same number regardless of where or when it runs. A 20 % increase in instantiations
+reliably signals that a type change added real complexity.
+
+## Running locally
+
+```sh
+# Measure instantiation count for the full test suite
+pnpm perf:types
+
+# Compare current branch against upstream/main and fail if regression > 5%
+pnpm perf:types:ci
+
+# Override the comparison base or threshold
+node perf/check-type-perf.mjs --base-ref origin/my-base-branch --threshold 1.15
+```
+
+`perf:types:ci` auto-detects the comparison base: it prefers `upstream/main` (fork workflow) and falls back to
+`origin/main`. In GitHub Actions, `GITHUB_BASE_REF` is used automatically.
+
+## How the CI check works
+
+`check-type-perf.mjs` temporarily swaps the files listed in `TRACKED_FILES` with their versions from the base branch,
+runs `tsc --extendedDiagnostics`, then restores the originals and runs again. The ratio of PR / baseline instantiations
+is compared against `THRESHOLD` (default: 1.05 = 5%).
+
+Files are restored in a `try/finally` block, so an interrupted run cannot leave the working tree dirty.
+
+## File structure
+
+```
+perf/
+├── helpers.ts                   # Shared type primitives (import from here, not inline)
+├── check-type-perf.mjs          # CI comparison script
+├── MessageKeys.perf-test.ts     # NestedKeyOf / MessageKeys / NamespaceKeys
+├── createTranslator.perf-test.ts# Translator<T, Namespace> + ICUArgs via call sites
+├── ICUArgs.perf-test.ts         # ICUArgs<Message, Options> in isolation
+└── ICUTags.perf-test.ts         # ICUTags<MessageString, TagsFn> in isolation
+```
+
+Each test file name mirrors its primary source file (`<source>.perf-test.ts`).
+
+## Writing a new test
+
+### 1. Create `perf/<SourceFile>.perf-test.ts`
+
+Import shared primitives from `helpers.ts`:
+
+```ts
+import type {Assert, Digit, ICUArgOpts, TwoDigit} from './helpers.js';
+```
+
+| Helper         | Size | Use for                                                          |
+|----------------|------|------------------------------------------------------------------|
+| `Digit`        | 10   | Translator tests — key count scales aggressively with call sites |
+| `TwoDigit`     | 100  | Bulk mapped types — 100 independent instantiations per variant   |
+| `ICUArgOpts`   | —    | Any test that touches `ICUArgs` directly                         |
+| `Assert<T, E>` | —    | Spot-check that `T extends E`; resolves to `never` on regression |
+
+### 2. Apply the two-layer pattern
+
+Every test file should have two sections:
+
+**Spot checks** — one representative message per structural variant, each wrapped in `Assert`. These double as
+type-level regression tests:
+
+```ts
+type AssertPlain = Assert<ICUArgs<'Hello, {name}!', ICUArgOpts>, {name: string}>;
+```
+
+**Bulk instantiation** — 100 unique messages generated via `TwoDigit` mapped types. Unique param/tag names per index `K`
+prevent structural caching:
+
+```ts
+type BulkPlain = { [K in TwoDigit]: ICUArgs<`Hello, {name${K}}!`, ICUArgOpts> };
+```
+
+### 3. Force evaluation
+
+TypeScript evaluates type aliases lazily. Reference every type you want counted in a terminal tuple so the compiler
+cannot defer work:
+
+```ts
+type _ = [AssertPlain, BulkPlain, ...]
+extends
+unknown ? true : false;
+```
+
+### 4. Register the source file in the CI check
+
+Open `check-type-perf.mjs` and add the source file path (relative to repo root) to `TRACKED_FILES`:
+
+```js
+const TRACKED_FILES = [
+  'packages/use-intl/src/core/MessageKeys.tsx',
+  'packages/use-intl/src/core/YourNewFile.tsx', // ← add here
+  ...
+];
+```
+
+The script swaps these files to their base-branch versions for the baseline measurement. Only add files whose types are
+directly exercised by the perf tests — unrelated files add noise to the comparison.
+
+## Maintaining the tests
+
+- **TypeScript version upgrades** may change instantiation counts. Run `pnpm perf:types:ci` and, if the change is
+  expected, adjust `THRESHOLD` in `check-type-perf.mjs` or accept the new baseline by doing nothing (the next main merge
+  becomes the new baseline automatically).
+- **Intentional complexity increases** — if a type change is correct but expensive, document why in the PR description
+  and, if needed, raise `THRESHOLD` temporarily with a follow-up issue to optimise.
+- **Adding ICU variants** — extend the spot-check list and add a corresponding `Bulk*` mapped type. Keep the `TwoDigit`
+  size unless you have a good reason to change it.

--- a/packages/use-intl/perf/check-type-perf.mjs
+++ b/packages/use-intl/perf/check-type-perf.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/**
+ * Compares TypeScript instantiation count between the current branch and a
+ * baseline branch for the files listed in TRACKED_FILES.
+ *
+ * Uses `Instantiations` (not `Total time`) as the primary decision metric
+ * because it is deterministic – the same source always produces the same
+ * count regardless of CPU load. Time metrics are shown for information only.
+ *
+ * Usage:
+ *   node perf/check-type-perf.mjs [--threshold 1.05] [--base-ref upstream/main]
+ *
+ * Exit codes:
+ *   0 – within threshold (or comparison skipped)
+ *   1 – regression detected
+ */
+
+import {execSync} from 'node:child_process';
+import {existsSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+const thresholdArgIdx = process.argv.indexOf('--threshold');
+/** Maximum allowed ratio PR/baseline before the check fails. Default: 5%. */
+const THRESHOLD =
+  thresholdArgIdx !== -1 ? parseFloat(process.argv[thresholdArgIdx + 1]) : 1.05;
+
+/**
+ * Source files (relative to repo root) whose content is swapped to the
+ * baseline version for the baseline measurement.
+ *
+ * Rules:
+ *  - Only list files directly exercised by perf test files.
+ *  - Unrelated files add noise without improving accuracy.
+ *  - Files added or removed in a PR are detected automatically and handled
+ *    correctly (see "File lifecycle" section below).
+ */
+const TRACKED_FILES = [
+  'packages/use-intl/src/core/MessageKeys.tsx',
+  'packages/use-intl/src/core/createTranslator.tsx',
+  'packages/use-intl/src/core/ICUArgs.tsx',
+  'packages/use-intl/src/core/ICUTags.tsx'
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_DIR = join(__dirname, '..');
+const REPO_ROOT = join(PKG_DIR, '..', '..');
+
+function run(cmd, cwd = PKG_DIR) {
+  return execSync(cmd, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+}
+
+function getFileFromGit(relativePath, ref) {
+  try {
+    return run(`git show ${ref}:${relativePath}`, REPO_ROOT);
+  } catch {
+    return null;
+  }
+}
+
+function parseMetrics(output) {
+  const int = (re) => parseInt(output.match(re)?.[1] ?? '0', 10);
+  const flt = (re) => parseFloat(output.match(re)?.[1] ?? '0');
+  return {
+    instantiations: int(/Instantiations:\s+(\d+)/),
+    types: int(/Types:\s+(\d+)/),
+    checkTime: flt(/Check time:\s+([\d.]+)s/),
+    totalTime: flt(/Total time:\s+([\d.]+)s/)
+  };
+}
+
+function measurePerf() {
+  // Run tsc directly and merge stderr into stdout (2>&1) so that
+  // --extendedDiagnostics output is captured regardless of which stream tsc
+  // uses on a given platform/version.
+  const output = execSync(
+    'node_modules/.bin/tsc --noEmit --extendedDiagnostics -p tsconfig.perf.json 2>&1',
+    {cwd: PKG_DIR, encoding: 'utf-8'}
+  );
+  return parseMetrics(output);
+}
+
+/** Formats a percentage delta with a sign. Returns 'n/a' when the base is zero. */
+function fmtDelta(pr, base) {
+  if (base === 0) return 'n/a';
+  const pct = (((pr - base) / base) * 100).toFixed(1);
+  return (pr >= base ? '+' : '') + pct + '%';
+}
+
+// ── File lifecycle ────────────────────────────────────────────────────────────
+//
+// Each tracked file falls into one of four lifecycle states:
+//
+//  'changed'  – present in both baseline and PR; can be cleanly swapped.
+//  'added'    – new in PR, absent in baseline. Both measurements use the PR
+//               version, so the file's overhead cancels out in the delta.
+//               A warning is printed so the author is aware.
+//  'deleted'  – removed in PR, present in baseline. The baseline measurement
+//               writes the baseline content; the PR measurement deletes the
+//               file so tsc sees the correct PR state.
+//  'absent'   – exists in neither; should not happen in practice.
+
+function resolveBaseRef() {
+  const flagIdx = process.argv.indexOf('--base-ref');
+  if (flagIdx !== -1) return process.argv[flagIdx + 1];
+  if (process.env.PERF_BASE_REF) return process.env.PERF_BASE_REF;
+  if (process.env.GITHUB_BASE_REF)
+    return `origin/${process.env.GITHUB_BASE_REF}`;
+  try {
+    run('git rev-parse upstream/main', REPO_ROOT);
+    return 'upstream/main';
+  } catch {
+    return 'origin/main';
+  }
+}
+
+const baseRef = resolveBaseRef();
+
+const entries = TRACKED_FILES.map((rel) => {
+  const abs = join(REPO_ROOT, rel);
+  const prContent = existsSync(abs) ? readFileSync(abs, 'utf-8') : null;
+  const baseContent = getFileFromGit(rel, baseRef);
+  const status =
+    prContent !== null && baseContent !== null
+      ? 'changed'
+      : prContent !== null
+        ? 'added'
+        : baseContent !== null
+          ? 'deleted'
+          : 'absent';
+
+  return {rel, abs, prContent, baseContent, status};
+});
+
+// Warn about lifecycle anomalies before starting measurements.
+const added = entries.filter((e) => e.status === 'added');
+const deleted = entries.filter((e) => e.status === 'deleted');
+
+if (added.length > 0) {
+  console.log(
+    `\nNote: these tracked files are new (not in ${baseRef}).\n` +
+      `Both measurements use the PR version, so their overhead cancels out:\n` +
+      added.map((e) => `  + ${e.rel}`).join('\n')
+  );
+}
+if (deleted.length > 0) {
+  console.log(
+    `\nNote: these tracked files were removed in this PR.\n` +
+      `The baseline measurement will temporarily restore them:\n` +
+      deleted.map((e) => `  - ${e.rel}`).join('\n')
+  );
+}
+
+const hasAnythingToCompare = entries.some(
+  (e) => e.status === 'changed' || e.status === 'deleted'
+);
+if (!hasAnythingToCompare) {
+  console.log(`\nNo comparable tracked files found on ${baseRef} – skipping.`);
+  process.exit(0);
+}
+
+// ── Swap helpers ──────────────────────────────────────────────────────────────
+
+function applyBaseline() {
+  for (const {abs, baseContent, status} of entries) {
+    // 'changed': replace PR content with baseline content.
+    // 'deleted': write baseline content so tsc can resolve imports.
+    if (status === 'changed' || status === 'deleted') {
+      writeFileSync(abs, baseContent, 'utf-8');
+    }
+    // 'added': leave PR content in place – we have no baseline to swap to.
+  }
+}
+
+function applyPR() {
+  for (const {abs, prContent, status} of entries) {
+    if (status === 'changed') {
+      writeFileSync(abs, prContent, 'utf-8');
+    } else if (status === 'deleted') {
+      // The file does not exist in the PR; remove the baseline copy we wrote.
+      if (existsSync(abs)) rmSync(abs);
+    }
+    // 'added': PR content is already on disk – nothing to do.
+  }
+}
+
+// ── Measure ───────────────────────────────────────────────────────────────────
+
+let baseMetrics;
+let prMetrics;
+
+try {
+  console.log(`\nMeasuring baseline (${baseRef})…`);
+  applyBaseline();
+  baseMetrics = measurePerf();
+
+  console.log('Measuring PR branch…');
+  applyPR();
+  prMetrics = measurePerf();
+} catch (err) {
+  applyPR(); // always restore working-tree state on error
+  throw err;
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+const col = (val) => String(val).padEnd(14);
+const row = (label, base, pr) =>
+  `│ ${label.padEnd(18)} │ ${col(base)} │ ${col(pr)} │ ${fmtDelta(pr, base).padEnd(8)}`;
+
+const baseLabel = baseRef.padEnd(14);
+console.log(`
+┌─ Type-check performance ──────────────────────────────────────────┐
+│ Metric             │ ${baseLabel} │ PR             │ Δ
+├────────────────────┼────────────────┼────────────────┼────────────
+${row('Instantiations', baseMetrics.instantiations, prMetrics.instantiations)}
+${row('Types', baseMetrics.types, prMetrics.types)}
+${row('Check time (s)', baseMetrics.checkTime, prMetrics.checkTime)} *
+${row('Total time (s)', baseMetrics.totalTime, prMetrics.totalTime)} *
+└───────────────────────────────────────────────────────────────────┘
+  * time metrics are noisy; pass/fail is based on Instantiations only.
+`);
+
+// ── Decision ──────────────────────────────────────────────────────────────────
+
+const instDelta = fmtDelta(
+  prMetrics.instantiations,
+  baseMetrics.instantiations
+);
+const thresholdPct = ((THRESHOLD - 1) * 100).toFixed(0);
+
+if (prMetrics.instantiations / (baseMetrics.instantiations || 1) > THRESHOLD) {
+  console.error(
+    `[FAIL] Instantiations grew by ${instDelta} (threshold: +${thresholdPct}%).\n` +
+      `       Optimise the type or raise THRESHOLD in check-type-perf.mjs if intentional.`
+  );
+  process.exit(1);
+}
+
+console.log(
+  `[PASS] Instantiation change ${instDelta} is within the +${thresholdPct}% threshold.`
+);

--- a/packages/use-intl/perf/createTranslator.perf-test.ts
+++ b/packages/use-intl/perf/createTranslator.perf-test.ts
@@ -1,0 +1,69 @@
+/**
+ * Performance test for `Translator<T, Namespace>` from `createTranslator`.
+ *
+ * Each key maps to a *unique* ICU string literal (unique param/tag names per
+ * key index), so TypeScript cannot reuse cached `ICUArgs` instantiations.
+ * This stresses the full type chain on every `t(key, values)` call:
+ *
+ *   Translator → NamespacedMessageKeys → MessageKeys → NestedKeyOf
+ *                        ↓ (on key access)
+ *              TranslateArgs → ICUArgsWithTags → ICUArgs → GetICUArgs
+ *
+ * Uses `Digit` (10 keys) rather than `TwoDigit` (100 keys) because the
+ * translator test couples key count with actual call-site type-checking,
+ * which scales more aggressively than a simple mapped type.
+ */
+
+import type {Translator} from '../src/core/createTranslator.js';
+import type {Digit} from './helpers.js';
+
+export type TranslatorMessages = {
+  plain: {[K in Digit as `msg_${K}`]: `Hello, {name${K}}!`};
+  plural: {
+    [K in Digit as `msg_${K}`]: `{count${K}, plural, =0 {nothing} one {# item} other {# items}}`;
+  };
+  select: {
+    [K in Digit as `msg_${K}`]: `{gender${K}, select, male {He} female {She} other {They}}`;
+  };
+  ordinal: {
+    [K in Digit as `msg_${K}`]: `{n${K}, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}`;
+  };
+  number: {
+    [K in Digit as `msg_${K}`]: `Progress: {value${K}, number, percent}`;
+  };
+  date: {[K in Digit as `msg_${K}`]: `Scheduled: {date${K}, date, full}`};
+  time: {[K in Digit as `msg_${K}`]: `At {time${K}, time, short}`};
+  rich: {
+    [K in Digit as `msg_${K}`]: `Click <link${K}>here</link${K}> for details.`;
+  };
+  mixed: {
+    [K in Digit as `msg_${K}`]: `{count${K}, plural, one {<b${K}># item</b${K}>} other {<b${K}># items</b${K}>}}`;
+  };
+};
+
+declare const tPlain: Translator<TranslatorMessages, 'plain'>;
+declare const tPlural: Translator<TranslatorMessages, 'plural'>;
+declare const tSelect: Translator<TranslatorMessages, 'select'>;
+declare const tOrdinal: Translator<TranslatorMessages, 'ordinal'>;
+declare const tNumber: Translator<TranslatorMessages, 'number'>;
+declare const tDate: Translator<TranslatorMessages, 'date'>;
+declare const tTime: Translator<TranslatorMessages, 'time'>;
+declare const tRich: Translator<TranslatorMessages, 'rich'>;
+declare const tMixed: Translator<TranslatorMessages, 'mixed'>;
+
+// Each call exercises the full overload resolution + ICUArgs chain for a
+// different ICU variant. Two calls per plural-like variant exercise distinct
+// cached instantiation paths.
+const _p0 = tPlain('msg_0', {name0: 'Alice'});
+const _p1 = tPlain('msg_1', {name1: 'Bob'});
+const _pl0 = tPlural('msg_0', {count0: 1});
+const _pl1 = tPlural('msg_1', {count1: 5});
+const _s0 = tSelect('msg_0', {gender0: 'male'});
+const _o0 = tOrdinal('msg_0', {n0: 1});
+const _n0 = tNumber('msg_0', {value0: 0.75});
+const _d0 = tDate('msg_0', {date0: new Date()});
+const _t0 = tTime('msg_0', {time0: new Date()});
+const _ri0: unknown = tRich.rich('msg_0', {link0: (c) => c});
+const _m0 = tMixed('msg_0', {count0: 1});
+
+void [_p0, _p1, _pl0, _pl1, _s0, _o0, _n0, _d0, _t0, _ri0, _m0];

--- a/packages/use-intl/perf/helpers.ts
+++ b/packages/use-intl/perf/helpers.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared primitives for all `*.perf-test.ts` files.
+ *
+ * Keep this file focused on types that are genuinely reused across tests.
+ * One-off types belong in the test file that uses them.
+ */
+
+/** Single decimal digit as a string literal union (0–9, 10 members). */
+export type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+
+/** Two-digit cartesian product (00–99, 100 members). Use for bulk key generation. */
+export type TwoDigit = `${Digit}${Digit}`;
+
+/**
+ * ICU argument options match `ICUArgsWithTags` in `createTranslator.tsx`.
+ * Every test that touches `ICUArgs` directly should use this so the
+ * measured types reflect actual production behavior.
+ */
+export type ICUArgOpts = {
+  ICUArgument: string;
+  ICUNumberArgument: number | bigint;
+  ICUDateArgument: Date;
+};
+
+/**
+ * Type-level assertion. Resolves to `true` when `T extends Expected`, else `never`.
+ *
+ * A result of `never` means the type under test no longer satisfies the
+ * expected shape – treat it as a type-level regression test.
+ *
+ * @example
+ *   type _ = Assert<ICUArgs<'Hello {name}', ICUArgOpts>, {name: string}>;
+ */
+export type Assert<T, Expected> = [T] extends [Expected] ? true : never;

--- a/packages/use-intl/tsconfig.perf.json
+++ b/packages/use-intl/tsconfig.perf.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["perf"],
+  "compilerOptions": {
+    "paths": {
+      "use-intl/format-message": ["./src/core/format-message/index.tsx"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a `perf/` directory with TypeScript type-performance tests covering all public types: `MessageKeys`, `ICUArgs`, `ICUTags`, and `Translator`
- Adds `check-type-perf.mjs` — a CI script that compares `tsc --extendedDiagnostics` Instantiation counts between the PR branch and baseline, failing on regressions above a configurable threshold (default: +5%)
- Adds a GitHub Actions workflow (`type-perf.yml`) that runs the check automatically on changes to `src/core/` or `perf/`

## Motivation

Type-level changes to recursive conditional types (`MessageKeys`, `ICUArgs`, `ICUTags`) can silently multiply TypeScript instantiation counts. A 2× increase in instantiations translates directly to slower editor responsiveness and longer `tsc` runs for end users with large message catalogs. Without a test harness this is invisible until a user reports it.

## How it works

**Metric: `Instantiations` (not `Total time`)**
`tsc --extendedDiagnostics` emits an `Instantiations` count that is fully deterministic — the same source always produces the same count regardless of CPU load. Time metrics (`Check time`, `Total time`) are shown in the report for information, but pass/fail is decided solely on Instantiations.

**Comparison mechanism**
`check-type-perf.mjs` swaps the content of `TRACKED_FILES` to their baseline versions (fetched via `git show <base-ref>:<path>`), runs `tsc`, then swaps back to PR versions and runs again. The ratio `PR / baseline` is compared against `THRESHOLD` (default 1.05).

**File lifecycle**
Files tracked in `TRACKED_FILES` that are added or removed within the PR are handled gracefully:
- **added** — no baseline to compare against; both measurements use the PR version so the overhead cancels out in the delta. A notice is printed.
- **deleted** — baseline content is temporarily written for the baseline measurement, then removed for the PR measurement.

**Test files**

| File                            | What it covers                                                                                  |
|---------------------------------|-------------------------------------------------------------------------------------------------|
| `MessageKeys.perf-test.ts`      | `NestedKeyOf`, `MessageKeys`, `NamespaceKeys` — 1 200+ leaf keys across 11 ICU-variant sections |
| `ICUArgs.perf-test.ts`          | `ICUArgs` — spot-check assertions + 100-key bulk instantiation for every ICU variant            |
| `ICUTags.perf-test.ts`          | `ICUTags` — single/sibling/nested tags, tag+param, tag+plural, 100-key bulk                     |
| `createTranslator.perf-test.ts` | `Translator` — full overload-resolution chain with actual `t(key, values)` call sites           |
| `helpers.ts`                    | Shared primitives: `Digit`, `TwoDigit`, `ICUArgOpts`, `Assert<T, Expected>`                     |

## Running locally

```bash
# One-shot measurement (shows extendedDiagnostics)
pnpm --filter use-intl perf:types

# Compare against baseline (same script as CI)
pnpm --filter use-intl perf:types:ci

# Override base ref or threshold
node packages/use-intl/perf/check-type-perf.mjs --base-ref origin/main --threshold 1.10
```
