### PR TITLE
docs: Mention planned Route Handler and Server Action support for root params

### DIFF
--- a/docs/src/pages/blog/nextjs-root-params.mdx
+++ b/docs/src/pages/blog/nextjs-root-params.mdx
@@ -186,7 +186,7 @@ That's it—with a single change to `i18n/request.ts` you can start using `next/
 
 ---
 
-**One caveat though**: `next/root-params` currently doesn't work in Route Handlers or Server Actions.
+**One caveat though**: `next/root-params` currently doesn't work in Route Handlers or Server Actions. Next.js [plans to add support](https://nextjs.org/blog/next-16-3#root-params) for these in a future release.
 
 You can work around that though by passing an explicit `locale` param at call sites, e.g. via [`bind`](https://nextjs.org/docs/app/guides/forms#passing-additional-arguments):
 
@@ -291,7 +291,7 @@ export async function generateMetadata(
 
 The cases where you still require a locale override are:
 
-1. When you're using functions from `next-intl` in **Route Handlers** or **Server Actions** (these are not supported by `next/root-params`)
+1. When you're using functions from `next-intl` in **Route Handlers** or **Server Actions**, which `next/root-params` doesn't support yet
 2. If your UI renders messages from **multiple locales** in parallel (uncommon)
 
 ### Static rendering


### PR DESCRIPTION
The `next/root-params` blog post stated that Route Handlers and Server Actions aren't supported, without mentioning that support is planned. The [Next.js 16.3 blog post](https://nextjs.org/blog/next-16-3#root-params) says:

> They're currently supported in Server Components, and we're planning on adding support for route handlers and Server Actions in a future release.

Changes:

1. The caveat section now adds a short hint linking to the Next.js announcement: "Next.js plans to add support for these in a future release."
2. The locale override list item was rephrased from "(these are not supported by `next/root-params`)" to ", which `next/root-params` doesn't support yet".

Both paragraphs were checked in a browser at 1280/1440/1536/1920px viewport widths to make sure neither ends in a word orphan on the desktop layout (last lines have 4–13 words).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6G5qDf5LGch6tGwtyoRBK)_