### PR TITLE
feat: Expose `forcePrefix` on `Link` and `useRouter` (#2332)

### DIFF
--- a/docs/src/pages/docs/routing/navigation.mdx
+++ b/docs/src/pages/docs/routing/navigation.mdx
@@ -169,6 +169,22 @@ The reason for this is that a potential [cookie](/docs/routing/configuration#loc
 
 If you'd like to avoid this behavior, you can instead use [`useRouter`](#userouter) to switch the locale, which can rely on updating the cookie on the client side before navigating to the target page.
 
+Alternatively, you can opt out of the forced prefix by passing `forcePrefix={false}`. The link will then follow your [`localePrefix`](/docs/routing/configuration#localeprefix) setting — switching to the default locale produces an unprefixed pathname, switching to a secondary locale still produces a prefix. This is useful when there's no cookie to defeat in the first place, e.g. when using [`output: 'export'`](https://nextjs.org/docs/app/guides/static-exports) where there's no middleware to perform the rewrite:
+
+```tsx
+// With `localePrefix: 'as-needed'` and `en` as the default locale:
+// Links to `/about`
+<Link href="/about" locale="en" forcePrefix={false}>
+  About
+</Link>
+// Links to `/de/about`
+<Link href="/about" locale="de" forcePrefix={false}>
+  Über uns
+</Link>
+```
+
+The same option is available on [`useRouter`](#userouter) (`push`, `replace`, `prefetch`).
+
 </Details>
 
 <Details id="link-unknown-routes">

--- a/packages/next-intl/src/navigation/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/createNavigation.test.tsx
@@ -794,6 +794,25 @@ describe.each([
         expect(markup).toContain('href="/en/about"');
       });
 
+      it('can opt out of the forced prefix when linking to the default locale', () => {
+        mockCurrentLocale('de');
+        const markup = renderToString(
+          <Link forcePrefix={false} href="/about" locale="en">
+            About
+          </Link>
+        );
+        expect(markup).toContain('href="/about"');
+      });
+
+      it('still applies a natural prefix for a secondary locale when `forcePrefix={false}`', () => {
+        const markup = renderToString(
+          <Link forcePrefix={false} href="/about" locale="de">
+            Über uns
+          </Link>
+        );
+        expect(markup).toContain('href="/de/about"');
+      });
+
       it('renders an object href', () => {
         render(
           <Link href={{pathname: '/about', query: {foo: 'bar'}}}>About</Link>

--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -533,6 +533,20 @@ describe("localePrefix: 'as-needed'", () => {
         expect(useNextRouter()[method]).toHaveBeenCalledWith('/en/about');
       });
 
+      it('can opt out of the forced prefix when switching to the default locale', () => {
+        invokeRouter((router) =>
+          router[method]('/about', {locale: 'en', forcePrefix: false})
+        );
+        expect(useNextRouter()[method]).toHaveBeenCalledWith('/about');
+      });
+
+      it('still applies a natural prefix for a secondary locale when `forcePrefix: false`', () => {
+        invokeRouter((router) =>
+          router[method]('/about', {locale: 'de', forcePrefix: false})
+        );
+        expect(useNextRouter()[method]).toHaveBeenCalledWith('/de/about');
+      });
+
       it('sets a cookie when switching to the default locale', () => {
         global.document.cookie = 'NEXT_LOCALE=de';
         mockCurrentLocale('de');

--- a/packages/next-intl/src/navigation/react-client/createNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.tsx
@@ -81,9 +81,9 @@ export default function createNavigation<
       >(fn: Fn) {
         return function handler(
           href: Parameters<typeof getPathname>[0]['href'],
-          options?: Partial<Options> & {locale?: Locale}
+          options?: Partial<Options> & {locale?: Locale; forcePrefix?: boolean}
         ): void {
-          const {locale: nextLocale, ...rest} = options || {};
+          const {forcePrefix, locale: nextLocale, ...rest} = options || {};
 
           const pathname = getPathname({
             href,
@@ -93,8 +93,13 @@ export default function createNavigation<
             // the full detection is rather expensive, and this behavior is
             // consistent with the `Link` component. The downside is an
             // additional redirect for users in other situations. Locale
-            // changes should be rare though, so this might be fine.
-            forcePrefix: nextLocale != null || undefined
+            // changes should be rare though, so this might be fine. Passing
+            // `forcePrefix: false` opts out of this and defers to the natural
+            // `localePrefix` behavior instead.
+            forcePrefix:
+              forcePrefix === false
+                ? undefined
+                : (forcePrefix ?? (nextLocale != null || undefined))
           });
 
           const args: [href: string, options?: Options] = [pathname];

--- a/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
+++ b/packages/next-intl/src/navigation/shared/createSharedNavigationFns.tsx
@@ -82,10 +82,12 @@ export default function createSharedNavigationFns<
         : HrefOrUrlObjectWithParams<Pathname>;
       /** @see https://next-intl.dev/docs/routing/navigation#link */
       locale?: Locale;
+      /** @see https://next-intl.dev/docs/routing/navigation#link-locale */
+      forcePrefix?: boolean;
     } & DOMAttributes<HTMLAnchorElement>
   >;
   function Link<Pathname extends keyof AppPathnames = never>(
-    {href, locale, ...rest}: LinkProps<Pathname>,
+    {forcePrefix, href, locale, ...rest}: LinkProps<Pathname>,
     ref: ComponentProps<typeof BaseLink>['ref']
   ) {
     let pathname, params;
@@ -110,8 +112,13 @@ export default function createSharedNavigationFns<
           locale: locale || curLocale,
           // @ts-expect-error -- This is ok
           href: pathnames == null ? pathname : {pathname, params},
-          // Always include a prefix when changing locales
-          forcePrefix: locale != null || undefined
+          // Always include a prefix when changing locales. Passing
+          // `forcePrefix={false}` opts out of this and defers to the
+          // natural `localePrefix` behavior instead.
+          forcePrefix:
+            forcePrefix === false
+              ? undefined
+              : (forcePrefix ?? (locale != null || undefined))
         })
       : pathname;
 


### PR DESCRIPTION
Fixes #2332.

## Summary

Mirrors the existing `forcePrefix` option on `redirect` for `Link` and `useRouter().push/replace/prefetch`. Today, whenever a `locale` prop is set on `Link` (or passed to `useRouter`), a prefix is implicitly forced so a locale cookie can be updated server-side before the request is rewritten to the unprefixed route. There's no userland opt-out.

With `output: 'export'`, this is broken by design: there is no middleware to perform the rewrite, the prefixed default-locale path (`/en/about`) isn't part of the static export, and with `localeCookie: false` there's no cookie to defeat in the first place. The forced prefix produces a 404 link.

This PR exposes `forcePrefix` so users can opt out:

```tsx
// With `localePrefix: 'as-needed'` and `en` as the default locale:
<Link href="/about" locale="en" forcePrefix={false}>About</Link>     // → /about
<Link href="/about" locale="de" forcePrefix={false}>Über uns</Link>  // → /de/about

router.push('/about', {locale: 'en', forcePrefix: false}); // → /about
router.push('/about', {locale: 'de', forcePrefix: false}); // → /de/about
```

## Semantics

| `forcePrefix` | Behavior                                                                             |
| ------------- | ------------------------------------------------------------------------------------ |
| omitted       | Unchanged — implicit prefix when `locale` is set (preserves the cookie-update flow). |
| `true`        | Force a prefix regardless of `localePrefix` setting (matches `redirect()`).          |
| `false`       | Opt out of the implicit force; defer to natural `localePrefix` behavior.             |

Note: for `Link`/`useRouter`, `forcePrefix={false}` is interpreted as "defer to `localePrefix`" rather than "never prefix" (the literal `redirect()` semantics). This is the behavior locale-switcher code actually wants and avoids a footgun where secondary-locale links would lose their prefix.

## Test plan

- [x] Unit tests added for `Link` and each `useRouter` method, covering both default-locale opt-out (no prefix) and secondary-locale opt-out (natural prefix retained). Full suite passes (902 tests).
- [x] Manually verified with the issue's reproduction repo under `output: 'export'` + `localePrefix: 'as-needed'`:
  - From `/about/`: English → `/about/`, Swedish → `/sv-se/about/` ✓
  - From `/sv-se/about/`: English → `/about/`, Swedish → `/sv-se/about/` ✓
- [x] `eslint`, `prettier`, `tsc --noEmit` clean.

## Docs

Updated the existing `<Details id="link-locale">` callout in `docs/.../navigation.mdx` to document the opt-out and the deferred-to-natural-prefixing semantics, with an example covering both the default-locale and secondary-locale outcomes.

## Not included / follow-up

The issue also floated two related improvements that I've left out of this PR to keep it focused:

1. A `forcePrefix` option on `defineRouting` so the opt-out can be set routing-wide instead of per call.
2. Automatically relaxing the implicit force when `localeCookie: false` + `localePrefix: 'as-needed'` (no new API — the cookie-defeating rationale doesn't apply in that config).

Which direction would you prefer for the follow-up? My read is that (2) is the more ergonomic default for the static-export case and doesn't expand the API surface, while (1) is more explicit. Happy to open a follow-up PR for whichever you'd like.
