### PR TITLE
fix: Stabilize extracted catalog order

### DIFF
--- a/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
+++ b/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
@@ -1014,6 +1014,58 @@ describe('po format', {timeout: 20_000}, () => {
     `);
   });
 
+  it('orders same-reference messages independently of file processing order', async () => {
+    async function extractWithDelayedFile(delayedFileName: string) {
+      filesystem.project = {
+        src: {
+          'A.tsx': `
+          import {useExtracted} from 'next-intl';
+          export default function A() {
+            const t = useExtracted();
+            return <div>{t('apple')}{t('banana')}</div>;
+          }
+          `,
+          'B.tsx': `
+          import {useExtracted} from 'next-intl';
+          export default function B() {
+            const t = useExtracted();
+            return <div>{t('banana')}{t('apple')}</div>;
+          }
+          `
+        },
+        messages: {}
+      };
+      fileTimestamps.clear();
+      readFileInterceptors.clear();
+      vi.mocked(fs.writeFile).mockClear();
+
+      let delayedFileReadStarted = false;
+      let resolveDelayedFile: (() => void) | undefined;
+      const delayedFilePromise = new Promise<void>((resolve) => {
+        resolveDelayedFile = resolve;
+      });
+      readFileInterceptors.set(delayedFileName, async () => {
+        delayedFileReadStarted = true;
+        await delayedFilePromise;
+      });
+
+      using compiler = createCompiler();
+      const extractAllPromise = compiler.extractAll();
+
+      await vi.waitFor(() => expect(delayedFileReadStarted).toBe(true));
+      resolveDelayedFile?.();
+      await extractAllPromise;
+      await waitForWriteFileCalls(1);
+
+      return filesystem.project.messages!['en.po'];
+    }
+
+    const aDelayedContent = await extractWithDelayedFile('A.tsx');
+    const bDelayedContent = await extractWithDelayedFile('B.tsx');
+
+    expect(aDelayedContent).toEqual(bDelayedContent);
+  });
+
   it('removes flags when externally deleted', async () => {
     filesystem.project.src['Greeting.tsx'] = `
     import {useExtracted} from 'next-intl';

--- a/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
+++ b/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
@@ -188,7 +188,9 @@ export default class CatalogManager implements Disposable {
         }))
       );
       for (const {filePath, messages} of extractedFiles) {
-        this.applyFileMessages(filePath, messages);
+        if (messages) {
+          this.applyFileMessages(filePath, messages);
+        }
       }
       this.mergeSourceDiskMetadata(sourceDiskMessages);
     })();
@@ -296,7 +298,11 @@ export default class CatalogManager implements Disposable {
 
   private async processFile(absoluteFilePath: string): Promise<boolean> {
     const messages = await this.extractFile(absoluteFilePath);
-    return this.applyFileMessages(absoluteFilePath, messages);
+    if (messages) {
+      return this.applyFileMessages(absoluteFilePath, messages);
+    } else {
+      return false;
+    }
   }
 
   private async extractFile(
@@ -323,10 +329,8 @@ export default class CatalogManager implements Disposable {
 
   private applyFileMessages(
     absoluteFilePath: string,
-    messages: Array<SourceMessage> | undefined
+    messages: Array<SourceMessage>
   ): boolean {
-    if (messages == null) return false;
-
     const prevFileMessages = this.sourceMessagesByFile.get(absoluteFilePath);
     const nextFileMessages = this.groupSourceMessagesById(messages);
     const affectedIds = new Set([

--- a/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
+++ b/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
@@ -13,7 +13,11 @@ import type {
   Locale,
   SourceMessage
 } from '../types.js';
-import {compareReferences, getDefaultProjectRoot} from '../utils.js';
+import {
+  compareReferences,
+  getDefaultProjectRoot,
+  localeCompare
+} from '../utils.js';
 import CatalogLocales from './CatalogLocales.js';
 import CatalogPersister from './CatalogPersister.js';
 import SaveScheduler from './SaveScheduler.js';
@@ -172,14 +176,20 @@ export default class CatalogManager implements Disposable {
     await this.loadCatalogsPromise;
 
     this.scanCompletePromise = (async () => {
-      const sourceFiles = await SourceFileScanner.getSourceFiles(
-        this.getSrcPaths()
+      const sourceFiles = Array.from(
+        await SourceFileScanner.getSourceFiles(this.getSrcPaths())
+      )
+        // Stable file order keeps catalog ties independent of processing timing
+        .toSorted(localeCompare);
+      const extractedFiles = await Promise.all(
+        sourceFiles.map(async (filePath) => ({
+          filePath,
+          messages: await this.extractFile(filePath)
+        }))
       );
-      await Promise.all(
-        Array.from(sourceFiles).map(async (filePath) =>
-          this.processFile(filePath)
-        )
-      );
+      for (const {filePath, messages} of extractedFiles) {
+        this.applyFileMessages(filePath, messages);
+      }
       this.mergeSourceDiskMetadata(sourceDiskMessages);
     })();
 
@@ -285,6 +295,13 @@ export default class CatalogManager implements Disposable {
   }
 
   private async processFile(absoluteFilePath: string): Promise<boolean> {
+    const messages = await this.extractFile(absoluteFilePath);
+    return this.applyFileMessages(absoluteFilePath, messages);
+  }
+
+  private async extractFile(
+    absoluteFilePath: string
+  ): Promise<Array<SourceMessage> | undefined> {
     let messages: Array<SourceMessage> = [];
     try {
       const content = await fs.readFile(absoluteFilePath, 'utf8');
@@ -292,7 +309,7 @@ export default class CatalogManager implements Disposable {
       try {
         extraction = await this.extractor.extract(absoluteFilePath, content);
       } catch {
-        return false;
+        return undefined;
       }
       messages = extraction.messages;
     } catch (err) {
@@ -301,6 +318,14 @@ export default class CatalogManager implements Disposable {
       }
       // ENOENT -> treat as no messages
     }
+    return messages;
+  }
+
+  private applyFileMessages(
+    absoluteFilePath: string,
+    messages: Array<SourceMessage> | undefined
+  ): boolean {
+    if (messages == null) return false;
 
     const prevFileMessages = this.sourceMessagesByFile.get(absoluteFilePath);
     const nextFileMessages = this.groupSourceMessagesById(messages);
@@ -563,7 +588,10 @@ export default class CatalogManager implements Disposable {
         events,
         Array.from(this.sourceMessagesByFile.keys())
       );
-    for (const event of expandedEvents) {
+    // Stable file order keeps catalog ties independent of event timing.
+    for (const event of expandedEvents.toSorted((a, b) =>
+      localeCompare(a.path, b.path)
+    )) {
       const hasChanged = await this.processFile(event.path);
       changed ||= hasChanged;
     }

--- a/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
+++ b/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
@@ -298,11 +298,12 @@ export default class CatalogManager implements Disposable {
 
   private async processFile(absoluteFilePath: string): Promise<boolean> {
     const messages = await this.extractFile(absoluteFilePath);
-    if (messages) {
-      return this.applyFileMessages(absoluteFilePath, messages);
-    } else {
-      return false;
-    }
+
+    // `undefined` only when `extractFile()` throws. An empty array is success
+    // and must still run `applyFileMessages` to clear stale ids for this file.
+    if (!messages) return false;
+
+    return this.applyFileMessages(absoluteFilePath, messages);
   }
 
   private async extractFile(


### PR DESCRIPTION
## Summary

When multiple messages tie on the same primary reference (`references[0]`), catalog order fell through to `messagesById` insertion order. Files were processed with `Promise.all`, so that order depended on which source file finished first—leading to non-deterministic `.po`/`.json` output.

This PR keeps extraction parallel but **applies** extracted messages to internal maps in **sorted source-file order**. Watcher batches also sort events by path before processing, so dev/watch behaves consistently.

## Relation to #2315

[PR #2315](https://github.com/amannn/next-intl/pull/2315) discussed the same tie-breaking issue and proposed sorting ties by message `id` inside `getSortedMessages`. That fixes churn globally but changes semantics for same-line ties within one file (source order vs id order).

Here we fix the cross-file race **without** changing `getSortedMessages`: stable ordering comes from deterministic merge order instead of an id tiebreaker.

## Testing

- New regression: `orders same-reference messages independently of file processing order` in `ExtractionCompiler.test.tsx`.
- Ran: `pnpm --filter next-intl test run src/extractor/ExtractionCompiler.test.tsx` (all passing).

Made with [Cursor](https://cursor.com)