### PR TITLE
test: Add e2e app for domain-based routing

### DIFF
--- a/e2e/domains/.gitignore
+++ b/e2e/domains/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+playwright-report/
+test-results/

--- a/e2e/domains/.prettierignore
+++ b/e2e/domains/.prettierignore
@@ -1,0 +1,3 @@
+.next
+test-results
+next-env.d.ts

--- a/e2e/domains/eslint.config.mjs
+++ b/e2e/domains/eslint.config.mjs
@@ -1,0 +1,5 @@
+import {defineConfig} from 'eslint/config';
+import nextVitals from 'eslint-config-next/core-web-vitals';
+import nextTs from 'eslint-config-next/typescript';
+
+export default defineConfig([...nextVitals, ...nextTs]);

--- a/e2e/domains/next-env.d.ts
+++ b/e2e/domains/next-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/e2e/domains/next.config.ts
+++ b/e2e/domains/next.config.ts
@@ -1,0 +1,7 @@
+import {NextConfig} from 'next';
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin();
+
+const config: NextConfig = {};
+export default withNextIntl(config);

--- a/e2e/domains/package.json
+++ b/e2e/domains/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "e2e-domains",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "lint": "eslint src tests && prettier . --check",
+    "build": "next build",
+    "start": "next start",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "next": "^16.3.0",
+    "next-intl": "workspace:*",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.51.1",
+    "@types/react": "^19.2.3",
+    "@types/react-dom": "^19.2.3",
+    "e2e-utils": "workspace:*",
+    "eslint": "^9.38.0",
+    "eslint-config-next": "^16.3.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.5.3"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "bracketSpacing": false,
+    "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/e2e/domains/playwright.config.ts
+++ b/e2e/domains/playwright.config.ts
@@ -1,0 +1,17 @@
+import {defineConfig} from '@playwright/test';
+import {reserveSharedPlaywrightDevPort} from 'e2e-utils/playwright-dev-port';
+
+const port = await reserveSharedPlaywrightDevPort('PW_E2E_DOMAINS_PORT');
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 120_000,
+  use: {
+    baseURL: `http://127.0.0.1:${port}`
+  },
+  webServer: {
+    command: `PORT=${port} pnpm start`,
+    port,
+    reuseExistingServer: !process.env.CI
+  }
+});

--- a/e2e/domains/src/app/[locale]/contact/page.tsx
+++ b/e2e/domains/src/app/[locale]/contact/page.tsx
@@ -1,0 +1,12 @@
+export default async function ContactPage({
+  params
+}: PageProps<'/[locale]/contact'>) {
+  const {locale} = await params;
+
+  return (
+    <main>
+      <p data-testid="locale">{locale}</p>
+      <p data-testid="page">contact</p>
+    </main>
+  );
+}

--- a/e2e/domains/src/app/[locale]/layout.tsx
+++ b/e2e/domains/src/app/[locale]/layout.tsx
@@ -1,0 +1,19 @@
+import {hasLocale} from 'next-intl';
+import {notFound} from 'next/navigation';
+import {routing} from '@/i18n/routing';
+
+export default async function LocaleLayout({
+  children,
+  params
+}: LayoutProps<'/[locale]'>) {
+  const {locale} = await params;
+  if (!hasLocale(routing.locales, locale)) {
+    notFound();
+  }
+
+  return (
+    <html lang={locale}>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/e2e/domains/src/app/[locale]/page.tsx
+++ b/e2e/domains/src/app/[locale]/page.tsx
@@ -1,0 +1,10 @@
+export default async function IndexPage({params}: PageProps<'/[locale]'>) {
+  const {locale} = await params;
+
+  return (
+    <main>
+      <p data-testid="locale">{locale}</p>
+      <p data-testid="page">index</p>
+    </main>
+  );
+}

--- a/e2e/domains/src/i18n/request.ts
+++ b/e2e/domains/src/i18n/request.ts
@@ -1,0 +1,12 @@
+import {hasLocale} from 'next-intl';
+import {getRequestConfig} from 'next-intl/server';
+import {routing} from './routing';
+
+export default getRequestConfig(async ({requestLocale}) => {
+  const requested = await requestLocale;
+  const locale = hasLocale(routing.locales, requested)
+    ? requested
+    : routing.defaultLocale;
+
+  return {locale, messages: {}};
+});

--- a/e2e/domains/src/i18n/routing.ts
+++ b/e2e/domains/src/i18n/routing.ts
@@ -1,0 +1,23 @@
+import {defineRouting} from 'next-intl/routing';
+
+// Reproduction for https://github.com/amannn/next-intl/issues/2369
+//
+// Note that the domains are declared without a port, since the tests address
+// the server via `127.0.0.1` and set the `host` header explicitly. This is
+// what next-intl matches against and avoids the need for `/etc/hosts` entries.
+export const EU_DOMAIN = 'example-eu.localhost';
+export const DE_DOMAIN = 'example-de.localhost';
+
+export const routing = defineRouting({
+  locales: ['en', 'nl', 'de'],
+  defaultLocale: 'en',
+
+  // `nl` is served at a sub-path, `en` and `de` are the roots of their
+  // respective domains and are therefore omitted from `prefixes`
+  localePrefix: {mode: 'as-needed', prefixes: {nl: '/nl'}},
+
+  domains: [
+    {domain: EU_DOMAIN, defaultLocale: 'en', locales: ['en', 'nl']},
+    {domain: DE_DOMAIN, defaultLocale: 'de', locales: ['de']}
+  ]
+});

--- a/e2e/domains/src/proxy.ts
+++ b/e2e/domains/src/proxy.ts
@@ -1,0 +1,8 @@
+import createMiddleware from 'next-intl/middleware';
+import {routing} from './i18n/routing';
+
+export default createMiddleware(routing);
+
+export const config = {
+  matcher: '/((?!_next|.*\\..*).*)'
+};

--- a/e2e/domains/tests/http.ts
+++ b/e2e/domains/tests/http.ts
@@ -1,0 +1,105 @@
+import http from 'node:http';
+
+/**
+ * Domain-based routing is resolved from the `x-forwarded-host` header (with a
+ * fallback to `host`). Requests are therefore sent to the local server while
+ * the domain is announced via forwarding headers—just like a reverse proxy in
+ * front of the app would do. This avoids the need for `/etc/hosts` entries as
+ * well as for domains that are aware of the port of the local server.
+ */
+function fetchWithForwardedHost(
+  port: number,
+  forwardedHost: string,
+  path: string
+): Promise<{status: number; location?: string; body: string}> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path,
+        method: 'GET',
+        headers: {
+          'x-forwarded-host': forwardedHost,
+          'x-forwarded-proto': 'http',
+          // Avoids that the port of the local server ends up in redirects
+          'x-forwarded-port': '80'
+        }
+      },
+      (response) => {
+        let body = '';
+        response.setEncoding('utf-8');
+        response.on('data', (chunk) => (body += chunk));
+        response.on('end', () =>
+          resolve({
+            status: response.statusCode!,
+            location: response.headers.location,
+            body
+          })
+        );
+      }
+    );
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+export type Hop = {
+  /** The requested URL. */
+  url: string;
+  status: number;
+  /** The value of the `location` header, if the response is a redirect. */
+  location?: string;
+};
+
+export type Result = {
+  /** All requests that were necessary, incl. the final one. */
+  hops: Array<Hop>;
+  /** The URL that was resolved after following all redirects. */
+  url: string;
+  status: number;
+  body: string;
+};
+
+export async function follow(
+  port: number,
+  startUrl: string,
+  maxHops = 10
+): Promise<Result> {
+  const hops: Array<Hop> = [];
+  let url = new URL(startUrl);
+
+  for (let i = 0; i < maxHops; i++) {
+    const response = await fetchWithForwardedHost(
+      port,
+      url.host,
+      url.pathname + url.search
+    );
+    hops.push({
+      url: url.toString(),
+      status: response.status,
+      location: response.location
+    });
+
+    if (response.location) {
+      url = new URL(response.location, url);
+    } else {
+      return {
+        hops,
+        url: url.toString(),
+        status: response.status,
+        body: response.body
+      };
+    }
+  }
+
+  throw new Error(`Too many redirects:\n${JSON.stringify(hops, null, 2)}`);
+}
+
+export function getPort() {
+  const port = Number(process.env.PW_E2E_DOMAINS_PORT);
+  if (!Number.isInteger(port)) {
+    throw new Error('Missing PW_E2E_DOMAINS_PORT');
+  }
+  return port;
+}

--- a/e2e/domains/tests/main.spec.ts
+++ b/e2e/domains/tests/main.spec.ts
@@ -1,0 +1,116 @@
+import {expect, test as it} from '@playwright/test';
+import {DE_DOMAIN, EU_DOMAIN} from '../src/i18n/routing';
+import {type Result, follow, getPort} from './http';
+
+const port = getPort();
+
+function get(url: string): Promise<Result> {
+  return follow(port, url);
+}
+
+it('serves the default locale of a domain unprefixed', async () => {
+  const result = await get(`http://${DE_DOMAIN}/`);
+  expect(result.hops).toEqual([
+    {url: `http://${DE_DOMAIN}/`, status: 200, location: undefined}
+  ]);
+  expect(result.body).toContain('>de<');
+});
+
+it('serves a secondary locale of a domain with a prefix', async () => {
+  const result = await get(`http://${EU_DOMAIN}/nl`);
+  expect(result.hops).toEqual([
+    {url: `http://${EU_DOMAIN}/nl`, status: 200, location: undefined}
+  ]);
+  expect(result.body).toContain('>nl<');
+});
+
+it('redirects a locale that is served on another domain to that domain', async () => {
+  const result = await get(`http://${EU_DOMAIN}/de`);
+
+  // The final destination is correct: `de` is the `defaultLocale` of
+  // `DE_DOMAIN` and is served unprefixed there (`as-needed`).
+  expect(result.url).toBe(`http://${DE_DOMAIN}/`);
+  expect(result.status).toBe(200);
+  expect(result.body).toContain('>de<');
+
+  // … however, this currently takes two redirects instead of one. The
+  // cross-domain redirect carries over the `/de` prefix from the source
+  // domain, and only the subsequent request on the target domain removes it
+  // again. Note that the intermediate URL does not respond with a 404, as
+  // reported in https://github.com/amannn/next-intl/issues/2369.
+  expect(result.hops).toEqual([
+    {
+      url: `http://${EU_DOMAIN}/de`,
+      status: 307,
+      location: `http://${DE_DOMAIN}/de`
+    },
+    {
+      url: `http://${DE_DOMAIN}/de`,
+      status: 307,
+      location: `http://${DE_DOMAIN}/`
+    },
+    {url: `http://${DE_DOMAIN}/`, status: 200, location: undefined}
+  ]);
+});
+
+it('takes the same extra redirect in the opposite direction', async () => {
+  // The extra redirect is not specific to `prefixes`, it applies to every
+  // cross-domain redirect where the target locale is the `defaultLocale` of
+  // the target domain while `as-needed` is used.
+  const result = await get(`http://${DE_DOMAIN}/en`);
+
+  expect(result.url).toBe(`http://${EU_DOMAIN}/`);
+  expect(result.status).toBe(200);
+  expect(result.body).toContain('>en<');
+
+  expect(result.hops).toEqual([
+    {
+      url: `http://${DE_DOMAIN}/en`,
+      status: 307,
+      location: `http://${EU_DOMAIN}/en`
+    },
+    {
+      url: `http://${EU_DOMAIN}/en`,
+      status: 307,
+      location: `http://${EU_DOMAIN}/`
+    },
+    {url: `http://${EU_DOMAIN}/`, status: 200, location: undefined}
+  ]);
+});
+
+it('redirects a nested pathname of a locale that is served on another domain', async () => {
+  const result = await get(`http://${EU_DOMAIN}/de/contact`);
+
+  expect(result.url).toBe(`http://${DE_DOMAIN}/contact`);
+  expect(result.status).toBe(200);
+  expect(result.body).toContain('>contact<');
+
+  // Same as above: an extra redirect, but no 404
+  expect(result.hops).toEqual([
+    {
+      url: `http://${EU_DOMAIN}/de/contact`,
+      status: 307,
+      location: `http://${DE_DOMAIN}/de/contact`
+    },
+    {
+      url: `http://${DE_DOMAIN}/de/contact`,
+      status: 307,
+      location: `http://${DE_DOMAIN}/contact`
+    },
+    {url: `http://${DE_DOMAIN}/contact`, status: 200, location: undefined}
+  ]);
+});
+
+it('redirects to an unprefixed pathname on the same domain in a single hop', async () => {
+  // For comparison: when the target domain is the current domain, the
+  // prefix is removed right away (`redirect()` normalizes in this case).
+  const result = await get(`http://${DE_DOMAIN}/de/contact`);
+  expect(result.hops).toEqual([
+    {
+      url: `http://${DE_DOMAIN}/de/contact`,
+      status: 307,
+      location: `http://${DE_DOMAIN}/contact`
+    },
+    {url: `http://${DE_DOMAIN}/contact`, status: 200, location: undefined}
+  ]);
+});

--- a/e2e/domains/tsconfig.json
+++ b/e2e/domains/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "strict": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{"name": "next"}],
+    "paths": {"@/*": ["./src/*"]},
+    "strictNullChecks": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,46 @@ importers:
         specifier: ^6.0.0
         version: 6.0.2
 
+  e2e/domains:
+    dependencies:
+      next:
+        specifier: ^16.3.0
+        version: 16.3.0(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@25.0.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next-intl:
+        specifier: workspace:*
+        version: link:../../packages/next-intl
+      react:
+        specifier: ^19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.51.1
+        version: 1.57.0
+      '@types/react':
+        specifier: ^19.2.3
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      e2e-utils:
+        specifier: workspace:*
+        version: link:../utils
+      eslint:
+        specifier: ^9.38.0
+        version: 9.39.2(jiti@2.6.1)
+      eslint-config-next:
+        specifier: ^16.3.0
+        version: 16.3.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.8.0
+      typescript:
+        specifier: ^5.5.3
+        version: 5.9.3
+
   e2e/extracted-json:
     dependencies:
       e2e-utils:


### PR DESCRIPTION
Closes #2369

Adds `e2e/domains`, an e2e app that reproduces the scenario from #2369 (`domains` + `localePrefix: {mode: 'as-needed', prefixes: {nl: '/nl'}}`) and follows the **full redirect chain**, recording every hop.

## TL;DR

The reported 404 does not happen. The final destination is correct — but it takes **two redirects instead of one**.

```
GET http://example-eu.localhost/de
  → 307 http://example-de.localhost/de     ← the URL reported as 404ing
  → 307 http://example-de.localhost/
  → 200 (renders `de`)
```

The intermediate URL is handled by the middleware on the target domain, which strips the prefix (`middleware.tsx:283-291`: `pathnameMatch.exact && hasMatchedDefaultLocale && isUnprefixedRouting` → redirect unprefixed). Same for nested paths: `/de/contact` → `example-de.localhost/de/contact` → `example-de.localhost/contact` → 200.

The issue only shows `curl -sI … | grep -i '^location'`, which doesn't follow redirects — the 404 looks like an inference from the Location header rather than an observation.

## It's not about `prefixes`

The issue frames this as a consequence of `en`/`de` being omitted from `prefixes` (and `''` being falsy in `getLocalePrefix`). That framing doesn't hold: the extra redirect happens for **every** cross-domain redirect where the target locale is the target domain's `defaultLocale` under `as-needed`. The opposite direction shows it with a plain default locale and no custom `prefixes` involved:

```
GET http://example-de.localhost/en
  → 307 http://example-eu.localhost/en
  → 307 http://example-eu.localhost/
  → 200 (renders `en`)
```

That's covered by a dedicated test. Since a domain locale switcher built with `Link`/`getPathname` produces same-domain hrefs like `/de`, this two-hop chain is the normal path for switching to a domain's default locale, not an edge case.

## What's actually correct today

- Final destination and status code: correct in every case tested.
- `Link` alternate links: correct — `<http://example-de.localhost/>; rel="alternate"; hreflang="de"`, i.e. they already point at the unprefixed URL and never at the redirecting `/de`.
- Same-domain redirects normalize in a single hop (also covered by a test), because `redirect()` runs its normalization when no `redirectDomain` is passed.

## The underlying asymmetry

The analysis in the issue is accurate as far as the code goes. `redirect()` gates its `defaultLocale === locale && mode === 'as-needed'` normalization behind `!redirectDomain`, and the cross-domain call site always passes `pathDomain?.domain` — so the normalization never runs for the cross-domain case. Since `pathDomain` is already resolved at the call site, passing the config object instead of the domain string would make both paths share it:

```diff
-function redirect(url: string, redirectDomain?: string) {
+function redirect(url: string, targetDomain?: DomainConfig<AppLocales>) {
   …
-  if (domainsConfig.length > 0 && !redirectDomain && domain) {
-    const bestMatchingDomain = getBestMatchingDomain(domain, locale, domainsConfig);
+  let redirectDomain: string | undefined;
+  if (domainsConfig.length > 0 && domain) {
+    const bestMatchingDomain =
+      targetDomain ?? getBestMatchingDomain(domain, locale, domainsConfig);
```

## Fix / no fix

Arguments for fixing:

- Saves a round trip on what is the common path for a locale switcher across domains.
- Redirect chains are worth avoiding for crawlers, even if each hop is a clean 307.
- The normalization already exists and reads as if it were meant to apply here; the gate makes it dead code for the cross-domain path.

Arguments against:

- Nothing is broken — no 404, correct final URL, correct alternate links. This is an optimization, not a bug fix.
- It touches cross-domain redirects for all `domains` setups, incl. domain-level `localePrefix` overrides and localized `pathnames`, so it needs a fair amount of test coverage relative to the payoff.

Deliberately not implemented here so the call stays open. If it should be fixed, the tests in this PR are written to make the change visible: the hop-by-hop assertions would need to be updated to a single redirect, while the final-destination assertions stay as they are.

## Notes on the setup

Domains are announced via `x-forwarded-host` (which `getHost` prefers over `host`), so the tests run against the local server without `/etc/hosts` entries and without pinning a port into the routing config. `x-forwarded-port: 80` keeps the local server's port out of the redirect URLs. The tests use plain `node:http` rather than a browser, since the assertions are about redirect chains and headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E81ZiM8S1KNn8A2Qy4pKEv


---
_Generated by [Claude Code](https://claude.ai/code/session_01E81ZiM8S1KNn8A2Qy4pKEv)_