### PR TITLE
docs: Add Studio link to footer

### DIFF
--- a/docs/src/components/Footer.tsx
+++ b/docs/src/components/Footer.tsx
@@ -19,6 +19,8 @@ export default function Footer() {
           <FooterSeparator />
           <FooterLink href="https://learn.next-intl.dev">Learn</FooterLink>
           <FooterSeparator />
+          <FooterLink href="https://studio.eloqnt.dev">Studio</FooterLink>
+          <FooterSeparator />
           <FooterLink href="/examples">Examples</FooterLink>
           <FooterSeparator />
           <FooterLink href="/blog">Blog</FooterLink>


### PR DESCRIPTION
Adds a `Studio` link to the docs footer so it mirrors the main navigation.

The main nav (`docs/src/pages/_meta.tsx`) lists Docs → Learn → Studio → Examples → Blog, but the footer was missing Studio. It's now placed between `Learn` and `Examples` to match that order, pointing at the same `https://studio.eloqnt.dev` URL (consistent with how the external `Learn` link is rendered in the footer).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nj2iioh4bs2tV8gpxsTMBY)_