### PR TITLE
fix: Deprecate `requestLocale` param of `getRequestConfig`

### DIFF
--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -37,9 +37,9 @@ Since this function is executed during the Server Components render pass, you ca
 <Details id="server-request-locale">
 <summary>What is the `requestLocale` parameter?</summary>
 
-Before Next.js introduced `next/root-params`, the `requestLocale` parameter was used to read the `[locale]` segment from the middleware, optionally allowing to override it from [`setRequestLocale`](/docs/routing/setup#with-setrequestlocale-legacy).
+Before Next.js introduced [`next/root-params`](/blog/nextjs-root-params), the `requestLocale` parameter was used to read the `[locale]` segment from the middleware, optionally allowing to override it from [`setRequestLocale`](/docs/routing/setup#with-setrequestlocale-legacy).
 
-This parameter is deprecated—please migrate to [`next/root-params`](/blog/nextjs-root-params).
+This is considered legacy and is no longer recommended.
 
 If you're still using `setRequestLocale`, the parameter typically corresponds to the `[locale]` segment that was matched by the middleware.
 

--- a/docs/src/pages/docs/usage/configuration.mdx
+++ b/docs/src/pages/docs/usage/configuration.mdx
@@ -39,7 +39,7 @@ Since this function is executed during the Server Components render pass, you ca
 
 Before Next.js introduced `next/root-params`, the `requestLocale` parameter was used to read the `[locale]` segment from the middleware, optionally allowing to override it from [`setRequestLocale`](/docs/routing/setup#with-setrequestlocale-legacy).
 
-This is considered legacy and is no longer recommended.
+This parameter is deprecated—please migrate to [`next/root-params`](/blog/nextjs-root-params).
 
 If you're still using `setRequestLocale`, the parameter typically corresponds to the `[locale]` segment that was matched by the middleware.
 

--- a/packages/next-intl/src/server/react-server/getRequestConfig.tsx
+++ b/packages/next-intl/src/server/react-server/getRequestConfig.tsx
@@ -28,6 +28,7 @@ export type GetRequestConfigParams = {
    *    catch-all for unknown routes (e.g. `/unknown.txt`), invalid values should
    *    be replaced with a valid locale.
    *
+   * @deprecated Please migrate to [`next/root-params`](https://next-intl.dev/blog/nextjs-root-params).
    * @see https://next-intl.dev/docs/usage/configuration#i18n-request
    */
   requestLocale: Promise<string | undefined>;


### PR DESCRIPTION
Marks the `requestLocale` parameter of `getRequestConfig` as `@deprecated`, matching the deprecation of `setRequestLocale` from #1632.

Previously, the two were out of sync: `setRequestLocale` carried a `@deprecated` tag pointing at `next/root-params`, and the docs already described `requestLocale` as legacy, but the type itself gave no signal.

**Changes:**

- `packages/next-intl/src/server/react-server/getRequestConfig.tsx`: add a `@deprecated` tag to `GetRequestConfigParams.requestLocale`, using the same migration pointer as `setRequestLocale` (`next/root-params`). The existing description is left in place for users who haven't migrated yet.
- `docs/src/pages/docs/usage/configuration.mdx`: the "What is the `requestLocale` parameter?" section said "considered legacy and no longer recommended" — now says deprecated, with a link to the `next/root-params` blog post.

No behavioral change; `requestLocale` keeps working as before. It remains functional for setups that can't use `next/root-params` yet (Next.js < 16.3, or Route Handlers / Server Actions).

**Verification:** `pnpm lint:source` and `pnpm test run` pass in `packages/next-intl` (896 tests). Confirmed the tag survives into the emitted `dist/types/server/react-server/getRequestConfig.d.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpYCVUyatSmgPqFm4V7NeA)_