### PR TITLE
fix: Avoid watchers for detached telemetry process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: "pnpm"
+          cache: 'pnpm'
       - run: pnpm install
 
       # Next.js caching
@@ -42,7 +42,7 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
-      - run: pnpm --filter example-app-router --filter "./e2e/extracted-json" --filter "./e2e/extracted-po" exec playwright install --with-deps
+      - run: pnpm --filter example-app-router exec playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       # Main tasks

--- a/packages/next-intl/src/plugin/createNextIntlPlugin.tsx
+++ b/packages/next-intl/src/plugin/createNextIntlPlugin.tsx
@@ -15,9 +15,11 @@ function initPlugin(
     );
   }
 
+  const skipWatchers = isNextTelemetryDetachedFlushProcess();
+
   const messagesPathOrPaths =
     pluginConfig.experimental?.createMessagesDeclaration;
-  if (messagesPathOrPaths) {
+  if (messagesPathOrPaths && !skipWatchers) {
     createMessagesDeclaration(
       typeof messagesPathOrPaths === 'string'
         ? [messagesPathOrPaths]
@@ -25,7 +27,9 @@ function initPlugin(
     );
   }
 
-  initExtractionCompiler(pluginConfig);
+  if (!skipWatchers) {
+    initExtractionCompiler(pluginConfig);
+  }
 
   return getNextConfig(pluginConfig, nextConfig);
 }
@@ -40,4 +44,18 @@ export default function createNextIntlPlugin(
   return function withNextIntl(nextConfig?: NextConfig) {
     return initPlugin(config, nextConfig);
   };
+}
+
+/**
+ * Next runs `telemetry/detached-flush.js` in a detached process to flush telemetry
+ * (often when `next dev` exits). That loads dev `next.config` with inherited
+ * `NODE_ENV=development`, which would otherwise start orphan plugin watchers.
+ */
+function isNextTelemetryDetachedFlushProcess(): boolean {
+  const scriptPath = process.argv[1];
+  if (!scriptPath) {
+    return false;
+  }
+  const normalized = scriptPath.replace(/\\/g, '/');
+  return normalized.includes('/telemetry/detached-flush');
 }

--- a/packages/next-intl/src/plugin/createNextIntlPlugin.tsx
+++ b/packages/next-intl/src/plugin/createNextIntlPlugin.tsx
@@ -53,9 +53,7 @@ export default function createNextIntlPlugin(
  */
 function isNextTelemetryDetachedFlushProcess(): boolean {
   const scriptPath = process.argv[1];
-  if (!scriptPath) {
-    return false;
-  }
+  if (!scriptPath) return false;
   const normalized = scriptPath.replace(/\\/g, '/');
   return normalized.includes('/telemetry/detached-flush');
 }

--- a/packages/next-intl/src/plugin/declaration/createMessagesDeclaration.tsx
+++ b/packages/next-intl/src/plugin/declaration/createMessagesDeclaration.tsx
@@ -17,7 +17,7 @@ export default function createMessagesDeclaration(
 
     // Note: These commands don't consult the
     // Next.js config, so we can't detect them here.
-    // - telemetry
+    // - telemetry (however, the `detached-flush` DOES - see `createNextIntlPlugin`)
     // - lint
     //
     // What remains are:

--- a/packages/next-intl/src/plugin/extractor/initExtractionCompiler.tsx
+++ b/packages/next-intl/src/plugin/extractor/initExtractionCompiler.tsx
@@ -9,9 +9,27 @@ let compiler: ExtractionCompiler | undefined;
 
 const runOnce = once('_NEXT_INTL_EXTRACT');
 
+/**
+ * Next runs `telemetry/detached-flush.js` in a detached process to flush telemetry
+ * (often when `next dev` exits). That loads dev `next.config` with inherited
+ * `NODE_ENV=development`, which would otherwise start orphan extract watchers.
+ */
+function isNextTelemetryDetachedFlushProcess(): boolean {
+  const scriptPath = process.argv[1];
+  if (!scriptPath) {
+    return false;
+  }
+  const normalized = scriptPath.replace(/\\/g, '/');
+  return normalized.includes('/telemetry/detached-flush');
+}
+
 export default function initExtractionCompiler(pluginConfig: PluginConfig) {
   const experimental = pluginConfig.experimental;
   if (!experimental?.extract) {
+    return;
+  }
+
+  if (isNextTelemetryDetachedFlushProcess()) {
     return;
   }
 
@@ -20,8 +38,9 @@ export default function initExtractionCompiler(pluginConfig: PluginConfig) {
   // - start
   // - typegen
   //
+  // Telemetry `detached-flush` is skipped above (still loads this config, but in a new process).
+  //
   // Doesn't consult Next.js config anyway:
-  // - telemetry
   // - lint
   //
   // What remains are:

--- a/packages/next-intl/src/plugin/extractor/initExtractionCompiler.tsx
+++ b/packages/next-intl/src/plugin/extractor/initExtractionCompiler.tsx
@@ -9,27 +9,9 @@ let compiler: ExtractionCompiler | undefined;
 
 const runOnce = once('_NEXT_INTL_EXTRACT');
 
-/**
- * Next runs `telemetry/detached-flush.js` in a detached process to flush telemetry
- * (often when `next dev` exits). That loads dev `next.config` with inherited
- * `NODE_ENV=development`, which would otherwise start orphan extract watchers.
- */
-function isNextTelemetryDetachedFlushProcess(): boolean {
-  const scriptPath = process.argv[1];
-  if (!scriptPath) {
-    return false;
-  }
-  const normalized = scriptPath.replace(/\\/g, '/');
-  return normalized.includes('/telemetry/detached-flush');
-}
-
 export default function initExtractionCompiler(pluginConfig: PluginConfig) {
   const experimental = pluginConfig.experimental;
   if (!experimental?.extract) {
-    return;
-  }
-
-  if (isNextTelemetryDetachedFlushProcess()) {
     return;
   }
 
@@ -38,10 +20,9 @@ export default function initExtractionCompiler(pluginConfig: PluginConfig) {
   // - start
   // - typegen
   //
-  // Telemetry `detached-flush` is skipped above (still loads this config, but in a new process).
-  //
   // Doesn't consult Next.js config anyway:
   // - lint
+  // - telemetry (however, the `detached-flush` DOES - see `createNextIntlPlugin`)
   //
   // What remains are:
   // - dev (NODE_ENV=development)


### PR DESCRIPTION
Relevant for `useExtracted` and `createMessagesDeclaration`.

See:
- https://github.com/vercel/next.js/discussions/92805
- https://github.com/amannn/next-intl/discussions/2036#discussioncomment-16847756