### PR TITLE
fix: Make extracted catalog order deterministic on tied references

### DIFF
--- a/e2e/extracted-po/tests/main.spec.ts
+++ b/e2e/extracted-po/tests/main.spec.ts
@@ -78,6 +78,37 @@ export default function Greeting() {
   expect(greetingRefs.length).toBeGreaterThanOrEqual(2);
 });
 
+it('orders tied messages by id', async ({page}) => {
+  // Two distinct messages on the same line tie on `references[0]`.
+  // 'apple' hashes to "hE2HeR" and 'banana' to "+OMYPT", so localeCompare
+  // sorts banana before apple — opposite to source order. Without the id
+  // tiebreaker the catalog preserves source order (apple first); with it,
+  // banana wins.
+  await using _ = await withTempEditApp(
+    'src/components/Greeting.tsx',
+    `'use client';
+
+import {useExtracted} from 'next-intl';
+
+export default function Greeting() {
+  const t = useExtracted();
+  return <div>{t('apple')}{t('banana')}</div>;
+}
+`
+  );
+
+  await page.goto('/');
+  const content = await expectCatalog(
+    'en.po',
+    (c) => c.includes('msgid "+OMYPT"') && c.includes('msgid "hE2HeR"'),
+    {timeout: 15_000}
+  );
+
+  const bananaPos = content.indexOf('msgid "+OMYPT"');
+  const applePos = content.indexOf('msgid "hE2HeR"');
+  expect(bananaPos).toBeLessThan(applePos);
+});
+
 it("saves catalog when it's missing", async ({page}) => {
   await page.goto('/');
   await expectCatalog(

--- a/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
+++ b/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
@@ -1165,6 +1165,10 @@ msgstr ""
       msgstr "Hallo!"
 
       #: src/Greeting.tsx:5
+      msgid "I5NMJ8"
+      msgstr ""
+
+      #: src/Greeting.tsx:5
       msgid "jqdzk6"
       msgstr ""
 
@@ -1174,10 +1178,6 @@ msgstr ""
 
       #: src/Greeting.tsx:5
       msgid "pE58D7"
-      msgstr ""
-
-      #: src/Greeting.tsx:5
-      msgid "I5NMJ8"
       msgstr ""
       ",
       ]

--- a/packages/next-intl/src/extractor/utils.test.tsx
+++ b/packages/next-intl/src/extractor/utils.test.tsx
@@ -41,7 +41,7 @@ describe('getSortedMessages', () => {
     ).toEqual(['a', 'b', 'c']);
   });
 
-  it('preserves original order when reference paths and lines match', () => {
+  it('uses id as tiebreaker when reference paths and lines match', () => {
     expect(
       getSortedMessages([
         {
@@ -60,7 +60,17 @@ describe('getSortedMessages', () => {
           references: [{path: 'components/A.tsx', line: 10}]
         }
       ]).map((message) => message.id)
-    ).toEqual(['c', 'a', 'b']);
+    ).toEqual(['a', 'b', 'c']);
+  });
+
+  it('uses id as tiebreaker when references are missing', () => {
+    expect(
+      getSortedMessages([
+        {id: 'c', message: 'c'},
+        {id: 'a', message: 'a'},
+        {id: 'b', message: 'b'}
+      ]).map((message) => message.id)
+    ).toEqual(['a', 'b', 'c']);
   });
 });
 

--- a/packages/next-intl/src/extractor/utils.tsx
+++ b/packages/next-intl/src/extractor/utils.tsx
@@ -55,11 +55,16 @@ export function getSortedMessages(
     const refA = messageA.references?.[0];
     const refB = messageB.references?.[0];
 
-    // No references: preserve original (extraction) order
-    if (!refA || !refB) return 0;
+    if (refA && refB) {
+      const refCompare = compareReferences(refA, refB);
+      if (refCompare !== 0) return refCompare;
+    }
 
-    // Sort by path, then line. Same path+line: preserve original order
-    return compareReferences(refA, refB);
+    // Tiebreaker for messages tied on (or missing) `references[0]`. Without
+    // this, the sort falls back to insertion order in `messagesById`, which
+    // is non-deterministic because source files are scanned via `fs.readdir`
+    // and processed concurrently.
+    return localeCompare(messageA.id, messageB.id);
   });
 }
 


### PR DESCRIPTION
Follow-up to the discussion in #2036.

## Problem

`getSortedMessages` (in `extractor/utils.tsx`) sorts catalog entries by `references[0]` only and returns `0` on ties (same path + line, or missing references). Since `Array.prototype.toSorted` is stable, ties fall back to `messagesById` insertion order — which is non-deterministic because source files are scanned via `fs.readdir` and processed concurrently.

In practice, two messages sharing the same first source location (e.g. two `t()` calls on the same JSX line, or messages in tightly-bound JSX expressions) swap positions across runs and across machines. For repos that re-extract on every commit through a pre-commit hook, this produces reorder-only diffs that pollute unrelated PRs.

This is the same family of issue as the one reported by @ceolinwill earlier in #2036 and partially fixed in 4.5.6 ("Stable, environment-agnostic key sorting"). That fix made the comparator locale-independent, but didn't add a tiebreaker — so messages tied on `references[0]` still flip.

@LouisCuvelier raised the same symptom in [#2036 (comment)](https://github.com/amannn/next-intl/discussions/2036#discussioncomment-16766583), asking whether `unstable_extractMessages` and `next dev` / `next build` produce the same output. They share this same comparator, so once it's deterministic, all paths converge.

## Fix

Add `localeCompare(messageA.id, messageB.id)` as the final tiebreaker in `getSortedMessages`. The `id` is already deterministic (it's the existing extraction hash), so this gives a fully stable order. ~3-line change.

```ts
// extractor/utils.tsx
if (refA && refB) {
  const refCompare = compareReferences(refA, refB);
  if (refCompare !== 0) return refCompare;
}
return localeCompare(messageA.id, messageB.id);
```

## Tests

- **Unit**: renamed `preserves original order when reference paths and lines match` → `uses id as tiebreaker when reference paths and lines match` (now asserts `['a', 'b', 'c']` instead of insertion order). Added `uses id as tiebreaker when references are missing`.
- **E2E** (`extracted-po`): new test `orders messages deterministically when they share a first reference` — places two `t()` calls on the same JSX line and asserts the catalog entries appear in id-sorted order.
- **Snapshot**: one inline snapshot in `ExtractionCompiler.test.tsx > po format > removes flags when externally deleted` updated. The test deliberately produces 5 messages all at `Greeting.tsx:5` (a tied-references case), so the order shifts under the new tiebreaker. Pure reorder, no content change.

## Caveat

The new e2e test verifies the fix's *outcome* (catalog order matches id-sort), not its *causality* — since the msgid is a hash of the source string, there's a chance the hash order coincides with insertion order, in which case the test would also pass without the fix. The unit tests cover the regression directly with controlled input.

## Scope

Intentionally minimal: only adds a tiebreaker. Does not change behavior for messages with mixed reference states (one has refs, the other doesn't) — those now sort by id alongside everything else, which is also deterministic. Happy to refine if you'd prefer a different rule there.