### PR TITLE
fix: ensure deterministic message ordering in extracted catalogs

### DIFF
--- a/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
+++ b/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
@@ -1027,12 +1027,12 @@ msgstr "World"
       msgstr "Hey!"
 
       #: src/Greeting.tsx:5
-      msgid "jqdzk6"
-      msgstr "World"
-
-      #: src/Greeting.tsx:5
       msgid "ODGmph"
       msgstr "!"
+
+      #: src/Greeting.tsx:5
+      msgid "jqdzk6"
+      msgstr "World"
       ",
       ]
     `);
@@ -1093,11 +1093,11 @@ msgstr ""
       msgstr "Hallo!"
 
       #: src/Greeting.tsx:5
-      msgid "jqdzk6"
+      msgid "ODGmph"
       msgstr ""
 
       #: src/Greeting.tsx:5
-      msgid "ODGmph"
+      msgid "jqdzk6"
       msgstr ""
 
       #: src/Greeting.tsx:5
@@ -1165,7 +1165,7 @@ msgstr ""
       msgstr "Hallo!"
 
       #: src/Greeting.tsx:5
-      msgid "jqdzk6"
+      msgid "I5NMJ8"
       msgstr ""
 
       #: src/Greeting.tsx:5
@@ -1173,11 +1173,11 @@ msgstr ""
       msgstr ""
 
       #: src/Greeting.tsx:5
-      msgid "pE58D7"
+      msgid "jqdzk6"
       msgstr ""
 
       #: src/Greeting.tsx:5
-      msgid "I5NMJ8"
+      msgid "pE58D7"
       msgstr ""
       ",
       ]

--- a/packages/next-intl/src/extractor/utils.test.tsx
+++ b/packages/next-intl/src/extractor/utils.test.tsx
@@ -41,7 +41,7 @@ describe('getSortedMessages', () => {
     ).toEqual(['a', 'b', 'c']);
   });
 
-  it('preserves original order when reference paths and lines match', () => {
+  it('breaks ties by id when reference paths and lines match', () => {
     expect(
       getSortedMessages([
         {
@@ -60,7 +60,48 @@ describe('getSortedMessages', () => {
           references: [{path: 'components/A.tsx', line: 10}]
         }
       ]).map((message) => message.id)
-    ).toEqual(['c', 'a', 'b']);
+    ).toEqual(['a', 'b', 'c']);
+  });
+
+  it('produces a stable order regardless of input order when some messages have no references', () => {
+    // Reproduces the non-transitive comparator bug: messages without
+    // references could land on either side of their referenced neighbors
+    // depending on the input order, producing spurious catalog diffs.
+    const messages = [
+      {
+        id: 'UVkKe5',
+        message: 'Sending code...',
+        references: [{path: 'auth.ts', line: 50}]
+      },
+      {id: 'nx5jYc', message: 'Send sign-in code'},
+      {
+        id: 'abc123',
+        message: 'Welcome',
+        references: [{path: 'auth.ts', line: 10}]
+      },
+      {id: 'zzz999', message: 'Goodbye'},
+      {
+        id: 'def456',
+        message: 'Login',
+        references: [{path: 'home.ts', line: 5}]
+      }
+    ];
+
+    const shuffled = [
+      messages[3],
+      messages[0],
+      messages[4],
+      messages[1],
+      messages[2]
+    ];
+
+    const sortedA = getSortedMessages(messages).map((m) => m.id);
+    const sortedB = getSortedMessages(shuffled).map((m) => m.id);
+
+    expect(sortedA).toEqual(sortedB);
+    // Referenced messages first (by path, then line), then reference-less
+    // messages (by id).
+    expect(sortedA).toEqual(['abc123', 'UVkKe5', 'def456', 'nx5jYc', 'zzz999']);
   });
 });
 

--- a/packages/next-intl/src/extractor/utils.tsx
+++ b/packages/next-intl/src/extractor/utils.tsx
@@ -55,12 +55,23 @@ export function getSortedMessages(
     const refA = messageA.references?.[0];
     const refB = messageB.references?.[0];
 
-    // No references: preserve original (extraction) order
-    if (!refA || !refB) return 0;
+    // Group reference-less messages after referenced ones; tiebreak by id so
+    // the comparator is a total order (transitive) and the result is
+    // independent of input order. The previous `return 0` for the mixed case
+    // produced non-transitive comparisons, which made catalog output depend
+    // on parallel extraction timing and caused spurious diffs.
+    if (!refA && !refB) return compareIds(messageA.id, messageB.id);
+    if (!refA) return 1;
+    if (!refB) return -1;
 
-    // Sort by path, then line. Same path+line: preserve original order
-    return compareReferences(refA, refB);
+    const cmp = compareReferences(refA, refB);
+    if (cmp !== 0) return cmp;
+    return compareIds(messageA.id, messageB.id);
   });
+}
+
+function compareIds(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 export function localeCompare(a: string, b: string) {


### PR DESCRIPTION
## Summary

`getSortedMessages` used a comparator that wasn't a total order, causing extracted message catalogs (e.g. `messages/en.json`, `messages/en.po`) to drift between extractor runs even when source code hadn't meaningfully changed. The drift surfaced as spurious PR diffs — typically a key swapping with one of its neighbors — that often couldn't be reproduced by re-running extraction on a stable tree.

## Root cause

```ts
if (!refA || !refB) return 0;
return compareReferences(refA, refB);
```

The `return 0` branch fires whenever either side lacks a `references` entry, which violates transitivity. Counterexample:

- A: `{ path: "auth.ts", line: 50 }`
- B: no ref
- C: `{ path: "auth.ts", line: 10 }`

Then `cmp(A, B) === 0` and `cmp(B, C) === 0`, but `cmp(A, C) > 0`. `Array.prototype.toSorted` is stable, but stability doesn't rescue a non-transitive comparator — output depends on input order and engine-specific Timsort pivot choices.

In practice, `JSONCodec.decode` doesn't round-trip references, so every fresh extractor process starts with reference-less messages and adds references as files are processed. Any save that fires before all files have been processed (incremental dev writes, watcher events, the first save after a partial pass) snapshots a mixed state and exposes the bug.

## Fix

Promote the comparator to a proper total order:

1. Push reference-less messages after referenced ones.
2. Tiebreak by `id` for both reference-less pairs and same-`(path, line)` pairs.

This preserves the existing intent (group by file path, then line) while making output independent of input order and parallel extraction timing.

## Impact

- **One-time reordering** of existing catalogs where the buggy comparator left reference-less messages or same-`(path, line)` ties in input-order-dependent positions. After that diff, catalogs converge to a stable canonical order.
- **No behavioral change** for catalogs where every message has a unique `(path, line)` reference.
- Applies identically to JSON and PO output (both go through `getSortedMessages`).

## Tests

- Added a regression test in `utils.test.tsx` that sorts a mixed set (referenced + reference-less) twice with shuffled input and asserts the outputs match.
- Updated the existing same-`(path, line)` test to expect id-based tiebreaking instead of input order.
- Refreshed 3 PO snapshots in `ExtractionCompiler.test.tsx` that depended on the old insertion-order behavior; they now reflect deterministic id ordering at same `(path, line)`.