### PR TITLE
fix: Revert x-forwarded-host redirect domain change

### DIFF
--- a/packages/next-intl/src/middleware/middleware.test.tsx
+++ b/packages/next-intl/src/middleware/middleware.test.tsx
@@ -1172,33 +1172,6 @@ describe('prefix-based routing', () => {
       );
     });
 
-    it('uses the forwarded host when behind a proxy', () => {
-      middleware(
-        createMockRequest('/', 'en', 'http://project.vercel.app', undefined, {
-          'x-forwarded-host': 'myproject.com',
-          'x-forwarded-proto': 'https'
-        })
-      );
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
-      expect(MockedNextResponse.redirect.mock.calls[0][0].toString()).toBe(
-        'https://myproject.com/en'
-      );
-
-      middleware(
-        createMockRequest('/', 'en', 'http://project.vercel.app', undefined, {
-          'x-forwarded-host': 'myproject.com',
-          'x-forwarded-port': '8443',
-          'x-forwarded-proto': 'https'
-        })
-      );
-      expect(MockedNextResponse.next).not.toHaveBeenCalled();
-      expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();
-      expect(MockedNextResponse.redirect.mock.calls[1][0].toString()).toBe(
-        'https://myproject.com:8443/en'
-      );
-    });
-
     it('redirects when a pathname starts with the locale characters', () => {
       middleware(createMockRequest('/engage'));
       expect(MockedNextResponse.rewrite).not.toHaveBeenCalled();

--- a/packages/next-intl/src/middleware/middleware.tsx
+++ b/packages/next-intl/src/middleware/middleware.tsx
@@ -101,7 +101,6 @@ export default function createMiddleware<
 
     function redirect(url: string, redirectDomain?: string) {
       const urlObj = new URL(url, request.url);
-      const forwardedHost = request.headers.get('x-forwarded-host');
 
       urlObj.pathname = normalizeTrailingSlash(urlObj.pathname);
 
@@ -129,24 +128,20 @@ export default function createMiddleware<
         }
       }
 
-      // Priority for redirect origins:
-      // 1) Explicit domain from `redirectDomain`
-      // 2) Reverse proxy host from `x-forwarded-host`
-      // 3) Fallback to `request.url`
-      const redirectHost = redirectDomain ?? forwardedHost;
-      if (redirectHost) {
-        urlObj.host = redirectHost;
-      }
+      if (redirectDomain) {
+        urlObj.host = redirectDomain;
 
-      if (forwardedHost) {
-        urlObj.protocol =
-          request.headers.get('x-forwarded-proto') ?? request.nextUrl.protocol;
+        if (request.headers.get('x-forwarded-host')) {
+          urlObj.protocol =
+            request.headers.get('x-forwarded-proto') ??
+            request.nextUrl.protocol;
 
-        const redirectHostPort = redirectHost?.split(':')[1] as
-          | string
-          | undefined;
-        urlObj.port =
-          redirectHostPort ?? request.headers.get('x-forwarded-port') ?? '';
+          const redirectDomainPort = redirectDomain.split(':')[1] as
+            | string
+            | undefined;
+          urlObj.port =
+            redirectDomainPort ?? request.headers.get('x-forwarded-port') ?? '';
+        }
       }
 
       if (request.nextUrl.basePath) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- revert commit `70d35dbfdb19edc24be39d5f455ff754fceac85c` from #2281
- restore middleware redirect behavior to pre-#2281 behavior
- implements revert request from https://github.com/amannn/next-intl/pull/2281#issuecomment-4419751926

## Testing
- `pnpm --filter next-intl exec eslint src/middleware/middleware.tsx src/middleware/middleware.test.tsx`
- `pnpm --filter next-intl exec prettier --check src/middleware/middleware.tsx src/middleware/middleware.test.tsx`
- `pnpm --filter next-intl exec vitest run src/middleware/middleware.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a31fab6-524a-4d9c-94b3-e62685407063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a31fab6-524a-4d9c-94b3-e62685407063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

