### PR TITLE
fix: Correctly format plural/select branches that are only `#` or empty

### DIFF
--- a/packages/icu-minify/src/format.tsx
+++ b/packages/icu-minify/src/format.tsx
@@ -234,7 +234,8 @@ function formatSelect<RichTextElement>(
   const value = String(getValue(values, name));
   const branch: CompiledNode | undefined = options[value] ?? options.other;
 
-  if (process.env.NODE_ENV !== 'production' && !branch) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (process.env.NODE_ENV !== 'production' && branch === undefined) {
     throw new Error(
       `No matching branch for select "${name}" with value "${value}"`
     );
@@ -274,7 +275,8 @@ function formatPlural<RichTextElement>(
     .select(value);
   const branch: CompiledNode | undefined = options[category] ?? options.other;
 
-  if (process.env.NODE_ENV !== 'production' && !branch) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (process.env.NODE_ENV !== 'production' && branch === undefined) {
     throw new Error(
       `No matching branch for plural "${name}" with category "${category}"`
     );

--- a/packages/icu-minify/test/roundtrip.test.ts
+++ b/packages/icu-minify/test/roundtrip.test.ts
@@ -619,6 +619,13 @@ describe('select', () => {
     ).toMatchInlineSnapshot(`"Dear Alex Smith"`);
   });
 
+  it('formats an empty branch', () => {
+    const compiled = compile('Hi{gender, select, female {, madam} other {}}');
+    expect(
+      formatMessage(compiled, 'en', {gender: 'unknown'})
+    ).toMatchInlineSnapshot(`"Hi"`);
+  });
+
   it('throws for a select without other', () => {
     expect(() => compile('{gender, select, female {She} male {He}}')).toThrow(
       'MISSING_OTHER_CLAUSE'
@@ -790,6 +797,23 @@ describe('cardinal plural (plural)', () => {
     );
     expect(formatMessage(compiled, 'pl', {n: 22})).toMatchInlineSnapshot(
       `"22 pliki"`
+    );
+  });
+
+  it('formats a branch that only contains the pound sign', () => {
+    const compiled = compile('{count, plural, one {one} other {#}}');
+    expect(formatMessage(compiled, 'en', {count: 5})).toMatchInlineSnapshot(
+      `"5"`
+    );
+  });
+
+  it('formats an empty branch', () => {
+    const compiled = compile('item{count, plural, one {} other {s}}');
+    expect(formatMessage(compiled, 'en', {count: 1})).toMatchInlineSnapshot(
+      `"item"`
+    );
+    expect(formatMessage(compiled, 'en', {count: 2})).toMatchInlineSnapshot(
+      `"items"`
     );
   });
 


### PR DESCRIPTION
### Bug

In `icu-minify/format`, a `plural` or `select` branch that compiles to a falsy value is wrongly rejected as a missing branch and throws in development:

- A branch that is only `#` compiles to `0` (`TYPE_POUND`), e.g. `{count, plural, one {one} other {#}}`.
- An empty branch `{}` compiles to `""`, e.g. `item{count, plural, one {} other {s}}`.

Both are valid ICU branches, but the guard uses `!branch`, which is truthy for `0` and `""`:

```
No matching branch for plural "count" with category "other"
```

The `?? options.other` selection is correct (nullish coalescing preserves `0`/`""`); only the subsequent dev guard misfires. In production the guard is skipped, so this is a development-only crash on valid messages, surfacing as a formatting error and message fallback.

### Fix

Check `branch === undefined` instead of `!branch`, so genuinely missing branches still throw while valid falsy branches format correctly. Same change in `formatSelect` and `formatPlural`.

### Tests

Adds regression tests for a bare-`#` branch and empty branches in both `plural` and `select`. They throw on `main` and pass with the fix.
