### PR TITLE
ci: Add manual recovery workflow for partial npm publishes

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -1,0 +1,50 @@
+# Manual recovery for a release whose npm publish failed partway through.
+#
+# The automatic `release` workflow bumps versions, commits, tags and creates the
+# GitHub release, and only THEN publishes each package to npm. If npm fails mid-
+# publish (e.g. a transient `504 Gateway Timeout`), some packages are live at the
+# new version while others are left behind — but the version bump and tag are
+# already pushed.
+#
+# Do NOT re-run the failed `release` job in that case: it would run
+# `lerna publish` again and bump a brand-new version. Instead, run this workflow.
+# It runs `lerna publish from-package`, which publishes only the packages whose
+# current version is missing from the npm registry and skips the ones already
+# there. It never bumps versions or creates tags.
+#
+# How to use:
+#   Actions → "release (manual recovery)" → Run workflow, and set `ref` to the
+#   release tag that failed to fully publish (e.g. `v4.13.4`). Checking out the
+#   tag ensures the packages are at the exact versions that were tagged.
+
+name: release (manual recovery)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Release tag/commit to publish from (e.g. v4.13.4)'
+        required: true
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'pnpm'
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm@latest # Trusted publishers
+      - run: pnpm install
+      - run: pnpm exec lerna publish from-package --yes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No NODE_AUTH_TOKEN since we use Trusted Publishers


### PR DESCRIPTION
## Why

When the automatic `release` workflow fails **after** versioning/tagging but **during** the npm publish (e.g. a transient `504 Gateway Timeout` from the registry), some packages end up published at the new version while others are left behind — but the version bump and tag are already pushed. This just happened in [run 30009041125](https://github.com/amannn/next-intl/actions/runs/30009041125/job/89212136114) for `v4.13.4`, where only `next-intl-swc-plugin-extractor` published and `icu-minify`, `use-intl`, `next-intl` were left at 4.13.3.

Re-running the failed `release` job isn't safe there — it runs `lerna publish` again and bumps a brand-new version.

## What

Adds a manually-dispatched `release (manual recovery)` workflow that runs `lerna publish from-package`. This publishes only the packages whose current version is missing from the npm registry and skips the ones already there — it never bumps versions or creates tags. It reuses the same Trusted Publishers (OIDC) setup as the main release workflow, so recovered packages still get provenance.

### How to use

Actions → **release (manual recovery)** → Run workflow, set `ref` to the release tag that failed to fully publish (e.g. `v4.13.4`).

A comment at the top of the workflow file documents when and how to use it.