### PR TITLE
ci: Rename root `publish` script to `release`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
       # Automatic release: bump versions, tag and publish on a fix/feat commit.
-      - run: pnpm run publish
+      - run: pnpm run release
         if: "${{github.event_name == 'push' && (startsWith(github.event.head_commit.message, 'fix: ') || startsWith(github.event.head_commit.message, 'feat: ') || startsWith(github.event.head_commit.message, 'feat!: '))}}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "scripts": {
-    "publish": "lerna publish",
+    "release": "lerna publish",
     "build-packages": "turbo run build --filter './packages/**' --filter '!./packages/swc-plugin-extractor'"
   },
   "devDependencies": {


### PR DESCRIPTION
## Why

Follow-up to #2364. The manual recovery run for `v4.13.4` published all packages successfully but the job still exited non-zero ([run](https://github.com/amannn/next-intl/actions/runs/30011790506/job/89221487080)):

```
lerna-lite ERR! ENOGIT Detached git HEAD, please checkout a branch to choose versions.
  pkgid: 'root@'   script: 'lerna publish'
```

`publish` is a reserved **npm lifecycle event name**. During `lerna publish from-package`, npm fired the root package's `publish` script as a lifecycle hook, which recursively ran `lerna publish` — and that failed with `ENOGIT` because the recovery run checks out a tag (detached HEAD). It fires *after* all real publishes complete, so it's a spurious red X, but it's confusing.

## What

Rename the root script `publish` → `release`, and update `release.yml` to call `pnpm run release`. No lifecycle event is named `release`, so the recursive invocation no longer happens and recovery runs exit cleanly. The automatic push-triggered release is unaffected (it just invokes the renamed script).