### PR TITLE
docs: Hide precompilation blog post from sidebar navigation

### DIFF
--- a/docs/src/pages/blog/_meta.tsx
+++ b/docs/src/pages/blog/_meta.tsx
@@ -6,6 +6,10 @@ export default {
     title: 'Using next/root-params in Next.js 16.3',
     display: 'hidden'
   },
+  precompilation: {
+    title: 'Ahead-of-time compilation for next-intl',
+    display: 'hidden'
+  },
   'use-extracted': {
     title: 'useExtracted: The Tailwind of i18n?',
     display: 'hidden'


### PR DESCRIPTION
The "Ahead-of-time compilation for next-intl" post (`blog/precompilation.mdx`) was missing from `docs/src/pages/blog/_meta.tsx`. Without an entry, Nextra auto-generates a visible sidebar item for the page, so the article showed up under "Blog" in the (mobile) navigation.

All other blog posts are listed in `_meta.tsx` with `display: 'hidden'` so that only "Overview" appears. This adds the missing entry in the same form, placed in the existing reverse-chronological order (after `nextjs-root-params`, Aug 2026 → Jan 2026).

Note: the docs workspace dependencies aren't installed in this environment, so Prettier/ESLint couldn't be run against the repo config. The added block matches the surrounding formatting exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ndr4U6Tgkt38x3jTBsXgg1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ndr4U6Tgkt38x3jTBsXgg1)_