### PR TITLE
docs: Add copy-to-clipboard for details section permalinks

### DIFF
--- a/docs/src/components/Details.tsx
+++ b/docs/src/components/Details.tsx
@@ -1,5 +1,13 @@
 import {useMDXComponents} from 'nextra/mdx';
-import {ComponentProps, ReactNode, useEffect, useReducer} from 'react';
+import {
+  ComponentProps,
+  MouseEvent,
+  ReactNode,
+  useEffect,
+  useReducer,
+  useRef,
+  useState
+} from 'react';
 import useLocationHash from '@/hooks/useLocationHash';
 
 type Props = ComponentProps<'details'>;
@@ -9,6 +17,8 @@ export default function Details({children, id, ...rest}: Props) {
   const hasLoadedHash = locationHash !== undefined;
   const isActive = id === locationHash;
   const [key, resetKey] = useReducer((x) => x + 1, 0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isCopied, setCopied] = useState(false);
 
   const OriginalDetails = useMDXComponents().details as (
     props: Props
@@ -28,17 +38,57 @@ export default function Details({children, id, ...rest}: Props) {
     }
   }, [isActive]);
 
+  useEffect(() => {
+    if (!isCopied) return;
+    const timerId = setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, [isCopied]);
+
+  async function onAnchorClick(event: MouseEvent<HTMLAnchorElement>) {
+    // Modifier-click (⌘ on Mac, Ctrl elsewhere) copies a Markdown link that
+    // uses the summary as the label, which is handy for sharing a section
+    // (e.g. on GitHub). A regular click keeps the default permalink behavior.
+    if (!(event.metaKey || event.ctrlKey)) return;
+
+    event.preventDefault();
+
+    const summary = containerRef.current
+      ?.querySelector('summary')
+      ?.textContent.trim();
+    const url = `${window.location.origin}${window.location.pathname}#${id}`;
+    const markdown = summary ? `[${summary}](${url})` : url;
+
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopied(true);
+    } catch {
+      console.error('Failed to copy!');
+    }
+  }
+
   return (
-    <div className="relative">
+    <div ref={containerRef} className="relative">
       {id && (
         <a
           aria-label="Permalink for this section"
           className="subheading-anchor absolute right-3 top-3 scroll-m-[5rem]"
           href={`#${id}`}
           id={id}
+          onClick={onAnchorClick}
+          title="Permalink for this section (⌘/Ctrl-click to copy as Markdown)"
         >
           {/* Styled by nextra via CSS class */}
         </a>
+      )}
+      {isCopied && (
+        <span className="absolute right-3 top-9 z-10 rounded bg-slate-900 px-2 py-1 text-xs text-white dark:bg-slate-700">
+          Copied Markdown link!
+        </span>
       )}
       <OriginalDetails
         key={key}


### PR DESCRIPTION
## Summary
Enhanced the Details component to support copying Markdown-formatted links to the clipboard when users modifier-click (⌘ on Mac, Ctrl elsewhere) on section permalinks.

## Key Changes
- Added clipboard copy functionality triggered by modifier-click on anchor links
- Displays a temporary "Copied Markdown link!" confirmation message that auto-dismisses after 2 seconds
- The copied text includes the section summary as a Markdown link label (e.g., `[Section Title](#url)`) for easy sharing
- Falls back to plain URL if summary text cannot be extracted
- Updated anchor title attribute to hint at the modifier-click behavior

## Implementation Details
- Used `useRef` to access the container DOM for querying the summary element
- Used `useState` to manage the copied state with automatic timeout cleanup
- Added `useEffect` hook to handle the 2-second auto-dismiss timer for the confirmation message
- Preserved default permalink behavior for regular clicks (non-modifier)
- Includes error handling with console logging if clipboard write fails

https://claude.ai/code/session_017Vt6mAhA7e4ggtWWes6fHd