### PR TITLE
feat: Remove line numbers from default `.po` codec

### DIFF
--- a/docs/src/pages/docs/usage/plugin.mdx
+++ b/docs/src/pages/docs/usage/plugin.mdx
@@ -225,7 +225,7 @@ When using this option, your messages will look like this:
 
 ```po
 #. Advance to the next slide
-#: src/components/Carousel.tsx:13
+#: src/components/Carousel.tsx
 msgid "carousel.next"
 msgstr "Right"
 ```
@@ -234,14 +234,16 @@ msgstr "Right"
 
 ```po
 #. Advance to the next slide
-#: src/components/Carousel.tsx:13
+#: src/components/Carousel.tsx
 msgid "5VpL9Z"
 msgstr "Right"
 ```
 
-Besides the message key and the label itself, this format also supports optional descriptions and file references to all modules that consume this message.
+Besides the message key and the label itself, this format also supports optional descriptions and file references for modules that consume this message.
 
 For local editing of .po files, you can use e.g. a tool like [Poedit](https://poedit.net/).
+
+**Note:** The default PO format emits path-only references (no line numbers) to avoid noisy diffs. If you'd like to store line numbers as well, you can create a [custom format](#formats-custom) that emits this format.
 
 ##### Custom format [#formats-custom]
 

--- a/e2e/extracted-monorepo-app/messages/de.po
+++ b/e2e/extracted-monorepo-app/messages/de.po
@@ -6,6 +6,6 @@ msgstr ""
 "X-Generator: next-intl\n"
 "X-Crowdin-SourceKey: msgstr\n"
 
-#: src/app/page.tsx:8
+#: src/app/page.tsx
 msgid "F6UyFs"
 msgstr "First-party Überschrift"

--- a/e2e/extracted-monorepo-app/messages/en.po
+++ b/e2e/extracted-monorepo-app/messages/en.po
@@ -6,6 +6,6 @@ msgstr ""
 "X-Generator: next-intl\n"
 "X-Crowdin-SourceKey: msgstr\n"
 
-#: src/app/page.tsx:8
+#: src/app/page.tsx
 msgid "F6UyFs"
 msgstr "First-party headline"

--- a/e2e/extracted-po/messages/en.po
+++ b/e2e/extracted-po/messages/en.po
@@ -6,15 +6,11 @@ msgstr ""
 "X-Generator: next-intl\n"
 "X-Crowdin-SourceKey: msgstr\n"
 
-#: src/app/page.tsx:9
+#: src/app/page.tsx
 msgid "NhX4DJ"
 msgstr "Hello"
 
-#. Shown on home screen
-#: src/components/Footer.tsx:7
+#: src/components/Footer.tsx
+#: src/components/Greeting.tsx
 msgid "+YJVTi"
 msgstr "Hey!"
-
-#: src/components/Greeting.tsx:7
-msgid "4xqPlJ"
-msgstr "Howdy!"

--- a/e2e/extracted-po/tests/main.spec.ts
+++ b/e2e/extracted-po/tests/main.spec.ts
@@ -74,8 +74,7 @@ export default function Greeting() {
   const entry = getPoEntry(content, 'OpKKos');
   expect(entry).toMatch(/msgstr "Hello!"/);
   expect(entry).toMatch(/Greeting\.tsx/);
-  const greetingRefs =
-    entry!.match(/^#: [^\n]*Greeting\.tsx[^\n]*$/gm) ?? [];
+  const greetingRefs = entry!.match(/^#: [^\n]*Greeting\.tsx[^\n]*$/gm) ?? [];
   expect(greetingRefs.length).toBe(1);
 });
 

--- a/e2e/extracted-po/tests/main.spec.ts
+++ b/e2e/extracted-po/tests/main.spec.ts
@@ -43,7 +43,7 @@ export default function Greeting() {
   expect(content).toContain('Newly extracted');
 });
 
-it('tracks all line numbers when same message appears multiple times in one file', async ({
+it('conflates file references when the same message appears multiple times in one file', async ({
   page
 }) => {
   await using _ = await withTempEditApp(
@@ -74,8 +74,9 @@ export default function Greeting() {
   const entry = getPoEntry(content, 'OpKKos');
   expect(entry).toMatch(/msgstr "Hello!"/);
   expect(entry).toMatch(/Greeting\.tsx/);
-  const greetingRefs = entry!.match(/#: [^\n]*Greeting\.tsx[^\n]*/g) ?? [];
-  expect(greetingRefs.length).toBeGreaterThanOrEqual(2);
+  const greetingRefs =
+    entry!.match(/^#: [^\n]*Greeting\.tsx[^\n]*$/gm) ?? [];
+  expect(greetingRefs.length).toBe(1);
 });
 
 it("saves catalog when it's missing", async ({page}) => {
@@ -448,7 +449,7 @@ msgstr ""
 "X-Something-Else: test\\n"
 "Language: en\\n"
 
-#: src/components/Greeting.tsx:5
+#: src/components/Greeting.tsx
 msgid "+YJVTi"
 msgstr "Hey!"
 `

--- a/e2e/shared-ui/messages/de.po
+++ b/e2e/shared-ui/messages/de.po
@@ -6,6 +6,6 @@ msgstr ""
 "X-Generator: next-intl\n"
 "X-Crowdin-SourceKey: msgstr\n"
 
-#: src/ProfileCard.tsx:10
+#: src/ProfileCard.tsx
 msgid "Cq+Nds"
 msgstr "Profilkarte"

--- a/e2e/shared-ui/messages/en.po
+++ b/e2e/shared-ui/messages/en.po
@@ -6,6 +6,6 @@ msgstr ""
 "X-Generator: next-intl\n"
 "X-Crowdin-SourceKey: msgstr\n"
 
-#: src/ProfileCard.tsx:10
+#: src/ProfileCard.tsx
 msgid "Cq+Nds"
 msgstr "Profile card"

--- a/examples/example-app-router-extracted/messages/de.po
+++ b/examples/example-app-router-extracted/messages/de.po
@@ -6,19 +6,19 @@ msgstr ""
 "X-Generator: next-intl\n"
 "X-Crowdin-SourceKey: msgstr\n"
 
-#: src/app/Counter.tsx:16
+#: src/app/Counter.tsx
 msgid "jm1lmy"
 msgstr "Anzahl: {count, number}"
 
-#: src/app/Counter.tsx:17
+#: src/app/Counter.tsx
 msgid "tQLRmz"
 msgstr "Erhöhen"
 
 #. Default meta title if not overridden by pages
-#: src/app/layout.tsx:17
+#: src/app/layout.tsx
 msgid "lNLCAE"
 msgstr "next-intl Beispiel"
 
-#: src/app/page.tsx:10
+#: src/app/page.tsx
 msgid "vlslj0"
 msgstr "Hallo {name}!"

--- a/examples/example-app-router-extracted/messages/en.po
+++ b/examples/example-app-router-extracted/messages/en.po
@@ -6,19 +6,19 @@ msgstr ""
 "X-Generator: next-intl\n"
 "X-Crowdin-SourceKey: msgstr\n"
 
-#: src/app/Counter.tsx:16
+#: src/app/Counter.tsx
 msgid "jm1lmy"
 msgstr "Count: {count, number}"
 
-#: src/app/Counter.tsx:17
+#: src/app/Counter.tsx
 msgid "tQLRmz"
 msgstr "Increment"
 
 #. Default meta title if not overridden by pages
-#: src/app/layout.tsx:17
+#: src/app/layout.tsx
 msgid "lNLCAE"
 msgstr "next-intl example"
 
-#: src/app/page.tsx:10
+#: src/app/page.tsx
 msgid "vlslj0"
 msgstr "Hey {name}!"

--- a/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
+++ b/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
@@ -445,7 +445,7 @@ describe('po format', {timeout: 20_000}, () => {
     await waitForWriteFileCalls(1);
     const output = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
 
-    expect(output).toContain('#: src/Greeting.tsx:4');
+    expect(output).toContain('#: src/Greeting.tsx');
     expect(output).not.toContain('src\\Greeting.tsx');
     expect(relativeSpy).toHaveBeenCalled();
   });
@@ -618,7 +618,7 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/component-b.tsx:5
+      #: src/component-b.tsx
       msgid "4xqPlJ"
       msgstr "Howdy!"
       ",
@@ -633,7 +633,7 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/component-b.tsx:5
+      #: src/component-b.tsx
       msgid "4xqPlJ"
       msgstr ""
       ",
@@ -713,7 +713,7 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/component-b.tsx:5
+      #: src/component-b.tsx
       msgid "OpKKos"
       msgstr "Hello!"
       ",
@@ -728,7 +728,7 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/component-b.tsx:5
+      #: src/component-b.tsx
       msgid "OpKKos"
       msgstr "Hallo!"
       ",
@@ -777,7 +777,7 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/component-b.tsx:5
+      #: src/component-b.tsx
       msgid "OpKKos"
       msgstr "Hello!"
       ",
@@ -792,7 +792,7 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/component-b.tsx:5
+      #: src/component-b.tsx
       msgid "OpKKos"
       msgstr ""
       ",
@@ -841,7 +841,7 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/component-b.tsx:5
+      #: src/component-b.tsx
       msgid "OpKKos"
       msgstr "Hello!"
       ",
@@ -856,7 +856,7 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/component-b.tsx:5
+      #: src/component-b.tsx
       msgid "OpKKos"
       msgstr ""
       ",
@@ -896,11 +896,11 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/app/page.tsx:5
+      #: src/app/page.tsx
       msgid "NhX4DJ"
       msgstr "Hello"
 
-      #: src/components/Header.tsx:5
+      #: src/components/Header.tsx
       msgid "PwaN2o"
       msgstr "Welcome"
       ",
@@ -918,13 +918,13 @@ describe('po format', {timeout: 20_000}, () => {
     `;
     filesystem.project.messages = {
       'en.po': `
-      #: src/Greeting.tsx:4
+      #: src/Greeting.tsx
       #, fuzzy
       msgid "+YJVTi"
       msgstr "Hey!"
       `,
       'de.po': `
-      #: src/Greeting.tsx:4
+      #: src/Greeting.tsx
       #, c-format
       msgid "+YJVTi"
       msgstr "Hallo!"
@@ -947,7 +947,7 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       #, fuzzy
       msgid "+YJVTi"
       msgstr "Hey!"
@@ -963,7 +963,7 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       #, c-format
       msgid "+YJVTi"
       msgstr "Hallo!"
@@ -997,16 +997,16 @@ describe('po format', {timeout: 20_000}, () => {
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/a.tsx:5
+      #: src/a.tsx
       msgid "PmvAXH"
       msgstr "Message A"
 
-      #: src/b.tsx:5
-      #: src/d.tsx:5
+      #: src/b.tsx
+      #: src/d.tsx
       msgid "5bb321"
       msgstr "Message B"
 
-      #: src/c.tsx:5
+      #: src/c.tsx
       msgid "c3UbA2"
       msgstr "Message C"
       ",
@@ -1084,12 +1084,12 @@ msgstr "Hey!"
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       #, c-format
       msgid "+YJVTi"
       msgstr "Hey!"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "jqdzk6"
       msgstr "World"
       ",
@@ -1141,15 +1141,15 @@ msgstr "World"
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "+YJVTi"
       msgstr "Hey!"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "jqdzk6"
       msgstr "World"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "ODGmph"
       msgstr "!"
       ",
@@ -1206,20 +1206,20 @@ msgstr ""
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       #, no-wrap
       msgid "+YJVTi"
       msgstr "Hallo!"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "jqdzk6"
       msgstr ""
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "ODGmph"
       msgstr ""
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "pE58D7"
       msgstr ""
       ",
@@ -1279,23 +1279,23 @@ msgstr ""
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "+YJVTi"
       msgstr "Hallo!"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "jqdzk6"
       msgstr ""
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "ODGmph"
       msgstr ""
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "pE58D7"
       msgstr ""
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgid "I5NMJ8"
       msgstr ""
       ",
@@ -1313,13 +1313,13 @@ msgstr ""
     `;
     filesystem.project.messages = {
       'en.po': `
-      #: src/Greeting.tsx:4
+      #: src/Greeting.tsx
       #, c-format
       msgid "OpKKos"
       msgstr "Hello!"
       `,
       'de.po': `
-      #: src/Greeting.tsx:4
+      #: src/Greeting.tsx
       #, fuzzy
       msgid "OpKKos"
       msgstr "Hallo!"
@@ -1371,7 +1371,7 @@ msgstr ""
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       #, c-format
       msgid "OpKKos"
       msgstr "Hello!"
@@ -1387,7 +1387,7 @@ msgstr ""
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       #, fuzzy
       msgid "OpKKos"
       msgstr "Hallo!"
@@ -1403,12 +1403,12 @@ msgstr ""
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       #, c-format
       msgid "OpKKos"
       msgstr "Hello!"
 
-      #: src/Greeting.tsx:10
+      #: src/Greeting.tsx
       msgid "nm/7yQ"
       msgstr "Hi!"
       ",
@@ -1423,12 +1423,12 @@ msgstr ""
       "X-Generator: next-intl\\n"
       "X-Crowdin-SourceKey: msgstr\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       #, fuzzy
       msgid "OpKKos"
       msgstr "Hallo!"
 
-      #: src/Greeting.tsx:10
+      #: src/Greeting.tsx
       msgid "nm/7yQ"
       msgstr ""
       ",
@@ -1719,7 +1719,7 @@ msgstr "Hallo!"`
         "X-Generator: next-intl\\n"
         "X-Crowdin-SourceKey: msgstr\\n"
 
-        #: src/new/Button.tsx:5
+        #: src/new/Button.tsx
         msgid "cfI2fq"
         msgstr "Click me updated"
         ",
@@ -1986,17 +1986,17 @@ describe('custom format', () => {
       "Content-Transfer-Encoding: 8bit\\n"
       "X-Generator: next-intl\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgctxt "OpKKos"
       msgid "Hello!"
       msgstr "Hello!"
 
-      #: src/Greeting.tsx:11
+      #: src/Greeting.tsx
       msgctxt "misc.l6ZjWT"
       msgid "The code you entered is incorrect. Please try again or contact support@example.com."
       msgstr "The code you entered is incorrect. Please try again or contact support@example.com."
 
-      #: src/Greeting.tsx:12
+      #: src/Greeting.tsx
       msgctxt "misc.Fp6Fab"
       msgid "Checking if you're logged in."
       msgstr "Checking if you're logged in."
@@ -2011,17 +2011,17 @@ describe('custom format', () => {
       "Content-Transfer-Encoding: 8bit\\n"
       "X-Generator: next-intl\\n"
 
-      #: src/Greeting.tsx:5
+      #: src/Greeting.tsx
       msgctxt "OpKKos"
       msgid "Hello!"
       msgstr "Hallo!"
 
-      #: src/Greeting.tsx:11
+      #: src/Greeting.tsx
       msgctxt "misc.l6ZjWT"
       msgid "The code you entered is incorrect. Please try again or contact support@example.com."
       msgstr ""
 
-      #: src/Greeting.tsx:12
+      #: src/Greeting.tsx
       msgctxt "misc.Fp6Fab"
       msgid "Checking if you're logged in."
       msgstr ""

--- a/packages/next-intl/src/extractor/format/codecs/POCodec.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/POCodec.tsx
@@ -55,15 +55,9 @@ export default defineCodec(() => {
           : id;
 
         // Path-only refs (no `:line`), unique paths
-        const pathOnlyRefs: Array<{path: string}> = [];
-        if (references.length > 0) {
-          const seenPaths = new Set<string>();
-          for (const reference of references) {
-            if (seenPaths.has(reference.path)) continue;
-            seenPaths.add(reference.path);
-            pathOnlyRefs.push({path: reference.path});
-          }
-        }
+        const pathOnlyRefs: Array<{path: string}> = [
+          ...new Set(references.map((ref) => ref.path))
+        ].map((path) => ({path}));
 
         return {
           msgid,

--- a/packages/next-intl/src/extractor/format/codecs/POCodec.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/POCodec.tsx
@@ -54,12 +54,23 @@ export default defineCodec(() => {
           ? id.slice(lastDotIndex + NAMESPACE_SEPARATOR.length)
           : id;
 
+        // Path-only refs (no `:line`), unique paths
+        const pathOnlyRefs: Array<{path: string}> = [];
+        if (references.length > 0) {
+          const seenPaths = new Set<string>();
+          for (const reference of references) {
+            if (seenPaths.has(reference.path)) continue;
+            seenPaths.add(reference.path);
+            pathOnlyRefs.push({path: reference.path});
+          }
+        }
+
         return {
           msgid,
           msgstr: message,
           ...(description.length > 0 && {extractedComments: description}),
           ...(hasNamespace && {msgctxt: id.slice(0, lastDotIndex)}),
-          ...(references.length > 0 && {references}),
+          ...(pathOnlyRefs.length > 0 && {references: pathOnlyRefs}),
           ...rest
         };
       });

--- a/packages/next-intl/src/extractor/format/codecs/fixtures/POCodecSourceMessageKey.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/fixtures/POCodecSourceMessageKey.tsx
@@ -57,9 +57,21 @@ export default defineCodec(() => {
 
         // Store the hashed ID in msgctxt so we can restore it during decode
         const {description = [], id, message, references, ...rest} = msg;
+
+        // Path-only refs (no `:line`), unique paths
+        const pathOnlyRefs: Array<{path: string}> = [];
+        if (references.length > 0) {
+          const seenPaths = new Set<string>();
+          for (const reference of references) {
+            if (seenPaths.has(reference.path)) continue;
+            seenPaths.add(reference.path);
+            pathOnlyRefs.push({path: reference.path});
+          }
+        }
+
         return {
           ...(description.length > 0 && {extractedComments: description}),
-          ...(references.length > 0 && {references}),
+          ...(pathOnlyRefs.length > 0 && {references: pathOnlyRefs}),
           ...rest,
           msgctxt: id,
           msgid: sourceMessage,

--- a/packages/next-intl/src/extractor/format/codecs/fixtures/POCodecSourceMessageKey.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/fixtures/POCodecSourceMessageKey.tsx
@@ -59,15 +59,9 @@ export default defineCodec(() => {
         const {description = [], id, message, references, ...rest} = msg;
 
         // Path-only refs (no `:line`), unique paths
-        const pathOnlyRefs: Array<{path: string}> = [];
-        if (references.length > 0) {
-          const seenPaths = new Set<string>();
-          for (const reference of references) {
-            if (seenPaths.has(reference.path)) continue;
-            seenPaths.add(reference.path);
-            pathOnlyRefs.push({path: reference.path});
-          }
-        }
+        const pathOnlyRefs: Array<{path: string}> = [
+          ...new Set(references.map((ref) => ref.path))
+        ].map((path) => ({path}));
 
         return {
           ...(description.length > 0 && {extractedComments: description}),

--- a/rfcs/001-message-extraction.md
+++ b/rfcs/001-message-extraction.md
@@ -255,7 +255,7 @@ The following file formats are being considered:
 
 ```
 #. Advance to the next slide
-#: src/components/Carousel.tsx:13
+#: src/components/Carousel.tsx
 msgid "5VpL9Z"
 msgstr "Right"
 


### PR DESCRIPTION
## Summary

The built-in PO codec now writes location comments as `#: path` only: line numbers are not serialized, and duplicate paths for the same message are merged. This matches common gettext “file” location style and cuts noise and merge pain on committed catalogs.

```diff
 #. Advance to the next slide
-#: src/components/Carousel.tsx:12
-#: src/components/Carousel.tsx:44
+#: src/components/Carousel.tsx
 msgid "carousel.next"
 msgstr "Right"
```





## Upgrade hint if you still want `#:path:line`

The extractor keeps line information internally during compilation; only the encode step omits lines. To keep gettext-style numbered references, define a [custom codec](https://next-intl.dev/docs/usage/plugin#formats-custom) modeled on the built-in `POCodec`: in `encode`, pass `references` through to serialization without stripping `line` (and skip path dedupe if you rely on multiplicity). Adjust ordering or dedupe to taste.

## Trade-offs

**Pros:** Fewer unrelated diffs when only non‑i18n code moves lines; fewer merge fights on `.po` files in busy repos; aligns with gettext’s own “file‑only” location mode used for version control hygiene.

**Cons:** Editors and Poedit lose one-click jump to an exact source line from the `#:` comment alone; catalogs no longer spell out multiple call sites in the same file via distinct `#:path:line` rows (duplicate paths collapse to one line per message).

**Verdict**. Path-only references should be sufficient, as a path + AST analysis/grep should be sufficient to find relevant call sites. Translators are not expected to view source code, but rather, automated tools should extract relevant information and provide structured context to (AI) translators that are not source code.


## Context

Community discussion and reports:

- [Discussion #2036 — `useExtracted` feedback](https://github.com/amannn/next-intl/discussions/2036) (see also [comment on packaging the default PO codec](https://github.com/amannn/next-intl/discussions/2036#discussioncomment-15770359) and [related thread](https://github.com/amannn/next-intl/discussions/2036#discussioncomment-15930728))
- [Issue #2321 — option to disable or tame file references for PO](https://github.com/amannn/next-intl/issues/2321) (closed with pointer back to #2036; [background comment](https://github.com/amannn/next-intl/discussions/2036#discussioncomment-15781717))
- [Issue #2087 — stabilize `useExtracted`](https://github.com/amannn/next-intl/issues/2087) (tracks “options for excluding line numbers” alongside the above)

<details>
<summary>Planning doc</summary>

# PO file references (`#:`) and line numbers — context for a maintainer decision

This note collects **what exists today**, **why people are unhappy**, **options**, and **trade-offs**, so we can confidently change defaults (especially: **stop emitting line numbers in the built-in PO codec**) without drifting into a maze of codec-specific flags.

Primary feedback sources:

- [Discussion #2036 — `useExtracted` feedback](https://github.com/amannn/next-intl/discussions/2036) (threaded replies, incl. [`discussioncomment-15770359`](https://github.com/amannn/next-intl/discussions/2036#discussioncomment-15770359), [`discussioncomment-15930728`](https://github.com/amannn/next-intl/discussions/2036#discussioncomment-15930728))
- [Issue #2321 — option to disable file references for PO](https://github.com/amannn/next-intl/issues/2321)

---

## 1. What we currently have

### Pipeline (high level)

1. **Extraction (SWC plugin)** computes a `Reference { path, line }` per static call site (`lookup_char_pos` on the invocation span).
2. **`CatalogManager`** groups `SourceMessage` rows by message id and builds an **`ExtractorMessage`** with `references`: all unique call sites merged, **sorted by** `compareReferences` (**path**, then **`line`**).
3. **`POCodec`** is a thin adapter: decode/encode via **`po-parser`**, passes `references` through on write. **`JSONCodec`** keeps `references: []` — references are PO-specific in practice.
4. **Catalog ordering for PO encode**: `getSortedMessages` sorts messages using each row’s **`references[0]`** (path, then line when present), with **`line?: number`** optional in types but always populated by the extractor today.

Supporting details already in-tree:

- **Cross-OS paths**: `normalizePathToPosix` so `#:` paths use forward slashes regardless of runner OS (addresses “Windows backslashes vs Mac slashes” feedback in [#2036](https://github.com/amannn/next-intl/discussions/2036)).
- **Duplicates in one file**: multiple `t('Hello!')` in the same module produce multiple `#:` lines (or repetitions depending on gettext serialization) — exercised by e2e (`extracted-po`).

### Intended purpose of `#: path:line`

- Matches common **gettext / Poedit / xgettext** conventions: translators jump from a catalog entry to **source**.
- Hypothesis from maintainers (historical): line numbers give **fine-grained context** for tooling (e.g. passing snippets to downstream QA / LLM-assisted workflows).

### Documentation

Docs show **`#: src/file.tsx`** (path only; [plugin docs — PO format](https://next-intl.dev/docs/usage/plugin#formats-po)).

---

## 2. What sucks (problem statement)

### 2.1 Line numbers create unrelated churn

**Core complaint** (echoed in [#2321](https://github.com/amannn/next-intl/issues/2321) and [#2036](https://github.com/amannn/next-intl/discussions/2036)): any edit **above** a call site shifts line numbers. Teams see:

- Noisy diffs on **`.po`** even when **strings and keys** did not change.
- **Merge conflicts** on generated catalogs in busy repos (especially painful when many PRs touch different areas but share one `en.po` / source-locale file).

The issue author’s framing is fair: **“why line numbers?”** — for many workflows, **search by key or by default message text** in the repo is enough to find usages; line-precise refs are not always worth the churn.

### 2.2 File references without lines are often enough

If a reference is only **`#: path/to/Component.tsx`**:

- Humans still know **where to look**.
- Automated tooling can **re-resolve** call sites with **AST search** (message id / default string) if it needs exact spans — line numbers are not the only way to get precision.

Line numbers are **brittle**; paths are **relatively stable** (renames/moves are real but rarer than “someone added five lines at the top of the file”).

### 2.3 Ergonomics: “I want gettext metadata, not line noise”

Users who **want PO** for descriptions / comments / translator tooling still ask for **less volatile** references. In [#2036](https://github.com/amannn/next-intl/discussions/2036), **fo-fo** asked whether **`POCodec` could be exported** so a custom codec could wrap it and **drop line numbers** without vendoring a full copy of the built-in codec — a signal that **forking the codec** feels heavy for a small formatting preference.

### 2.4 Extraction lifecycle & conflicts mid-pull

Reports (e.g. in [#2036](https://github.com/amannn/next-intl/discussions/2036)) of **unexpected `.po` conflicts** when localization was not intentionally edited sometimes involve **running `next dev` during a partially applied pull** — **intermediate filesystem states** triggering extraction. That’s operational, but **line-level diffs on catalogs** amplify the fallout.

---

## 3. Ecosystem: line numbers in PO (prior art)

This is not unique to next-intl. Other stacks show the same tension: **translator-oriented precision** vs **version-control hygiene**.

### 3.1 Why line numbers exist at all (classic gettext)

Tools like **`xgettext`** emit **`#: path:line`** so translators (and Poedit’s “go to source”) can open the **exact** usage. Multiple call sites in one file become multiple **`#:`** lines with different line suffixes — useful for disambiguation without reading the whole module.

### 3.2 The same ecosystem explicitly added ways to *drop* them for VCS

GNU gettext gained **`--add-location=full|file|never`** (and **`--no-location`**, equivalent to **`never`**) so teams can control how much location metadata is written. Django’s [`#28015`](https://code.djangoproject.com/ticket/28015) quotes the gettext manual: the option exists **“in order to ease the version control of po files”**, and threads it through **`makemessages`** as **`--add-location`**. So “file only” / “no location” is a **first-class, documented** variant of the same format — not a hack.

### 3.3 Lingui (closest JS analog)

Lingui hit the same complaints years earlier and shipped **formatter options** instead of a single opinion:

- **[Issue #587 — Make catalog file line number references optional](https://github.com/lingui/js-lingui/issues/587)** (2019): **GitFlow-style merge conflicts** across **every language catalog**; author asked for an option to turn off line numbers; merged via [PR #588](https://github.com/lingui/js-lingui/pull/588), released in **v2.9.0**. A maintainer initially suggested auto-resolving merge conflicts on extract; the reporter countered that **conflict markers still block a clean extract** unless you add merge-driver-level tooling — a **config flag** is simpler.
- **`@lingui/format-po`**: documents **`lineNumbers`** (and related **`origins`**) — see [Message catalog formats](https://lingui.dev/ref/catalog-formats). [PR #1007](https://github.com/lingui/js-lingui/pull/1007) titled “allow to disable lineNumbers”.
- **[Issue #2405 — Reduce PO catalog comments changes](https://github.com/lingui/js-lingui/issues/2405)** (2026): massive diffs from path+line comments; wants **paths only**, notes that **`lineNumbers: false`** still leaves **duplicate `#:` lines per file** when the same msgid appears many times — they want **deduplication** / post-processing with **`uniq`**.

Interpretation for us: **path-only refs are an established Lingui-supported mode**; lingering pain there is **duplication**, not philosophical opposition to stripping lines.

### 3.4 Broader gettext practice

Teams that keep **`.pot` templates** + **`msgmerge`** into locale **`*.po`** deliberately limit how often translator files churn; next-intl’s **single checked-in catalog per locale** is closer to “always regenerate the PO” workflows, where **reference volatility hurts more**. StackOverflow and gettext docs have long threads on **noise in diffs**; mitigations cited include stripping locations for **diff** only or using **`--no-location`**-style pipelines.

### 3.5 Who still *wants* lineful refs (and why)

- **Human translators** using editor features that jump to **line**.
- **Review / QA** where “show me this string in context” means **one click**, not search-in-file.
- **Disambiguation**: many occurrences in one file — **`path:line`** lists each without deduping.

None of these require line numbers for **machine** consumers if the tool can **re-scan** the file by key or default message; they **do** matter for **human** speed and for **tools that only consume the PO** (no repo checkout).

---

## 4. If we change the default: plausible reactions

Rough forecast — not exhaustive — based on the above and on next-intl’s own threads.

| Reaction | Why it might show up | Mitigation / counterpoint |
| -------- | -------------------- | ------------------------- |
| **Relief** | Same story as Lingui #587 / Django / gettext **`file`**: less noise, fewer conflicts when PO is committed. | Communicate as **aligning with gettext’s own VCS-oriented modes**. |
| **“Why no toggle? Lingui has `lineNumbers`.”** | Users expect a boolean on the built-in codec. | **Custom `defineCodec`** for lineful output; optional later **export/wrap `POCodec`** (§6.D) to reduce vendoring. |
| **Poedit / translator grumbling** | Weaker “go to exact line” if only path is stored. | Path + msgid / default text search is usually enough; power users who need lines keep a **custom codec**. |
| **“How many usages did this string have?”** | Multiple **`#: file:NN`** lines made multiplicity obvious; **deduped path-only** hides it. | Rare ask; tooling can count from source; if needed, codecs could emit **paths without dedupe** (separate discussion). |
| **Crowdin / TMS** | Hypothetical dependency on **`line`** in **`#:`**. | Sanity-check real pipelines; gettext location comments are hints, not authoritative keys — see §8. |
| **One-time giant diff** | Every committed PO updates reference lines. | Changelog + “re-run extract once”; same as any reference-format change. |

Net: switching default to **path-only** is **credibly mainstream** (gettext shipped the knob for exactly this class of pain). The main predictable gripe vs Lingui is **lack of an official boolean** — we consciously trade that for **fewer maintained branches** and **custom codecs** carrying the long tail.

---

## 5. Tradeoffs — real costs and our verdict

These are genuine downsides of dropping **`path:line`** from the built-in codec; §4 covers how outsiders might phrase them.

### 5.1 Weaker IDE / Poedit “jump to exact line”

**Cost:** Editors and gettext tools historically used **`#: file:line`** to jump **straight** to a call site. Path-only **`#: file`** narrows scope to the module at best.

**Verdict:** “Jump to file / line” is a **thin** notion of translator context compared to how we want catalogs to relate to coding work **going forward**:

- Translators **should not** be routed into reading arbitrary source trees as part of baseline workflow.
- The useful direction is **one-way from code into translation artifacts**: **AI agents or deterministic extractors** surface **meaningful context** (surrounding strings, semantic descriptions in PO, snapshots, TMS context, screenshots, `#.` comments) — not bare line pointers.
- **`#:` path** stays enough **for machines**: open the right file(s) when needed; **precision** beyond that belongs in **explicit context fields** or **AST re-resolution**, not in volatile ints.

**Net verdict:** Acceptable trade for the **default** codec; workflows that cherish jump-to-line can use a **custom codec** that still emits lines.

### 5.2 No multiplicity signal per file (`#:` lines used to pile up)

**Cost:** Repeated **`#: same.ts:N`** rows made “this string fires **five** times **here**” obvious in the `.po`; path-only **`#:` dedup** loses that cardinality hint.

**Verdict:** **Probably acceptable.** Product / QA tooling can derive counts from extraction or AST when copy consistency matters; catalogs need not redundantly encode occurrence counts in reference comments.

---

## 6. Options (with pros / cons)

### A. Path-only `#:` references in default `POCodec` (no `:line`)

**Idea:** On **encode**, emit refs like **`#: src/a.tsx`** (and dedupe duplicate paths that only differed by line). Optionally keep **`line` in memory** for extractor / equality / tooling that still wants it internally.

| Pros                                                  | Cons                                                                  |
| ----------------------------------------------------- | --------------------------------------------------------------------- |
| Large reduction in churn from **non-i18n** edits      | One-time churn on upgrade (whole catalog diff)                        |
| Still gettext-friendly; Poedit accepts file-only refs | Loses instant “jump to line” accuracy in external tools               |
| Aligns with “search or AST resolves call site anyway” | If two usages in one file matter to someone, **path-only** is coarser |

** Maintainer alignment:** Matches stated direction — **change the default codec output**, avoid new built-in codec options.

### B. Omit `#:` lines entirely from default `POCodec`

| Pros                                                                   | Cons                                                                   |
| ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| Minimum catalog noise                                                  | Worse ergonomics for Poedit/external gettext workflows relying on refs |
| `getSortedMessages` already warns on missing refs — would need rethink | Might surprise users who **like** pointers to originating files        |

Probably too aggressive unless we **strongly** position PO as “metadata + msgstr only” — **A** hits the main pain without discarding usefulness of **paths**.

### C. Codec config flag (`includeLineNumbers: boolean`, etc.)

| Pros                                         | Cons                                                           |
| -------------------------------------------- | -------------------------------------------------------------- |
| Zero behavioral surprise for subset of users | **Explicit non-goal**: proliferates branching, tests, and docs |

User preference recorded: **do not add options on built-ins** — teams that care keep a **custom codec**.

### D. Export / compose built-in `POCodec` (+ user wraps encode)

| Pros                                               | Cons                                              |
| -------------------------------------------------- | ------------------------------------------------- |
| Lowers cost of forks                               | Public API surface + semver expectations          |
| Answers “strip lines without copying file” (#2036) | Doesn’t decide default; orthogonal packaging task |

Consider as **follow-up ergonomics**, not substitute for sane defaults.

### E. Strip lines in extractor globally (always drop `line` in `Reference`)

| Pros                             | Cons                                                                                                                                                                         |
| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Single representation everywhere | **`compareReferences`** and duplicate detection in **`CatalogManager`** become weaker (`areSourceMessagesEqual`) — two calls same file collapse unless we redefine semantics |
|                                  | Breaks assumptions in tests expecting line-distinct occurrences                                                                                                              |

Usually **inferior** to **encode-layer path-only PO**: keep precise internal facts, serialize **stable** catalogs.

---

## 7. Synthesis / suggestion

### Default PO codec should emit **paths, not lines**

Rationale:

1. **Translator reality:** file-level pointers + descriptions + `#.` comments carry most workflow value.
2. **Engineering reality:** lines move constantly; **`#:`** then lies or churns — both are bad for version control hygiene.
3. **Tooling reality:** locating exact call sites from **path + id / default message** via static analysis is viable; brittle line ints are weaker for automation than searchable structure.
4. **Prior art:** GNU gettext **`--add-location=file`**, Django **`makemessages --add-location`**, and Lingui **`lineNumbers: false`** all legitimize omitting lines for **VCS-friendly** catalogs (§3).
5. **Product stance:** Avoid per-codec switches; **`defineCodec`** remains the valve for gettext purists who insist on **`xgettext`-style** `path:line` output.
6. **Tradeoffs acceptable for default:** weaker jump-to-line and loss of multiplicity in `#:` rows are outweighed by VCS ergonomics plus the **context model** in **§5.1–§5.2**.

### Migration / communication

- **Breaking-ish visually:** `.po` files will change substantially once — worth a **changelog** note: expect a **one-time reorder / ref format change**.
- Refresh **docs examples** (`#:` without `:NN`).
- Update **tests** (many `ExtractionCompiler` expectations anchor on `:line`; e2e **“tracks all line numbers…”** becomes **path-level** assertions).

### Optional follow-up

- **Export `POCodec`** or a **small helper** (“serialize PO refs from `ExtractorMessage`”) for teams that want **lineful** gettext without vendoring — only if we want to support that composition pattern officially.

---

## 8. Open questions

1. **Crowdin / Lokalise / Poedit:** any integration that _requires_ `path:line` for a feature we care about? (Anecdotal: usually not for web catalogs, but worth a quick sanity check against real projects.)
2. **Multiple `#:` same path:** after path-only + dedupe, is one `#: path` per file per entry enough, or do we still want **one line per occurrence** with **path only** repeated? (Gettext allows either; **deduped** minimizes noise.)
3. **Whether to keep `line` in `ExtractorMessage` on disk** when reading old files: decode can keep lines from existing PO; next encode drops them — **acceptable gradual migration**.

---

## 9. Appendix — terminology

| Term         | Meaning here                                                                          |
| ------------ | ------------------------------------------------------------------------------------- |
| `Reference`  | Single call-site location `{ path, line? }` from extractor                            |
| `references` | Aggregated array on `ExtractorMessage` (PO `#:` rows)                                 |
| `POCodec`    | Built-in gettext codec (`packages/next-intl/src/extractor/format/codecs/POCodec.tsx`) |


</details>