### PR TITLE
fix: Deprecate `toJSONString` of custom formats (prints a deprecation warning)

### DIFF
--- a/docs/src/pages/docs/usage/plugin.mdx
+++ b/docs/src/pages/docs/usage/plugin.mdx
@@ -261,10 +261,6 @@ export default defineCodec(() => ({
 
   encode(messages, context) {
     // ...
-  },
-
-  toJSONString(content, context) {
-    // ...
   }
 }));
 ```

--- a/packages/next-intl/src/extractor/format/ExtractorCodec.tsx
+++ b/packages/next-intl/src/extractor/format/ExtractorCodec.tsx
@@ -26,18 +26,11 @@ export default interface ExtractorCodec {
   ): string;
 
   /**
-   * Turns the content of a file into a JSON string that represents extracted
-   * messages. The returned value will be passed to `JSON.parse`.
-   *
-   * @return E.g. `[{"id":"-YJVTi","message":"Hey!"}]`
-   *
-   * This is used when loading messages into your application, typically via a
-   * dynamic import (e.g. `import(`../messages/${locale}.json`)`).
-   *
-   * If your file content is JSON and should be used as-is, you can set this to
-   * an identity function.
+   * @deprecated No longer used. Catalogs are loaded into your application via
+   * `decode`, so you can remove `toJSONString` from your codec. Providing it
+   * logs a deprecation warning and has no effect.
    */
-  toJSONString(content: string, context: ExtractorCodecContext): string;
+  toJSONString?(content: string, context: ExtractorCodecContext): string;
 }
 
 export function defineCodec(factory: () => ExtractorCodec) {

--- a/packages/next-intl/src/extractor/format/codecs/JSONCodec.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/JSONCodec.tsx
@@ -28,10 +28,6 @@ export default defineCodec(() => ({
       setNestedProperty(root, message.id, message.message);
     }
     return JSON.stringify(root, null, 2) + '\n';
-  },
-
-  toJSONString(source) {
-    return source;
   }
 }));
 

--- a/packages/next-intl/src/extractor/format/codecs/POCodec.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/POCodec.tsx
@@ -1,5 +1,5 @@
 import POParser from 'po-parser';
-import {getSortedMessages, setNestedProperty} from '../../utils.js';
+import {getSortedMessages} from '../../utils.js';
 import {defineCodec} from '../ExtractorCodec.js';
 
 export default defineCodec(() => {
@@ -77,15 +77,6 @@ export default defineCodec(() => {
         },
         messages: encodedMessages
       });
-    },
-
-    toJSONString(source, context) {
-      const parsed = this.decode(source, context);
-      const messagesObject = {};
-      for (const message of parsed) {
-        setNestedProperty(messagesObject, message.id, message.message);
-      }
-      return JSON.stringify(messagesObject);
     }
   };
 });

--- a/packages/next-intl/src/extractor/format/codecs/fixtures/JSONCodecStructured.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/fixtures/JSONCodecStructured.tsx
@@ -25,15 +25,5 @@ export default defineCodec(() => ({
       };
     }
     return JSON.stringify(obj, null, 2) + '\n';
-  },
-
-  toJSONString(content) {
-    const data = JSON.parse(content);
-    const result: Record<string, string> = {};
-    for (const [id, value] of Object.entries(data)) {
-      const obj = value as StoredMessage;
-      result[id] = obj.message;
-    }
-    return JSON.stringify(result);
   }
 }));

--- a/packages/next-intl/src/extractor/format/codecs/fixtures/POCodecSourceMessageKey.tsx
+++ b/packages/next-intl/src/extractor/format/codecs/fixtures/POCodecSourceMessageKey.tsx
@@ -1,5 +1,5 @@
 import POParser from 'po-parser';
-import {getSortedMessages, setNestedProperty} from '../../../utils.js';
+import {getSortedMessages} from '../../../utils.js';
 import {defineCodec} from '../../ExtractorCodec.js';
 
 export default defineCodec(() => {
@@ -81,15 +81,6 @@ export default defineCodec(() => {
         },
         messages: encodedMessages
       });
-    },
-
-    toJSONString(source, context) {
-      const parsed = this.decode(source, context);
-      const messagesObject = {};
-      for (const message of parsed) {
-        setNestedProperty(messagesObject, message.id, message.message);
-      }
-      return JSON.stringify(messagesObject);
     }
   };
 });

--- a/packages/next-intl/src/plugin/catalog/catalogLoader.tsx
+++ b/packages/next-intl/src/plugin/catalog/catalogLoader.tsx
@@ -16,6 +16,8 @@ import type {TurbopackLoaderContext} from '../types.js';
 // create multiple loader instances so don't expect a singleton.
 let cachedCodec: ExtractorCodec | null = null;
 
+let hasWarnedAboutToJSONString = false;
+
 type CompiledMessageCacheEntry = {
   compiledMessage: unknown;
   messageValue: string;
@@ -62,24 +64,64 @@ export default function catalogLoader(
 
   getCodec(options, this.rootContext)
     .then((codec) => {
-      const locale = path.basename(this.resourcePath, extension);
-      let outputString: string;
+      warnIfToJSONStringProvided(codec);
 
+      const locale = path.basename(this.resourcePath, extension);
+      const decoded = codec.decode(source, {locale});
+
+      let messages: Record<string, unknown>;
       if (options.messages.precompile) {
-        const decoded = codec.decode(source, {locale});
         const cache = getMessageCache(this.resourcePath);
-        const precompiled = precompileMessages(decoded, cache);
-        outputString = JSON.stringify(precompiled);
+        messages = precompileMessages(decoded, cache);
       } else {
-        outputString = codec.toJSONString(source, {locale});
+        messages = buildMessages(decoded);
       }
 
       // https://v8.dev/blog/cost-of-javascript-2019#json
-      const result = `export default JSON.parse(${JSON.stringify(outputString)});`;
+      const result = `export default JSON.parse(${JSON.stringify(JSON.stringify(messages))});`;
 
       callback(null, result);
     })
     .catch(callback);
+}
+
+function warnIfToJSONStringProvided(codec: ExtractorCodec) {
+  if (hasWarnedAboutToJSONString || !codec.toJSONString) return;
+  hasWarnedAboutToJSONString = true;
+  console.warn(
+    '`toJSONString` is deprecated and no longer used—catalogs are now loaded via `decode`. Remove `toJSONString` from your codec.'
+  );
+}
+
+/**
+ * Builds a nested messages object from decoded messages, mirroring the shape
+ * produced by `precompileMessages` but keeping the raw message strings.
+ */
+function buildMessages(
+  messages: Array<ExtractorMessage>
+): Record<string, unknown> {
+  const result = Object.create(null) as Record<string, unknown>;
+  for (const message of messages) {
+    assertStringMessage(message);
+    setNestedProperty(result, message.id, message.message);
+  }
+  return result;
+}
+
+function assertStringMessage(message: ExtractorMessage) {
+  const messageValue = message.message;
+
+  if (Array.isArray(messageValue)) {
+    throw new Error(
+      `Message at \`${message.id}\` resolved to an array, but only strings are supported. See https://next-intl.dev/docs/usage/translations#arrays-of-messages`
+    );
+  }
+
+  if (typeof messageValue === 'object') {
+    throw new Error(
+      `Message at \`${message.id}\` resolved to \`${typeof messageValue}\`, but only strings are supported. Use a \`.\` to retrieve nested messages. See https://next-intl.dev/docs/usage/translations#structuring-messages`
+    );
+  }
 }
 
 /**
@@ -95,19 +137,8 @@ function precompileMessages(
 
   for (const message of messages) {
     cacheKeysToEvict.delete(message.id);
+    assertStringMessage(message);
     const messageValue = message.message;
-
-    if (Array.isArray(messageValue)) {
-      throw new Error(
-        `Message at \`${message.id}\` resolved to an array, but only strings are supported. See https://next-intl.dev/docs/usage/translations#arrays-of-messages`
-      );
-    }
-
-    if (typeof messageValue === 'object') {
-      throw new Error(
-        `Message at \`${message.id}\` resolved to \`${typeof messageValue}\`, but only strings are supported. Use a \`.\` to retrieve nested messages. See https://next-intl.dev/docs/usage/translations#structuring-messages`
-      );
-    }
 
     const cachedEntry = cache.get(message.id);
     const hasCacheMatch = cachedEntry?.messageValue === messageValue;

--- a/packages/next-intl/src/plugin/catalog/catalogLoader.tsx
+++ b/packages/next-intl/src/plugin/catalog/catalogLoader.tsx
@@ -89,7 +89,7 @@ function warnIfToJSONStringProvided(codec: ExtractorCodec) {
   if (hasWarnedAboutToJSONString || !codec.toJSONString) return;
   hasWarnedAboutToJSONString = true;
   console.warn(
-    '`toJSONString` is deprecated and no longer used—catalogs are now loaded via `decode`. Remove `toJSONString` from your codec.'
+    '`toJSONString` is deprecated and no longer used, please remove it.'
   );
 }
 

--- a/packages/next-intl/src/plugin/catalog/catalogLoader.tsx
+++ b/packages/next-intl/src/plugin/catalog/catalogLoader.tsx
@@ -89,7 +89,7 @@ function warnIfToJSONStringProvided(codec: ExtractorCodec) {
   if (hasWarnedAboutToJSONString || !codec.toJSONString) return;
   hasWarnedAboutToJSONString = true;
   console.warn(
-    '`toJSONString` is deprecated and no longer used, please remove it.'
+    '`toJSONString` is deprecated and no longer needed, please remove it.'
   );
 }
 


### PR DESCRIPTION
## Why

`toJSONString` was only ever called in one place: the `!precompile` branch of the catalog loader (`plugin/catalog/catalogLoader.tsx`). The `precompile` branch already loads catalogs through `decode`. Since `precompile` is set to become the default, `toJSONString` is redundant—`decode` carries all the information needed to load messages into the app.

## What changed

- **Loader no longer calls `toJSONString`.** Both branches now `decode` the source. The `!precompile` branch builds the nested messages object from the decoded messages (`buildMessages`), mirroring `precompileMessages` but keeping the raw strings. The string/array/object validation is shared via `assertStringMessage`. Output is identical after `JSON.parse` for the built-in JSON/PO codecs.
- **Built-in codecs drop `toJSONString`** (`JSONCodec`, `POCodec`); they're loaded via `decode` like everything else.
- **The type marks it `@deprecated` and optional** (`toJSONString?`), so existing custom codecs keep type-checking.
- **A one-time deprecation warning** fires if a resolved codec still provides `toJSONString`, pointing the author to remove it.
- **Docs and fixtures updated** to no longer reference `toJSONString` (the custom-format example in `plugin.mdx`, plus the `JSONCodecStructured` / `POCodecSourceMessageKey` test fixtures).

## Soundness note

For the built-in JSON/PO codecs this is behavior-preserving. For **custom** codecs whose old `toJSONString` produced a non-nested shape (e.g. flat dotted keys), the runtime output now matches the `precompile` path (nested via `setNestedProperty`). This unifies the two branches on the shape next-intl actually expects at runtime, and the deprecation warning prompts authors to remove the now-unused method.

## Verification

- `vitest run src/extractor` passes (53 tests), covering codec decode/encode and the structured/custom fixtures.
- ESLint + Prettier pass on all changed files.
- `tsc --noEmit` introduces no new errors in the changed files (the only remaining message is the pre-existing `icu-minify/compile` resolution quirk that requires a built `icu-minify` package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KV7kCx7pyhC2FrMw6fGzsj)_