### PR TITLE
fix: Resolve precompile format-only alias when config is bundled (e.g. `bun --bun next dev`)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           node-version: 22.x
           cache: 'pnpm'
+      # Used by the `e2e-bun-precompile-app` regression test (see its `test.mjs`)
+      - uses: oven-sh/setup-bun@v2
       - run: pnpm install
 
       # Next.js caching

--- a/e2e/bun-precompile-app/.gitignore
+++ b/e2e/bun-precompile-app/.gitignore
@@ -1,0 +1,3 @@
+/.next/
+/node_modules
+next-env.d.ts

--- a/e2e/bun-precompile-app/.gitignore
+++ b/e2e/bun-precompile-app/.gitignore
@@ -1,3 +1,5 @@
-/.next/
-/node_modules
+node_modules/
+.next/
+playwright-report/
+test-results/
 next-env.d.ts

--- a/e2e/bun-precompile-app/messages/en.json
+++ b/e2e/bun-precompile-app/messages/en.json
@@ -1,1 +1,1 @@
-{"Hello": "Hello world!"}
+{"Hello": "Hello {name}!"}

--- a/e2e/bun-precompile-app/messages/en.json
+++ b/e2e/bun-precompile-app/messages/en.json
@@ -1,0 +1,1 @@
+{"Hello": "Hello world!"}

--- a/e2e/bun-precompile-app/next.config.ts
+++ b/e2e/bun-precompile-app/next.config.ts
@@ -1,0 +1,9 @@
+import {NextConfig} from 'next';
+// Note: `next-intl/plugin` is used indirectly through a workspace package
+// (`e2e-bun-precompile-config`), mirroring a common monorepo setup. See
+// `test.mjs` for the regression this reproduces.
+import {withI18n} from 'e2e-bun-precompile-config/plugin';
+
+const config: NextConfig = {};
+
+export default withI18n(config);

--- a/e2e/bun-precompile-app/package.json
+++ b/e2e/bun-precompile-app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "e2e-bun-precompile-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev",
+    "start": "next start",
+    "test": "node ./test.mjs"
+  },
+  "dependencies": {
+    "e2e-bun-precompile-config": "workspace:*",
+    "next": "^16.0.10",
+    "next-intl": "workspace:*",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.3",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.5.3"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/e2e/bun-precompile-app/package.json
+++ b/e2e/bun-precompile-app/package.json
@@ -16,8 +16,11 @@
     "react-dom": "^19.2.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.51.1",
+    "@types/node": "^20.14.5",
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
+    "e2e-utils": "workspace:*",
     "typescript": "^5.5.3"
   },
   "engines": {

--- a/e2e/bun-precompile-app/playwright.config.ts
+++ b/e2e/bun-precompile-app/playwright.config.ts
@@ -1,0 +1,23 @@
+import {defineConfig, devices} from '@playwright/test';
+import {reserveSharedPlaywrightDevPort} from 'e2e-utils/playwright-dev-port';
+
+const port = await reserveSharedPlaywrightDevPort(
+  'PW_E2E_BUN_PRECOMPILE_DEV_PORT'
+);
+
+export default defineConfig({
+  workers: 1,
+  fullyParallel: false,
+  testDir: './tests',
+  timeout: 120_000,
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL: `http://localhost:${port}`
+  },
+  webServer: {
+    // `--bun` runs Next.js on Bun's runtime instead of Node.js
+    command: `PORT=${port} bun --bun run dev`,
+    port,
+    reuseExistingServer: !process.env.CI
+  }
+});

--- a/e2e/bun-precompile-app/src/app/layout.tsx
+++ b/e2e/bun-precompile-app/src/app/layout.tsx
@@ -1,0 +1,14 @@
+import {NextIntlClientProvider} from 'next-intl';
+import {getLocale} from 'next-intl/server';
+
+export default async function RootLayout({children}: LayoutProps<'/'>) {
+  const locale = await getLocale();
+
+  return (
+    <html lang={locale}>
+      <body>
+        <NextIntlClientProvider>{children}</NextIntlClientProvider>
+      </body>
+    </html>
+  );
+}

--- a/e2e/bun-precompile-app/src/app/page.tsx
+++ b/e2e/bun-precompile-app/src/app/page.tsx
@@ -2,5 +2,5 @@ import {useTranslations} from 'next-intl';
 
 export default function Page() {
   const t = useTranslations();
-  return <h1>{t('Hello')}</h1>;
+  return <h1>{t('Hello', {name: 'Jane'})}</h1>;
 }

--- a/e2e/bun-precompile-app/src/app/page.tsx
+++ b/e2e/bun-precompile-app/src/app/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function Page() {
+  const t = useTranslations();
+  return <h1>{t('Hello')}</h1>;
+}

--- a/e2e/bun-precompile-app/src/i18n/request.ts
+++ b/e2e/bun-precompile-app/src/i18n/request.ts
@@ -1,0 +1,9 @@
+import {getRequestConfig} from 'next-intl/server';
+
+export default getRequestConfig(async () => {
+  const locale = 'en';
+  const messages = (await import(`../../messages/${locale}.json`))
+    .default as Record<string, unknown>;
+
+  return {locale, messages};
+});

--- a/e2e/bun-precompile-app/test.mjs
+++ b/e2e/bun-precompile-app/test.mjs
@@ -1,0 +1,64 @@
+// Regression test for https://github.com/amannn/next-intl/discussions/2209
+//
+// When `experimental.messages.precompile` is enabled and `next-intl/plugin` is
+// used through a workspace wrapper package (see `next.config.ts`), running
+// `bun --bun next …` previously failed to load `next.config` with:
+//
+//   Cannot find module 'use-intl/format-message/format-only' from ''
+//
+// The plugin resolves the `format-only` build via `require.resolve`
+// (`createRequire(import.meta.url)`). When Next bundles the config before
+// evaluating it, `import.meta.url` is unavailable, so the resolution base is
+// empty and `require.resolve` throws. The fix falls back to the bare specifier
+// in that case.
+//
+// This test asserts that `next.config` *loads* under `bun --bun` (i.e. the
+// plugin no longer throws while resolving `format-only`). It deliberately does
+// not require the full build to finish: under `bun --bun`, Turbopack spawns a
+// Node subprocess for message-catalog loaders that rejects the inherited
+// `--bun`/`--smol` `NODE_OPTIONS`, which is unrelated to this regression.
+
+import {spawnSync} from 'node:child_process';
+import {createRequire} from 'node:module';
+
+const require = createRequire(import.meta.url);
+const REPORTED_ERROR =
+  "Cannot find module 'use-intl/format-message/format-only'";
+const CONFIG_LOAD_ERROR = 'Failed to load next.config';
+
+// The bug only reproduces on Bun's runtime (`--bun`), so skip when Bun is
+// unavailable (e.g. a plain Node environment) rather than failing.
+if (spawnSync('bun', ['--version'], {encoding: 'utf8'}).status !== 0) {
+  console.log('Skipping: `bun` is not available in this environment.');
+  process.exit(0);
+}
+
+const nextBin = require.resolve('next/dist/bin/next');
+
+console.log('Running `bun --bun next build` …\n');
+const result = spawnSync('bun', ['--bun', nextBin, 'build'], {
+  encoding: 'utf8',
+  stdio: 'pipe',
+  timeout: 300_000
+});
+
+if (result.error) {
+  console.error(`\n❌ Failed to run \`bun --bun next build\`: ${result.error}`);
+  process.exit(1);
+}
+
+const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+
+if (output.includes(REPORTED_ERROR) || output.includes(CONFIG_LOAD_ERROR)) {
+  process.stdout.write(output);
+  console.error(
+    `\n❌ Regression: \`next.config\` failed to load under \`bun --bun\`.`
+  );
+  process.exit(1);
+}
+
+// Note: the full build may not finish here — under `bun --bun`, Turbopack
+// spawns a Node subprocess for message-catalog loaders that rejects the
+// inherited `--bun` `NODE_OPTIONS`. That is unrelated to this regression, so
+// the surrounding output is only surfaced above when the config fails to load.
+console.log('✅ `next.config` loaded successfully under `bun --bun`.');

--- a/e2e/bun-precompile-app/test.mjs
+++ b/e2e/bun-precompile-app/test.mjs
@@ -1,64 +1,17 @@
-// Regression test for https://github.com/amannn/next-intl/discussions/2209
-//
-// When `experimental.messages.precompile` is enabled and `next-intl/plugin` is
-// used through a workspace wrapper package (see `next.config.ts`), running
-// `bun --bun next …` previously failed to load `next.config` with:
-//
-//   Cannot find module 'use-intl/format-message/format-only' from ''
-//
-// The plugin resolves the `format-only` build via `require.resolve`
-// (`createRequire(import.meta.url)`). When Next bundles the config before
-// evaluating it, `import.meta.url` is unavailable, so the resolution base is
-// empty and `require.resolve` throws. The fix falls back to the bare specifier
-// in that case.
-//
-// This test asserts that `next.config` *loads* under `bun --bun` (i.e. the
-// plugin no longer throws while resolving `format-only`). It deliberately does
-// not require the full build to finish: under `bun --bun`, Turbopack spawns a
-// Node subprocess for message-catalog loaders that rejects the inherited
-// `--bun`/`--smol` `NODE_OPTIONS`, which is unrelated to this regression.
+// Runs the Playwright tests for this app, with the dev server running on
+// Bun's runtime (see `playwright.config.ts`). The regression this app guards
+// against only occurs with `bun --bun` (see `tests/main.spec.ts`), so skip
+// when Bun is unavailable (e.g. a plain Node.js environment) rather than
+// failing.
 
 import {spawnSync} from 'node:child_process';
-import {createRequire} from 'node:module';
 
-const require = createRequire(import.meta.url);
-const REPORTED_ERROR =
-  "Cannot find module 'use-intl/format-message/format-only'";
-const CONFIG_LOAD_ERROR = 'Failed to load next.config';
-
-// The bug only reproduces on Bun's runtime (`--bun`), so skip when Bun is
-// unavailable (e.g. a plain Node environment) rather than failing.
 if (spawnSync('bun', ['--version'], {encoding: 'utf8'}).status !== 0) {
   console.log('Skipping: `bun` is not available in this environment.');
   process.exit(0);
 }
 
-const nextBin = require.resolve('next/dist/bin/next');
-
-console.log('Running `bun --bun next build` …\n');
-const result = spawnSync('bun', ['--bun', nextBin, 'build'], {
-  encoding: 'utf8',
-  stdio: 'pipe',
-  timeout: 300_000
+const result = spawnSync('pnpm', ['exec', 'playwright', 'test'], {
+  stdio: 'inherit'
 });
-
-if (result.error) {
-  console.error(`\n❌ Failed to run \`bun --bun next build\`: ${result.error}`);
-  process.exit(1);
-}
-
-const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
-
-if (output.includes(REPORTED_ERROR) || output.includes(CONFIG_LOAD_ERROR)) {
-  process.stdout.write(output);
-  console.error(
-    `\n❌ Regression: \`next.config\` failed to load under \`bun --bun\`.`
-  );
-  process.exit(1);
-}
-
-// Note: the full build may not finish here — under `bun --bun`, Turbopack
-// spawns a Node subprocess for message-catalog loaders that rejects the
-// inherited `--bun` `NODE_OPTIONS`. That is unrelated to this regression, so
-// the surrounding output is only surfaced above when the config fails to load.
-console.log('✅ `next.config` loaded successfully under `bun --bun`.');
+process.exit(result.status ?? 1);

--- a/e2e/bun-precompile-app/tests/main.spec.ts
+++ b/e2e/bun-precompile-app/tests/main.spec.ts
@@ -1,0 +1,24 @@
+import {expect, test as it} from '@playwright/test';
+
+// Regression test for https://github.com/amannn/next-intl/discussions/2209#discussioncomment-17687273
+//
+// When `experimental.messages.precompile` is enabled and `next-intl/plugin` is
+// used through a workspace wrapper package (see `next.config.ts`), running
+// `bun --bun next dev` previously failed to load `next.config` with:
+//
+//   Cannot find module 'use-intl/format-message/format-only'
+//
+// The plugin resolves the `format-only` build via `require.resolve`
+// (`createRequire(import.meta.url)`). When Next.js bundles the config before
+// evaluating it, `import.meta.url` is unavailable, so the resolution base is
+// empty and `require.resolve` throws.
+//
+// The dev server for this test runs on Bun (see `playwright.config.ts`).
+// Asserting the formatted output also ensures that the
+// `use-intl/format-message` alias is actually applied — if it isn't,
+// precompiled messages fail to format.
+
+it('formats a precompiled message', async ({page}) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', {name: 'Hello Jane!'})).toBeVisible();
+});

--- a/e2e/bun-precompile-app/tsconfig.json
+++ b/e2e/bun-precompile-app/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "strict": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{"name": "next"}],
+    "paths": {"@/*": ["./src/*"]},
+    "strictNullChecks": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/e2e/bun-precompile-config/package.json
+++ b/e2e/bun-precompile-config/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "e2e-bun-precompile-config",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./plugin": "./plugin.js"
+  },
+  "peerDependencies": {
+    "next": "^16.0.0",
+    "next-intl": "workspace:*"
+  }
+}

--- a/e2e/bun-precompile-config/plugin.js
+++ b/e2e/bun-precompile-config/plugin.js
@@ -1,0 +1,20 @@
+import createNextIntlPlugin from 'next-intl/plugin';
+
+// A shared wrapper around `next-intl/plugin`, as commonly used in monorepos to
+// centralize i18n config. Importing `next-intl/plugin` through a workspace
+// package like this causes the bundler to inline `next-intl` into the bundled
+// `next.config`, which is what surfaces the module resolution issue that this
+// setup reproduces (see the app's `next.config.ts`).
+export function withI18n(nextConfig) {
+  const withNextIntl = createNextIntlPlugin({
+    experimental: {
+      messages: {
+        path: './messages',
+        format: 'json',
+        // Precompilation is what triggers the `use-intl/format-message` alias
+        precompile: true
+      }
+    }
+  });
+  return withNextIntl(nextConfig);
+}

--- a/packages/next-intl/src/plugin/getNextConfig.tsx
+++ b/packages/next-intl/src/plugin/getNextConfig.tsx
@@ -33,6 +33,24 @@ function normalizeTurbopackAliasPath(pathname: string) {
   return pathname.replace(/\\/g, '/');
 }
 
+const FORMAT_ONLY_SPECIFIER = 'use-intl/format-message/format-only';
+
+function resolveFormatOnlyModule() {
+  try {
+    return require.resolve(FORMAT_ONLY_SPECIFIER);
+  } catch {
+    // `require.resolve` relies on `import.meta.url` (via `createRequire`), which
+    // can be unavailable when `next.config` is bundled before being evaluated
+    // (e.g. when running `bun --bun next dev`, especially in a monorepo where
+    // the plugin is invoked through a wrapper package). In that case the
+    // resolution base is empty and `require.resolve` throws. We then fall back
+    // to the bare specifier, which the app's bundler can resolve from its own
+    // context.
+    // https://github.com/amannn/next-intl/discussions/2209#discussioncomment-17687273
+    return undefined;
+  }
+}
+
 function resolveI18nPath(providedPath?: string, cwd?: string) {
   function resolvePath(pathname: string) {
     const parts = [];
@@ -170,22 +188,25 @@ export default function getNextConfig(
 
     // Add alias for precompiled message formatting
     if (pluginConfig.experimental?.messages?.precompile) {
-      // Workaround for https://github.com/vercel/next.js/issues/88540
-      let formatOnlyPath = path.relative(
-        process.cwd(),
-        require.resolve('use-intl/format-message/format-only')
-      );
+      const formatOnlyModule = resolveFormatOnlyModule();
 
-      // Turbopack seems to require this, otherwise `use-intl/format-message` is
-      // still bundled (despite the code correctly calling into `format-only`).
-      // Note that in this monorepo this is not necessary, because we'll end
-      // up with a path like `../…` — but for actual consumers this is required.
-      if (!formatOnlyPath.startsWith('.')) {
-        formatOnlyPath = `./${formatOnlyPath}`;
+      if (formatOnlyModule) {
+        // Workaround for https://github.com/vercel/next.js/issues/88540
+        let formatOnlyPath = path.relative(process.cwd(), formatOnlyModule);
+
+        // Turbopack seems to require this, otherwise `use-intl/format-message` is
+        // still bundled (despite the code correctly calling into `format-only`).
+        // Note that in this monorepo this is not necessary, because we'll end
+        // up with a path like `../…` — but for actual consumers this is required.
+        if (!formatOnlyPath.startsWith('.')) {
+          formatOnlyPath = `./${formatOnlyPath}`;
+        }
+
+        resolveAlias['use-intl/format-message'] =
+          normalizeTurbopackAliasPath(formatOnlyPath);
+      } else {
+        resolveAlias['use-intl/format-message'] = FORMAT_ONLY_SPECIFIER;
       }
-
-      resolveAlias['use-intl/format-message'] =
-        normalizeTurbopackAliasPath(formatOnlyPath);
     }
 
     // Add loaders
@@ -275,10 +296,12 @@ export default function getNextConfig(
       if (pluginConfig.experimental?.messages?.precompile) {
         // Use require.resolve to get the actual file path, since
         // bundlers don't properly resolve package subpath exports
-        // when used as alias targets
+        // when used as alias targets. When resolution fails (e.g. the config
+        // was bundled and `import.meta.url` is unavailable), we fall back to
+        // the bare specifier, which the bundler can resolve from its context.
         (config.resolve.alias as Record<string, string>)[
           'use-intl/format-message'
-        ] = require.resolve('use-intl/format-message/format-only');
+        ] = resolveFormatOnlyModule() ?? FORMAT_ONLY_SPECIFIER;
       }
 
       // Add loader for extractor

--- a/packages/next-intl/src/plugin/getNextConfig.tsx
+++ b/packages/next-intl/src/plugin/getNextConfig.tsx
@@ -17,7 +17,6 @@ import {hasStableTurboConfig, isNextJs16OrHigher} from './nextFlags.js';
 import type {PluginConfig} from './types.js';
 import {throwError} from './utils.js';
 
-const require = createRequire(import.meta.url);
 function withExtensions(localPath: string) {
   return [
     `${localPath}.ts`,
@@ -33,22 +32,51 @@ function normalizeTurbopackAliasPath(pathname: string) {
   return pathname.replace(/\\/g, '/');
 }
 
-const FORMAT_ONLY_SPECIFIER = 'use-intl/format-message/format-only';
-
+/**
+ * Returns the absolute path of the `format-only` build, since bundlers don't
+ * properly resolve package subpath exports when used as alias targets
+ * (see https://github.com/vercel/next.js/issues/88540).
+ *
+ * When running `bun --bun next dev` while the plugin is invoked through a
+ * wrapper package (e.g. in a monorepo), `next.config` is bundled before being
+ * evaluated. In that environment, `require.resolve` has no valid resolution
+ * base and throws — even when `createRequire` receives an explicit path. In
+ * that case we recover via Bun's native resolver, either from the app
+ * directory or via `next-intl` (in case a strict `node_modules` layout is
+ * used, e.g. with pnpm or Bun's isolated linker).
+ * https://github.com/amannn/next-intl/discussions/2209#discussioncomment-17687273
+ */
 function resolveFormatOnlyModule() {
+  const specifier = 'use-intl/format-message/format-only';
+
   try {
-    return require.resolve(FORMAT_ONLY_SPECIFIER);
+    return createRequire(import.meta.url).resolve(specifier);
   } catch {
-    // `require.resolve` relies on `import.meta.url` (via `createRequire`), which
-    // can be unavailable when `next.config` is bundled before being evaluated
-    // (e.g. when running `bun --bun next dev`, especially in a monorepo where
-    // the plugin is invoked through a wrapper package). In that case the
-    // resolution base is empty and `require.resolve` throws. We then fall back
-    // to the bare specifier, which the app's bundler can resolve from its own
-    // context.
-    // https://github.com/amannn/next-intl/discussions/2209#discussioncomment-17687273
-    return undefined;
+    // Continue below
   }
+
+  const bun = (
+    globalThis as {
+      Bun?: {resolveSync(id: string, parent: string): string};
+    }
+  ).Bun;
+  if (bun) {
+    const parents = [
+      () => process.cwd(),
+      () => path.dirname(bun.resolveSync('next-intl/plugin', process.cwd()))
+    ];
+    for (const getParent of parents) {
+      try {
+        return bun.resolveSync(specifier, getParent());
+      } catch {
+        // Try the next parent
+      }
+    }
+  }
+
+  // As a last resort, let the app's bundler resolve the
+  // bare specifier from its own context
+  return specifier;
 }
 
 function resolveI18nPath(providedPath?: string, cwd?: string) {
@@ -188,11 +216,10 @@ export default function getNextConfig(
 
     // Add alias for precompiled message formatting
     if (pluginConfig.experimental?.messages?.precompile) {
-      const formatOnlyModule = resolveFormatOnlyModule();
+      let formatOnlyPath = resolveFormatOnlyModule();
 
-      if (formatOnlyModule) {
-        // Workaround for https://github.com/vercel/next.js/issues/88540
-        let formatOnlyPath = path.relative(process.cwd(), formatOnlyModule);
+      if (path.isAbsolute(formatOnlyPath)) {
+        formatOnlyPath = path.relative(process.cwd(), formatOnlyPath);
 
         // Turbopack seems to require this, otherwise `use-intl/format-message` is
         // still bundled (despite the code correctly calling into `format-only`).
@@ -202,11 +229,10 @@ export default function getNextConfig(
           formatOnlyPath = `./${formatOnlyPath}`;
         }
 
-        resolveAlias['use-intl/format-message'] =
-          normalizeTurbopackAliasPath(formatOnlyPath);
-      } else {
-        resolveAlias['use-intl/format-message'] = FORMAT_ONLY_SPECIFIER;
+        formatOnlyPath = normalizeTurbopackAliasPath(formatOnlyPath);
       }
+
+      resolveAlias['use-intl/format-message'] = formatOnlyPath;
     }
 
     // Add loaders
@@ -294,14 +320,9 @@ export default function getNextConfig(
 
       // Add alias for precompiled message formatting
       if (pluginConfig.experimental?.messages?.precompile) {
-        // Use require.resolve to get the actual file path, since
-        // bundlers don't properly resolve package subpath exports
-        // when used as alias targets. When resolution fails (e.g. the config
-        // was bundled and `import.meta.url` is unavailable), we fall back to
-        // the bare specifier, which the bundler can resolve from its context.
         (config.resolve.alias as Record<string, string>)[
           'use-intl/format-message'
-        ] = resolveFormatOnlyModule() ?? FORMAT_ONLY_SPECIFIER;
+        ] = resolveFormatOnlyModule();
       }
 
       // Add loader for extractor

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,43 @@ importers:
         specifier: ^6.0.0
         version: 6.0.2
 
+  e2e/bun-precompile-app:
+    dependencies:
+      e2e-bun-precompile-config:
+        specifier: workspace:*
+        version: link:../bun-precompile-config
+      next:
+        specifier: ^16.0.10
+        version: 16.2.2(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next-intl:
+        specifier: workspace:*
+        version: link:../../packages/next-intl
+      react:
+        specifier: ^19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.3
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.5.3
+        version: 5.9.3
+
+  e2e/bun-precompile-config:
+    dependencies:
+      next:
+        specifier: ^16.0.0
+        version: 16.2.2(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next-intl:
+        specifier: workspace:*
+        version: link:../../packages/next-intl
+
   e2e/extracted-json:
     dependencies:
       e2e-utils:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,12 +132,21 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.51.1
+        version: 1.57.0
+      '@types/node':
+        specifier: ^20.14.5
+        version: 20.19.29
       '@types/react':
         specifier: ^19.2.3
         version: 19.2.14
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      e2e-utils:
+        specifier: workspace:*
+        version: link:../utils
       typescript:
         specifier: ^5.5.3
         version: 5.9.3


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by https://github.com/vercel/next.js/issues/88540.** Once Turbopack supports package subpath exports as alias targets, the plugin can simply alias to the bare specifier `use-intl/format-message/format-only` and this entire class of problems disappears. Until then, affected users should apply the workaround below.

## Problem

Reported in [#2209](https://github.com/amannn/next-intl/discussions/2209#discussioncomment-17687273).

With `experimental.messages.precompile` enabled, running `bun --bun next dev` in a monorepo where `next-intl/plugin` is invoked through a shared wrapper package fails to start the dev server:

```
⨯ Failed to load next.config.ts
error: Cannot find module 'use-intl/format-message/format-only' from ''
```

## Why this problem exists

1. **The plugin must resolve a file path at config time.** With `precompile` enabled, messages are compiled to ASTs at build time, so the runtime should only ship the lightweight `format-only` formatter. The plugin achieves this by aliasing `use-intl/format-message` to the `format-only` build. Since Turbopack doesn't apply bare package subpaths as alias targets (vercel/next.js#88540), the alias target must be a **file path** — hence the plugin calls `require.resolve('use-intl/format-message/format-only')`, anchored to its own location via `createRequire(import.meta.url)`.

2. **A wrapper package causes the plugin to be inlined into the compiled config.** Next.js compiles `next.config.ts` before evaluating it. Packages in `node_modules` remain external, but **workspace packages are inlined** — and a wrapper around `next-intl/plugin` transitively pulls the plugin code into the compiled config. Inlined code loses its file identity: `import.meta.url` becomes `''`. This is why the issue only occurs with a wrapper package, and not when importing `next-intl/plugin` directly (a direct import stays external and keeps a valid `import.meta.url`).

## Why this only applies to Bun

Node.js evaluates the compiled config in a context where module resolution still works — `createRequire(import.meta.url).resolve(…)` returns the correct path (verified).

Under `bun --bun`, the compiled config is evaluated in a context where `createRequire` **ignores its filename argument entirely**: resolution runs `from ''` even when `createRequire` receives a valid absolute path, and even when the real built-in is obtained via `process.getBuiltinModule('module')` to rule out bundler shims (verified). This looks like a Bun bug in the module-evaluation context that Next.js uses for the compiled config — no resolution base that the plugin passes is honored. Only Bun's proprietary `Bun.resolveSync(id, parent)` API respects a parent in that context.

## Workaround for affected users

Import `next-intl/plugin` **directly** in each app's `next.config.ts` and share plain config options through your monorepo package instead of wrapping the plugin call:

```ts
// next.config.ts (in each app)
import createNextIntlPlugin from 'next-intl/plugin';
import i18nConfig from '@repo/i18n/config';

const withNextIntl = createNextIntlPlugin(i18nConfig);

export default withNextIntl({
  // …
});
```

```ts
// @repo/i18n — export plain options instead of wrapping the plugin
export default {
  experimental: {
    messages: {
      // …
      precompile: true
    }
  }
};
```

Verified working with `bun --bun next dev` (no library change required): the direct import keeps `next-intl` external during config compilation, so resolution behaves exactly like in a single-package setup. Alternatively, running `next dev` on Node.js (i.e. `bun next dev` without `--bun`) avoids the issue entirely — Bun remains the package manager, and Node.js is the officially supported runtime for Next.js.

## What this PR contains

- A fallback in the plugin that recovers resolution via `Bun.resolveSync` (from the app directory, or via `next-intl` for strict `node_modules` layouts) when `require.resolve` has no valid base, with the bare specifier as a last resort. Only the failure path is affected; behavior is unchanged whenever `import.meta.url` is available.
- An e2e reproduction (`e2e/bun-precompile-app` + `e2e/bun-precompile-config`) mirroring the reporter's setup, with a Playwright test that runs `next dev` on Bun and asserts the formatted output of a `Hello {name}` message — guarding both config loading and that the alias is actually applied (without it, precompiled messages fail to format at runtime).

Verified in all three states: unfixed plugin → dev server fails with the reported error; config-load-only fix (bare-specifier alias) → message fails to format; full fix → `Hello Jane!` renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMJB2oaFtqYr5zSqrcN5nx