### PR TITLE
fix: Handle ICU escape sequences around `<` consistently in dev and production

### DIFF
--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -4,7 +4,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-client)",
     path: 'dist/esm/production/index.react-client.js',
-    limit: '11.7 KB'
+    limit: '11.72 KB'
   },
   {
     name: "import {NextIntlClientProvider} from 'next-intl' (react-client)",
@@ -15,7 +15,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl' (react-server)",
     path: 'dist/esm/production/index.react-server.js',
-    limit: '12.7 KB'
+    limit: '12.72 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-client)",
@@ -37,7 +37,7 @@ const config: SizeLimitConfig = [
   {
     name: "import * from 'next-intl/server' (react-server)",
     path: 'dist/esm/production/server.react-server.js',
-    limit: '11.98 KB'
+    limit: '12 KB'
   },
   {
     name: "import * from 'next-intl/middleware'",

--- a/packages/use-intl/src/core/createTranslator.test.tsx
+++ b/packages/use-intl/src/core/createTranslator.test.tsx
@@ -429,6 +429,31 @@ describe('type safety', () => {
       };
     });
 
+    it('strips ICU escape quotes from `<` in production builds', () => {
+      // `getPlainMessage`'s production fast-path skips ICU compilation when
+      // no values are passed and the message contains no `'{`/`'}`. But ICU
+      // also uses single quotes to escape `<` (so a literal `<locale>` can be
+      // written as `'<locale>'`). The fast-path was returning the candidate
+      // verbatim and leaking the escape quotes into the output.
+      vi.stubEnv('NODE_ENV', 'production');
+      try {
+        const t = translateMessage("styleguide.'<locale>'.md");
+        expect(t('msg')).toBe('styleguide.<locale>.md');
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('strips ICU escape quotes from `{` in production builds', () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      try {
+        const t = translateMessage("'{not a placeholder}'");
+        expect(t('msg')).toBe('{not a placeholder}');
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
     it('validates simple rich text', () => {
       const t = translateMessage(
         'Please refer to <guidelines>the guidelines</guidelines>.'

--- a/packages/use-intl/src/core/createTranslator.test.tsx
+++ b/packages/use-intl/src/core/createTranslator.test.tsx
@@ -444,16 +444,6 @@ describe('type safety', () => {
       }
     });
 
-    it('strips ICU escape quotes from `{` in production builds', () => {
-      vi.stubEnv('NODE_ENV', 'production');
-      try {
-        const t = translateMessage("'{not a placeholder}'");
-        expect(t('msg')).toBe('{not a placeholder}');
-      } finally {
-        vi.unstubAllEnvs();
-      }
-    });
-
     it('validates simple rich text', () => {
       const t = translateMessage(
         'Please refer to <guidelines>the guidelines</guidelines>.'

--- a/packages/use-intl/src/core/format-message/compile-format.tsx
+++ b/packages/use-intl/src/core/format-message/compile-format.tsx
@@ -38,8 +38,11 @@ function getPlainMessage(
   return (
     // 1. Values are provided
     values ||
-      // 2. There are escaped braces (e.g. "'{name'}")
-      /'[{}]/.test(candidate) ||
+      // 2. There are ICU escape sequences. A single quote followed by
+      //    `{`, `}`, `<`, `#`, `|`, or another `'` starts an escape that
+      //    `intl-messageformat` strips at format time — skipping compilation
+      //    would leak the escape characters into the output.
+      /'[{}<#|']/.test(candidate) ||
       // 3. There are missing arguments or tags (dev-only error handling)
       (process.env.NODE_ENV !== 'production' && /<|{/.test(candidate))
       ? undefined // Compile

--- a/packages/use-intl/src/core/format-message/compile-format.tsx
+++ b/packages/use-intl/src/core/format-message/compile-format.tsx
@@ -38,10 +38,7 @@ function getPlainMessage(
   return (
     // 1. Values are provided
     values ||
-      // 2. There are ICU escape sequences. A single quote followed by
-      //    `{`, `}`, `<`, `#`, `|`, or another `'` starts an escape that
-      //    `intl-messageformat` strips at format time — skipping compilation
-      //    would leak the escape characters into the output.
+      // 2. There are ICU escape sequences (e.g. "'{name'}")
       /'[{}<#|']/.test(candidate) ||
       // 3. There are missing arguments or tags (dev-only error handling)
       (process.env.NODE_ENV !== 'production' && /<|{/.test(candidate))


### PR DESCRIPTION
## Bug

A message that uses ICU's single-quote escape to render a literal `<` (e.g. `styleguide.'<locale>'.md`, meant to render as `styleguide.<locale>.md`) renders correctly in development but leaks the escape quotes in production:

| Build | Input | Output |
| --- | --- | --- |
| dev | `styleguide.'<locale>'.md` | `styleguide.<locale>.md` |
| prod | `styleguide.'<locale>'.md` | `styleguide.'<locale>'.md` |

Same input, different output — only the dev/prod gate decides whether ICU compilation runs at all.

## Root cause

`getPlainMessage` in `packages/use-intl/src/core/format-message/compile-format.tsx`:

```ts
return (
  values ||
    /'[{}]/.test(candidate) ||
    (process.env.NODE_ENV !== 'production' && /<|{/.test(candidate))
    ? undefined  // Compile
    : candidate  // Don't compile
);
```

The third arm (`/<|{/`) is documented as "dev-only error handling" — but it doubles as a hidden correctness guard. In dev it catches messages containing `<`, which forces ICU compilation, which then strips the escape quotes around `<locale>`. In production the third arm is gone, so a message with no `'{`/`'}` is returned verbatim — escape quotes and all.

The second arm only checks `'{` / `'}`. It should also catch ICU's other escape forms, including `'<` (literal `<`), `'#` (literal `#` inside plural/select), `'|` (literal `|` inside select), and `''` (literal `'`).

## Fix

Broaden the unconditional check #2 to detect every ICU escape opener that `intl-messageformat` strips at format time:

```diff
-      // 2. There are escaped braces (e.g. "'{name'}")
-      /'[{}]/.test(candidate) ||
+      // 2. There are ICU escape sequences. A single quote followed by
+      //    `{`, `}`, `<`, `#`, `|`, or another `'` starts an escape that
+      //    `intl-messageformat` strips at format time — skipping compilation
+      //    would leak the escape characters into the output.
+      /'[{}<#|']/.test(candidate) ||
```

The dev-only third arm stays as-is — it still serves its original purpose of reporting missing arguments/tags.

## Repro

Direct call against the published dev vs prod builds of `use-intl/format-message`:

```js
import devFormat from 'use-intl/dist/esm/development/format-message/index.js';
import prodFormat from 'use-intl/dist/esm/production/format-message/index.js';

const baseOpts = {
  locale: 'en',
  cache: { message: new Map(), dateTime: new Map(), number: new Map(),
           pluralRules: new Map(), list: new Map(), relativeTime: new Map(),
           displayNames: new Map() },
  formatters: {}, globalFormats: undefined, formats: undefined, timeZone: 'UTC'
};

devFormat('key',  "styleguide.'<locale>'.md", undefined, baseOpts);
// → "styleguide.<locale>.md"
prodFormat('key', "styleguide.'<locale>'.md", undefined, baseOpts);
// → "styleguide.'<locale>'.md"   ← bug
```

After the fix both return `"styleguide.<locale>.md"`.

## Test plan

- [x] `pnpm --filter use-intl test` — the new test cases fail without the fix and pass with it.
- [x] Existing tests still pass (330 passed).
- [ ] Manual prod build of an app that contains a message like `styleguide.'<locale>'.md` renders it without the escape quotes.

## Originally surfaced by

A Next.js docs page in a downstream app, where a heading bound to `t("styleguide.'<locale>'.md")` rendered correctly on localhost but as `styleguide.'<locale>'.md` on the production build. The downstream fix was to enable `precompile: true` (which routes through `format-only.js` and bypasses this branch entirely); this PR fixes the runtime path so the workaround isn't needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QffRTXjwbFxM6HDUHAw7g3)_