### PR TITLE
feat: Split extracted catalogs by namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Features
+
+* Split extracted catalogs by namespace (`extract.split: 'namespace'`)
+
 ## 4.13.6 (2026-08-10)
 
 ### Bug Fixes

--- a/docs/src/pages/docs/usage/extraction.mdx
+++ b/docs/src/pages/docs/usage/extraction.mdx
@@ -189,7 +189,7 @@ If you want to use an explicit ID instead of the auto-generated one, you can opt
 
 This can be useful when you have a label that is used in multiple places, but should have different translations in other languages. This is an escape hatch that should rarely be necessary.
 
-### Namespaces
+### Namespaces [#namespaces]
 
 If you want to organize your messages under a specific namespace, you can pass it to `useExtracted`:
 
@@ -221,6 +221,37 @@ Namespaces are useful in situations like:
 2. **Splitting:** If you want to pass only certain messages to the client side, this can help to group them accordingly (e.g. `<NextIntlClientProvider messages={messages.client}>`).
 
 It's a good idea to not overuse namespaces, as they can make moving messages between components more difficult if this involves refactoring the namespace.
+
+#### Split catalogs by namespace [#split-catalogs]
+
+By default, all namespaces are written to a single catalog per locale (e.g. `messages/en.po`). For large apps you can opt into one file per namespace with [`extract.split`](/docs/usage/plugin#extract-split):
+
+```tsx
+extract: {
+  split: 'namespace'
+},
+```
+
+This uses the first segment of each message id as the directory name:
+
+```
+messages/
+  en.po              // Unnamespaced messages
+  de.po
+  design-system/en.po
+  design-system/de.po
+```
+
+The files still contain full message ids (`msgctxt "design-system"` in `.po`, or a nested `"design-system"` object in JSON). Load and merge them in `getRequestConfig`:
+
+```tsx
+const messages = {
+  ...(await import(`../../messages/${locale}.po`)).default,
+  ...(await import(`../../messages/design-system/${locale}.po`)).default
+};
+```
+
+Shallow merging is enough because each file owns a distinct top-level key. After you enable `split`, the next extraction rewrites an existing monolith: namespaced entries move into `{namespace}/{locale}` files and translations are preserved.
 
 ### `await getExtracted()` [#get-extracted]
 

--- a/docs/src/pages/docs/usage/plugin.mdx
+++ b/docs/src/pages/docs/usage/plugin.mdx
@@ -117,6 +117,20 @@ It's only required to configure this property when [`messages.path`](#messages-p
 
 See also: [Monorepos and external packages](/docs/usage/extraction#monorepos-external-packages).
 
+#### `extract.split` [#extract-split]
+
+When using [`useExtracted`](/docs/usage/extraction), you can write namespaced messages to separate catalog files:
+
+```tsx
+extract: {
+  split: 'namespace'
+},
+```
+
+With this setting, `useExtracted('ui')` writes to `messages/ui/en.po` (or `.json`) instead of a single `messages/en.po`. Messages without a namespace stay in the root `{locale}` file.
+
+See [namespaces](/docs/usage/extraction#namespaces) for the on-disk layout and how to load the files at runtime.
+
 ### `messages` [#messages]
 
 This defines where messages for locales are stored and how they're loaded.

--- a/e2e/extracted-po-split/.gitignore
+++ b/e2e/extracted-po-split/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+playwright-report/
+test-results/

--- a/e2e/extracted-po-split/.prettierignore
+++ b/e2e/extracted-po-split/.prettierignore
@@ -1,0 +1,3 @@
+.next
+test-results
+next-env.d.ts

--- a/e2e/extracted-po-split/eslint.config.mjs
+++ b/e2e/extracted-po-split/eslint.config.mjs
@@ -1,0 +1,20 @@
+import {defineConfig} from 'eslint/config';
+import nextVitals from 'eslint-config-next/core-web-vitals';
+import nextTs from 'eslint-config-next/typescript';
+
+export default defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  {
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          varsIgnorePattern: '^_'
+        }
+      ]
+    }
+  }
+]);

--- a/e2e/extracted-po-split/messages/en.po
+++ b/e2e/extracted-po-split/messages/en.po
@@ -1,0 +1,11 @@
+msgid ""
+msgstr ""
+"Language: en\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: next-intl\n"
+"X-Crowdin-SourceKey: msgstr\n"
+
+#: src/app/page.tsx
+msgid "NhX4DJ"
+msgstr "Hello"

--- a/e2e/extracted-po-split/messages/ui/en.po
+++ b/e2e/extracted-po-split/messages/ui/en.po
@@ -1,0 +1,12 @@
+msgid ""
+msgstr ""
+"Language: en\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: next-intl\n"
+"X-Crowdin-SourceKey: msgstr\n"
+
+#: src/components/Greeting.tsx
+msgctxt "ui"
+msgid "-YJVTi"
+msgstr "Hey!"

--- a/e2e/extracted-po-split/next-env.d.ts
+++ b/e2e/extracted-po-split/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/e2e/extracted-po-split/next.config.ts
+++ b/e2e/extracted-po-split/next.config.ts
@@ -1,0 +1,20 @@
+import {NextConfig} from 'next';
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin({
+  experimental: {
+    extract: {
+      split: 'namespace'
+    },
+    srcPath: './src',
+    messages: {
+      path: './messages',
+      format: 'po',
+      locales: 'infer',
+      sourceLocale: 'en'
+    }
+  }
+});
+
+const config: NextConfig = {};
+export default withNextIntl(config);

--- a/e2e/extracted-po-split/package.json
+++ b/e2e/extracted-po-split/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "e2e-extracted-po-split",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "lint": "eslint src tests && prettier . --check",
+    "build": "next build",
+    "start": "next start",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "e2e-utils": "workspace:*",
+    "next": "^16.3.0",
+    "next-intl": "workspace:*",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
+    "use-intl": "workspace:*"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.1.0",
+    "@playwright/test": "^1.51.1",
+    "@types/react": "^19.2.3",
+    "@types/react-dom": "^19.2.3",
+    "eslint": "^9.38.0",
+    "eslint-config-next": "^16.3.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.5.3"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "bracketSpacing": false,
+    "trailingComma": "none"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/e2e/extracted-po-split/playwright.config.ts
+++ b/e2e/extracted-po-split/playwright.config.ts
@@ -1,0 +1,22 @@
+import {defineConfig, devices} from '@playwright/test';
+import {reserveSharedPlaywrightDevPort} from 'e2e-utils/playwright-dev-port';
+
+const port = await reserveSharedPlaywrightDevPort(
+  'PW_E2E_EXTRACTED_PO_SPLIT_DEV_PORT'
+);
+
+export default defineConfig({
+  workers: 1,
+  fullyParallel: false,
+  testDir: './tests',
+  timeout: 120_000,
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL: `http://localhost:${port}`
+  },
+  webServer: {
+    command: `PORT=${port} pnpm dev`,
+    port,
+    reuseExistingServer: !process.env.CI
+  }
+});

--- a/e2e/extracted-po-split/src/app/layout.tsx
+++ b/e2e/extracted-po-split/src/app/layout.tsx
@@ -1,0 +1,14 @@
+import {NextIntlClientProvider} from 'next-intl';
+import {getLocale} from 'next-intl/server';
+
+export default async function RootLayout({children}: LayoutProps<'/'>) {
+  const locale = await getLocale();
+
+  return (
+    <html lang={locale}>
+      <body>
+        <NextIntlClientProvider>{children}</NextIntlClientProvider>
+      </body>
+    </html>
+  );
+}

--- a/e2e/extracted-po-split/src/app/page.tsx
+++ b/e2e/extracted-po-split/src/app/page.tsx
@@ -1,0 +1,12 @@
+import {useExtracted} from 'next-intl';
+import Greeting from '@/components/Greeting';
+
+export default function Page() {
+  const t = useExtracted();
+  return (
+    <div>
+      <h1>{t('Hello')}</h1>
+      <Greeting />
+    </div>
+  );
+}

--- a/e2e/extracted-po-split/src/components/Greeting.tsx
+++ b/e2e/extracted-po-split/src/components/Greeting.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import {useExtracted} from 'next-intl';
+
+export default function Greeting() {
+  const t = useExtracted('ui');
+  return <div>{t('Hey!')}</div>;
+}

--- a/e2e/extracted-po-split/src/i18n/request.ts
+++ b/e2e/extracted-po-split/src/i18n/request.ts
@@ -1,0 +1,21 @@
+import {getRequestConfig} from 'next-intl/server';
+
+export default getRequestConfig(async () => {
+  const locale = 'en';
+  const root = (await import(`../../messages/${locale}.po`)).default as Record<
+    string,
+    unknown
+  >;
+  const ui = (await import(`../../messages/ui/${locale}.po`)).default as Record<
+    string,
+    unknown
+  >;
+
+  return {
+    locale,
+    messages: {
+      ...root,
+      ...ui
+    }
+  };
+});

--- a/e2e/extracted-po-split/tests/catalog-utils.ts
+++ b/e2e/extracted-po-split/tests/catalog-utils.ts
@@ -1,0 +1,36 @@
+import fs from 'fs/promises';
+import path from 'path';
+import {expect} from '@playwright/test';
+
+export function getPoEntry(poContent: string, msgid: string): string | null {
+  const blocks = poContent.split(/\n\n+/);
+  const escaped = msgid.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const block = blocks.find((b) => new RegExp(`msgid "${escaped}"`).test(b));
+  return block ? block.trim() : null;
+}
+
+export function createPoCatalogUtils(messagesDir: string) {
+  return {
+    async expectCatalog(
+      file: string,
+      predicate: (content: string) => boolean,
+      opts?: {timeout?: number}
+    ): Promise<string> {
+      const filePath = path.join(messagesDir, file);
+      await expect
+        .poll(
+          async () => {
+            try {
+              const content = await fs.readFile(filePath, 'utf-8');
+              return predicate(content);
+            } catch {
+              return false;
+            }
+          },
+          opts?.timeout ? {timeout: opts.timeout} : undefined
+        )
+        .toBe(true);
+      return fs.readFile(filePath, 'utf-8');
+    }
+  };
+}

--- a/e2e/extracted-po-split/tests/main.spec.ts
+++ b/e2e/extracted-po-split/tests/main.spec.ts
@@ -1,0 +1,70 @@
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {expect, test as it} from '@playwright/test';
+import {createPoCatalogUtils, getPoEntry} from './catalog-utils.js';
+import {withTempEdit} from 'e2e-utils/temp-files';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = path.join(__dirname, '..');
+const MESSAGES_DIR = path.join(APP_ROOT, 'messages');
+
+const {expectCatalog} = createPoCatalogUtils(MESSAGES_DIR);
+const withTempEditApp = (filePath: string, content: string) =>
+  withTempEdit(APP_ROOT, filePath, content);
+
+it('renders messages from the root catalog and a namespace catalog', async ({
+  page
+}) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', {name: 'Hello'})).toBeVisible();
+  await expect(page.getByText('Hey!')).toBeVisible();
+});
+
+it('writes unnamespaced messages to the root catalog', async ({page}) => {
+  await page.goto('/');
+  const content = await expectCatalog(
+    'en.po',
+    (catalog) => getPoEntry(catalog, 'NhX4DJ') != null
+  );
+  expect(getPoEntry(content, 'NhX4DJ')).toMatch(/msgstr "Hello"/);
+  expect(content).not.toContain('msgctxt "ui"');
+});
+
+it('writes namespaced messages to a namespace catalog', async ({page}) => {
+  await page.goto('/');
+  const content = await expectCatalog(
+    'ui/en.po',
+    (catalog) => getPoEntry(catalog, '-YJVTi') != null
+  );
+  expect(content).toMatch(/msgctxt "ui"\s+msgid "-YJVTi"\s+msgstr "Hey!"/);
+});
+
+it('extracts new namespaced messages into the namespace catalog', async ({
+  page
+}) => {
+  await using _ = await withTempEditApp(
+    'src/components/Greeting.tsx',
+    `'use client';
+
+import {useExtracted} from 'next-intl';
+
+export default function Greeting() {
+  const t = useExtracted('ui');
+  return <div>{t('Hey!')}{t('Newly extracted')}</div>;
+}
+`
+  );
+
+  await page.goto('/');
+  const content = await expectCatalog('ui/en.po', (catalog) =>
+    catalog.includes('Newly extracted')
+  );
+  expect(content).toContain('Newly extracted');
+  expect(content).toContain('msgctxt "ui"');
+
+  const root = await expectCatalog(
+    'en.po',
+    (catalog) => getPoEntry(catalog, 'NhX4DJ') != null
+  );
+  expect(root).not.toContain('Newly extracted');
+});

--- a/e2e/extracted-po-split/tsconfig.json
+++ b/e2e/extracted-po-split/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "strict": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{"name": "next"}],
+    "paths": {"@/*": ["./src/*"]},
+    "strictNullChecks": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
+++ b/packages/next-intl/src/extractor/ExtractionCompiler.test.tsx
@@ -1884,6 +1884,268 @@ describe('`srcPath` filtering', () => {
   });
 });
 
+describe('split by namespace', {timeout: 20_000}, () => {
+  function createSplitCompiler(format: 'json' | 'po') {
+    return new ExtractionCompiler(
+      {
+        extract: {
+          locales: 'infer',
+          path: './messages',
+          sourceLocale: 'en',
+          srcPath: './src',
+          split: 'namespace'
+        },
+        messages: {
+          format,
+          path: ['./messages']
+        }
+      },
+      {
+        isDevelopment: true,
+        projectRoot: '/project',
+        saveDebounceMs: 0
+      }
+    );
+  }
+
+  it('writes namespaced messages to a namespace directory for json', async () => {
+    filesystem.project.src['Greeting.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted();
+      const tUi = useExtracted('ui');
+      return <div>{t('Hey!')}{tUi('Hello!')}</div>;
+    }
+    `;
+
+    using compiler = createSplitCompiler('json');
+    await compiler.extractAll();
+
+    expect(JSON.parse(getNestedValue(filesystem, 'messages/en.json'))).toEqual({
+      '-YJVTi': 'Hey!'
+    });
+    expect(
+      JSON.parse(getNestedValue(filesystem, 'messages/ui/en.json'))
+    ).toEqual({
+      ui: {
+        OpKKos: 'Hello!'
+      }
+    });
+  });
+
+  it('writes namespaced messages to a namespace directory for po', async () => {
+    filesystem.project.src['Greeting.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted();
+      const tUi = useExtracted('ui');
+      return <div>{t('Hey!')}{tUi('Hello!')}</div>;
+    }
+    `;
+
+    using compiler = createSplitCompiler('po');
+    await compiler.extractAll();
+
+    const root = getNestedValue(filesystem, 'messages/en.po') as string;
+    expect(root).toContain('msgid "-YJVTi"');
+    expect(root).toContain('msgstr "Hey!"');
+    expect(root).not.toContain('msgctxt "ui"');
+
+    const namespaced = getNestedValue(
+      filesystem,
+      'messages/ui/en.po'
+    ) as string;
+    expect(namespaced).toMatch(
+      /msgctxt "ui"\s+msgid "OpKKos"\s+msgstr "Hello!"/
+    );
+  });
+
+  it('preserves target-locale translations when splitting', async () => {
+    filesystem.project.messages = {
+      'en.po': '',
+      'de.po': `
+#: src/Greeting.tsx
+msgid "-YJVTi"
+msgstr "Hallo!"
+
+#: src/Greeting.tsx
+msgctxt "ui"
+msgid "OpKKos"
+msgstr "Hallo Welt!"
+`
+    };
+    filesystem.project.src['Greeting.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted();
+      const tUi = useExtracted('ui');
+      return <div>{t('Hey!')}{tUi('Hello!')}</div>;
+    }
+    `;
+
+    using compiler = createSplitCompiler('po');
+    await compiler.extractAll();
+
+    const rootDe = getNestedValue(filesystem, 'messages/de.po') as string;
+    expect(rootDe).toContain('msgid "-YJVTi"');
+    expect(rootDe).toContain('msgstr "Hallo!"');
+    expect(rootDe).not.toContain('msgctxt "ui"');
+
+    const uiDe = getNestedValue(filesystem, 'messages/ui/de.po') as string;
+    expect(uiDe).toMatch(
+      /msgctxt "ui"\s+msgid "OpKKos"\s+msgstr "Hallo Welt!"/
+    );
+  });
+
+  it('migrates a monolithic catalog into namespace files', async () => {
+    filesystem.project.messages = {
+      'en.po': `
+#: src/Greeting.tsx
+msgid "-YJVTi"
+msgstr "Hey!"
+
+#: src/Greeting.tsx
+msgctxt "ui"
+msgid "OpKKos"
+msgstr "Hello!"
+`,
+      'de.po': `
+#: src/Greeting.tsx
+msgid "-YJVTi"
+msgstr "Hallo!"
+
+#: src/Greeting.tsx
+msgctxt "ui"
+msgid "OpKKos"
+msgstr "Hallo Welt!"
+`
+    };
+    filesystem.project.src['Greeting.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted();
+      const tUi = useExtracted('ui');
+      return <div>{t('Hey!')}{tUi('Hello!')}</div>;
+    }
+    `;
+
+    using compiler = createSplitCompiler('po');
+    await compiler.extractAll();
+
+    const rootEn = getNestedValue(filesystem, 'messages/en.po') as string;
+    expect(rootEn).toContain('msgid "-YJVTi"');
+    expect(rootEn).not.toContain('msgctxt "ui"');
+
+    const uiEn = getNestedValue(filesystem, 'messages/ui/en.po') as string;
+    expect(uiEn).toMatch(/msgctxt "ui"\s+msgid "OpKKos"\s+msgstr "Hello!"/);
+
+    const rootDe = getNestedValue(filesystem, 'messages/de.po') as string;
+    expect(rootDe).toContain('msgstr "Hallo!"');
+    expect(rootDe).not.toContain('msgctxt "ui"');
+
+    const uiDe = getNestedValue(filesystem, 'messages/ui/de.po') as string;
+    expect(uiDe).toContain('msgstr "Hallo Welt!"');
+  });
+
+  it('deletes stale namespace catalogs when the namespace disappears', async () => {
+    filesystem.project.src['Greeting.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted('ui');
+      return <div>{t('Hello!')}</div>;
+    }
+    `;
+
+    using compiler = createSplitCompiler('po');
+    await compiler.extractAll();
+    expect(getNestedValue(filesystem, 'messages/ui/en.po')).toEqual(
+      expect.stringContaining('msgctxt "ui"')
+    );
+
+    await simulateSourceFileUpdate(
+      '/project/src/Greeting.tsx',
+      `
+      import {useExtracted} from 'next-intl';
+      function Greeting() {
+        const t = useExtracted();
+        return <div>{t('Hey!')}</div>;
+      }
+      `
+    );
+    await vi.waitFor(() => {
+      expect(getNestedValue(filesystem, 'messages/ui/en.po')).toBeUndefined();
+    });
+
+    const root = getNestedValue(filesystem, 'messages/en.po') as string;
+    expect(root).toContain('msgid "-YJVTi"');
+    expect(root).not.toContain('msgctxt "ui"');
+  });
+
+  it('infers target locales from nested namespace catalogs', async () => {
+    setNestedValue(
+      filesystem,
+      'messages/ui/fr.po',
+      `
+#: src/Greeting.tsx
+msgctxt "ui"
+msgid "OpKKos"
+msgstr "Bonjour!"
+`
+    );
+    filesystem.project.src['Greeting.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted('ui');
+      return <div>{t('Hello!')}</div>;
+    }
+    `;
+
+    using compiler = createSplitCompiler('po');
+    await compiler.extractAll();
+
+    const uiFr = getNestedValue(filesystem, 'messages/ui/fr.po') as string;
+    expect(uiFr).toMatch(/msgctxt "ui"\s+msgid "OpKKos"\s+msgstr "Bonjour!"/);
+    expect(getNestedValue(filesystem, 'messages/fr.po')).toEqual(
+      expect.stringContaining('Language: fr')
+    );
+  });
+
+  it('keeps a single catalog per locale when split is not configured', async () => {
+    filesystem.project.src['Greeting.tsx'] = `
+    import {useExtracted} from 'next-intl';
+    function Greeting() {
+      const t = useExtracted('ui');
+      return <div>{t('Hello!')}</div>;
+    }
+    `;
+
+    using compiler = new ExtractionCompiler(
+      {
+        extract: {
+          locales: 'infer',
+          path: './messages',
+          sourceLocale: 'en',
+          srcPath: './src'
+        },
+        messages: {
+          format: 'po',
+          path: ['./messages']
+        }
+      },
+      {
+        isDevelopment: true,
+        projectRoot: '/project',
+        saveDebounceMs: 0
+      }
+    );
+    await compiler.extractAll();
+
+    const root = getNestedValue(filesystem, 'messages/en.po') as string;
+    expect(root).toMatch(/msgctxt "ui"\s+msgid "OpKKos"\s+msgstr "Hello!"/);
+    expect(getNestedValue(filesystem, 'messages/ui/en.po')).toBeUndefined();
+  });
+});
+
 describe('custom format', () => {
   it('supports a structured json custom format with codecs', async () => {
     filesystem.project.messages = {
@@ -2159,6 +2421,26 @@ function getNestedValue(obj: any, pathname: string): any {
   }
 
   return undefined;
+}
+
+function deleteNestedValue(obj: any, pathname: string): void {
+  let pathParts: Array<string>;
+
+  if (pathname.startsWith('/')) {
+    pathParts = pathname.replace(/^\//, '').split('/');
+  } else {
+    pathParts = ['project', ...pathname.split('/')];
+  }
+
+  let current = obj;
+  for (let i = 0; i < pathParts.length - 1; i++) {
+    current = current?.[pathParts[i]];
+    if (!current || typeof current !== 'object') {
+      return;
+    }
+  }
+
+  delete current[pathParts[pathParts.length - 1]];
 }
 
 function setNestedValue(obj: any, pathname: string, value: string): void {
@@ -2539,6 +2821,25 @@ vi.mock('fs/promises', () => ({
     writeFile: vi.fn(async (filePath: string, content: string) => {
       setNestedValue(filesystem, filePath, content);
       fileTimestamps.set(filePath, new Date());
+    }),
+    unlink: vi.fn(async (filePath: string) => {
+      const content = getNestedValue(filesystem, filePath);
+      if (typeof content !== 'string') {
+        throw createENOENTError(filePath);
+      }
+      deleteNestedValue(filesystem, filePath);
+      fileTimestamps.delete(filePath);
+    }),
+    rmdir: vi.fn(async (dirPath: string) => {
+      const contents = getDirectoryContents(filesystem, dirPath);
+      if (contents.length > 0) {
+        const error = new Error(
+          `ENOTEMPTY: directory not empty, rmdir '${dirPath}'`
+        ) as NodeJS.ErrnoException;
+        error.code = 'ENOTEMPTY';
+        throw error;
+      }
+      deleteNestedValue(filesystem, dirPath);
     }),
     stat: vi.fn(async (filePath: string) => {
       const content = getNestedValue(filesystem, filePath);

--- a/packages/next-intl/src/extractor/catalog/CatalogLocales.tsx
+++ b/packages/next-intl/src/extractor/catalog/CatalogLocales.tsx
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import fsPromises from 'fs/promises';
 import path from 'path';
-import type {ExtractorConfig, Locale} from '../types.js';
+import type {CatalogSplit, ExtractorConfig, Locale} from '../types.js';
 
 type LocaleChangeCallback = (params: {
   added: Array<Locale>;
@@ -13,6 +13,7 @@ type CatalogLocalesParams = {
   sourceLocale: Locale;
   extension: string;
   locales: ExtractorConfig['extract']['locales'];
+  split?: CatalogSplit;
 };
 
 export default class CatalogLocales {
@@ -20,6 +21,7 @@ export default class CatalogLocales {
   private extension: string;
   private sourceLocale: Locale;
   private locales: ExtractorConfig['extract']['locales'];
+  private split?: CatalogSplit;
   private watcher?: fs.FSWatcher;
   private targetLocales?: Array<Locale>;
   private onChangeCallbacks: Set<LocaleChangeCallback> = new Set();
@@ -29,6 +31,7 @@ export default class CatalogLocales {
     this.sourceLocale = params.sourceLocale;
     this.extension = params.extension;
     this.locales = params.locales;
+    this.split = params.split;
   }
 
   public async getTargetLocales(): Promise<Array<Locale>> {
@@ -46,13 +49,47 @@ export default class CatalogLocales {
     return this.targetLocales;
   }
 
+  private addLocaleFromFileName(fileName: string, locales: Set<Locale>): void {
+    if (!fileName.endsWith(this.extension)) {
+      return;
+    }
+    const locale = path.basename(fileName, this.extension);
+    if (locale.length > 0) {
+      locales.add(locale);
+    }
+  }
+
   private async readTargetLocales(): Promise<Array<Locale>> {
     try {
-      const files = await fsPromises.readdir(this.messagesDir);
-      return files
-        .filter((file) => file.endsWith(this.extension))
-        .map((file) => path.basename(file, this.extension))
-        .filter((locale) => locale !== this.sourceLocale);
+      const locales = new Set<Locale>();
+      const entries = await fsPromises.readdir(this.messagesDir, {
+        withFileTypes: true
+      });
+
+      for (const entry of entries) {
+        if (entry.isFile()) {
+          this.addLocaleFromFileName(entry.name, locales);
+          continue;
+        }
+
+        if (this.split !== 'namespace' || !entry.isDirectory()) {
+          continue;
+        }
+
+        const nestedEntries = await fsPromises.readdir(
+          path.join(this.messagesDir, entry.name),
+          {withFileTypes: true}
+        );
+        for (const nestedEntry of nestedEntries) {
+          if (nestedEntry.isFile()) {
+            this.addLocaleFromFileName(nestedEntry.name, locales);
+          }
+        }
+      }
+
+      return Array.from(locales).filter(
+        (locale) => locale !== this.sourceLocale
+      );
     } catch {
       return [];
     }
@@ -73,6 +110,16 @@ export default class CatalogLocales {
     }
   }
 
+  private isCatalogFileName(filename: string): boolean {
+    if (!filename.endsWith(this.extension)) {
+      return false;
+    }
+    if (this.split === 'namespace') {
+      return true;
+    }
+    return !filename.includes(path.sep);
+  }
+
   private async startWatcher(): Promise<void> {
     if (this.watcher) {
       return;
@@ -82,14 +129,9 @@ export default class CatalogLocales {
 
     this.watcher = fs.watch(
       this.messagesDir,
-      {persistent: false, recursive: false},
+      {persistent: false, recursive: this.split === 'namespace'},
       (event, filename) => {
-        const isCatalogFile =
-          filename != null &&
-          filename.endsWith(this.extension) &&
-          !filename.includes(path.sep);
-
-        if (isCatalogFile) {
+        if (filename != null && this.isCatalogFileName(filename)) {
           void this.onChange();
         }
       }

--- a/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
+++ b/packages/next-intl/src/extractor/catalog/CatalogManager.tsx
@@ -136,7 +136,8 @@ export default class CatalogManager implements Disposable {
       this.persister = new CatalogPersister({
         messagesPath: this.config.extract.path,
         codec: await this.getCodec(),
-        extension: getFormatExtension(this.config.messages.format)
+        extension: getFormatExtension(this.config.messages.format),
+        split: this.config.extract.split
       });
       return this.persister;
     }
@@ -151,7 +152,8 @@ export default class CatalogManager implements Disposable {
         messagesDir,
         extension: getFormatExtension(this.config.messages.format),
         locales: this.config.extract.locales,
-        sourceLocale: this.config.extract.sourceLocale
+        sourceLocale: this.config.extract.sourceLocale,
+        split: this.config.extract.split
       });
       return this.catalogLocales;
     }

--- a/packages/next-intl/src/extractor/catalog/CatalogPersister.tsx
+++ b/packages/next-intl/src/extractor/catalog/CatalogPersister.tsx
@@ -1,33 +1,68 @@
 import fs from 'fs/promises';
 import fsPath from 'path';
 import type ExtractorCodec from '../format/ExtractorCodec.js';
-import type {ExtractorMessage, Locale} from '../types.js';
+import type {CatalogSplit, ExtractorMessage, Locale} from '../types.js';
+import {getCatalogNamespace} from '../utils.js';
 
 export default class CatalogPersister {
   private messagesPath: string;
   private codec: ExtractorCodec;
   private extension: string;
+  private split?: CatalogSplit;
 
   public constructor(params: {
     messagesPath: string;
     codec: ExtractorCodec;
     extension: string;
+    split?: CatalogSplit;
   }) {
     this.messagesPath = params.messagesPath;
     this.codec = params.codec;
     this.extension = params.extension;
+    this.split = params.split;
   }
 
   private getFileName(locale: Locale): string {
     return locale + this.extension;
   }
 
-  private getFilePath(locale: Locale): string {
+  private getCatalogDir(): string {
+    return fsPath.dirname(this.getRootFilePath('placeholder'));
+  }
+
+  private getRootFilePath(locale: Locale): string {
     return fsPath.join(this.messagesPath, this.getFileName(locale));
   }
 
-  public async read(locale: Locale): Promise<Array<ExtractorMessage>> {
-    const filePath = this.getFilePath(locale);
+  private getNamespaceFilePath(namespace: string, locale: Locale): string {
+    return fsPath.join(
+      this.getCatalogDir(),
+      namespace,
+      this.getFileName(locale)
+    );
+  }
+
+  private displayName(filePath: string): string {
+    return fsPath.relative(this.getCatalogDir(), filePath) || filePath;
+  }
+
+  private async listNamespaceDirs(): Promise<Array<string>> {
+    try {
+      const entries = await fs.readdir(this.getCatalogDir(), {
+        withFileTypes: true
+      });
+      return entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+    } catch {
+      return [];
+    }
+  }
+
+  private async readFile(
+    filePath: string,
+    locale: Locale
+  ): Promise<Array<ExtractorMessage>> {
     let content: string;
     try {
       content = await fs.readFile(filePath, 'utf8');
@@ -41,7 +76,7 @@ export default class CatalogPersister {
         return [];
       }
       throw new Error(
-        `Error while reading ${this.getFileName(locale)}:\n> ${error}`,
+        `Error while reading ${this.displayName(filePath)}:\n> ${error}`,
         {cause: error}
       );
     }
@@ -49,9 +84,91 @@ export default class CatalogPersister {
       return this.codec.decode(content, {locale});
     } catch (error) {
       throw new Error(
-        `Error while decoding ${this.getFileName(locale)}:\n> ${error}`,
+        `Error while decoding ${this.displayName(filePath)}:\n> ${error}`,
         {cause: error}
       );
+    }
+  }
+
+  public async read(locale: Locale): Promise<Array<ExtractorMessage>> {
+    if (this.split !== 'namespace') {
+      return this.readFile(this.getRootFilePath(locale), locale);
+    }
+
+    const byId = new Map<string, ExtractorMessage>();
+    const rootMessages = await this.readFile(
+      this.getRootFilePath(locale),
+      locale
+    );
+    for (const message of rootMessages) {
+      byId.set(message.id, message);
+    }
+
+    const dirs = await this.listNamespaceDirs();
+    for (const dir of dirs) {
+      const messages = await this.readFile(
+        this.getNamespaceFilePath(dir, locale),
+        locale
+      );
+      for (const message of messages) {
+        byId.set(message.id, message);
+      }
+    }
+
+    return Array.from(byId.values());
+  }
+
+  private async writeFile(
+    filePath: string,
+    messages: Array<ExtractorMessage>,
+    context: {
+      locale: Locale;
+      sourceMessagesById: Map<string, ExtractorMessage>;
+    }
+  ): Promise<void> {
+    const content = this.codec.encode(messages, context);
+
+    try {
+      await fs.mkdir(fsPath.dirname(filePath), {recursive: true});
+      await fs.writeFile(filePath, content);
+    } catch (error) {
+      console.error(`❌ Failed to write catalog: ${error}`);
+    }
+  }
+
+  private async removeFile(filePath: string): Promise<void> {
+    try {
+      await fs.unlink(filePath);
+    } catch (error) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        error.code === 'ENOENT'
+      ) {
+        return;
+      }
+      console.error(`❌ Failed to remove catalog: ${error}`);
+    }
+  }
+
+  private async removeDirIfEmpty(dirPath: string): Promise<void> {
+    try {
+      const entries = await fs.readdir(dirPath);
+      if (entries.length > 0) {
+        return;
+      }
+      await fs.rmdir(dirPath);
+    } catch (error) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        error.code === 'ENOENT'
+      ) {
+        return;
+      }
+      console.error(`❌ Failed to remove catalog directory: ${error}`);
     }
   }
 
@@ -62,25 +179,77 @@ export default class CatalogPersister {
       sourceMessagesById: Map<string, ExtractorMessage>;
     }
   ): Promise<void> {
-    const filePath = this.getFilePath(context.locale);
-    const content = this.codec.encode(messages, context);
+    if (this.split !== 'namespace') {
+      await this.writeFile(
+        this.getRootFilePath(context.locale),
+        messages,
+        context
+      );
+      return;
+    }
 
-    try {
-      const outputDir = fsPath.dirname(filePath);
-      await fs.mkdir(outputDir, {recursive: true});
-      await fs.writeFile(filePath, content);
-    } catch (error) {
-      console.error(`❌ Failed to write catalog: ${error}`);
+    const rootMessages: Array<ExtractorMessage> = [];
+    const messagesByNamespace = new Map<string, Array<ExtractorMessage>>();
+
+    for (const message of messages) {
+      const namespace = getCatalogNamespace(message.id);
+      if (namespace == null) {
+        rootMessages.push(message);
+        continue;
+      }
+
+      const namespaceMessages = messagesByNamespace.get(namespace);
+      if (namespaceMessages) {
+        namespaceMessages.push(message);
+      } else {
+        messagesByNamespace.set(namespace, [message]);
+      }
+    }
+
+    await this.writeFile(
+      this.getRootFilePath(context.locale),
+      rootMessages,
+      context
+    );
+
+    for (const [namespace, namespaceMessages] of messagesByNamespace) {
+      await this.writeFile(
+        this.getNamespaceFilePath(namespace, context.locale),
+        namespaceMessages,
+        context
+      );
+    }
+
+    const dirs = await this.listNamespaceDirs();
+    for (const dir of dirs) {
+      if (messagesByNamespace.has(dir)) {
+        continue;
+      }
+      await this.removeFile(this.getNamespaceFilePath(dir, context.locale));
+      await this.removeDirIfEmpty(fsPath.join(this.getCatalogDir(), dir));
     }
   }
 
   public async getLastModified(locale: Locale): Promise<Date | undefined> {
-    const filePath = this.getFilePath(locale);
-    try {
-      const stats = await fs.stat(filePath);
-      return stats.mtime;
-    } catch {
-      return undefined;
+    const filePaths = [this.getRootFilePath(locale)];
+    if (this.split === 'namespace') {
+      const dirs = await this.listNamespaceDirs();
+      for (const dir of dirs) {
+        filePaths.push(this.getNamespaceFilePath(dir, locale));
+      }
     }
+
+    let latest: Date | undefined;
+    for (const filePath of filePaths) {
+      try {
+        const stats = await fs.stat(filePath);
+        if (!latest || stats.mtime > latest) {
+          latest = stats.mtime;
+        }
+      } catch {
+        // File may not exist yet
+      }
+    }
+    return latest;
   }
 }

--- a/packages/next-intl/src/extractor/normalizeExtractorConfig.tsx
+++ b/packages/next-intl/src/extractor/normalizeExtractorConfig.tsx
@@ -31,6 +31,7 @@ export default function normalizeExtractorConfig(
 
   let extractPath: string | undefined;
   let sourceLocale: string | undefined;
+  let split: ExtractorConfig['extract']['split'];
 
   if (extract !== undefined && extract !== true) {
     if (extract.sourceLocale) {
@@ -42,6 +43,10 @@ export default function normalizeExtractorConfig(
 
     if (extract.path) {
       extractPath = stripTrailingSlash(extract.path);
+    }
+
+    if (extract.split === 'namespace') {
+      split = 'namespace';
     }
   }
 
@@ -84,7 +89,8 @@ export default function normalizeExtractorConfig(
       locales,
       path: extractPath,
       sourceLocale,
-      srcPath
+      srcPath,
+      split
     },
     messages: {
       format: input.messages.format,

--- a/packages/next-intl/src/extractor/types.tsx
+++ b/packages/next-intl/src/extractor/types.tsx
@@ -5,6 +5,9 @@ import type {MessagesFormat} from './format/types.js';
 // don't require a match here.
 export type Locale = string;
 
+/** Partitions extracted catalogs into `{namespace}/{locale}{ext}` files. */
+export type CatalogSplit = 'namespace';
+
 export type ExtractorMessageReference = {
   path: string;
   line?: number;
@@ -64,6 +67,12 @@ export type ExtractorConfigInput = {
     | {
         /** Defaults to `messages.path` when it is a single path. */
         path?: string;
+        /**
+         * Write namespaced messages to `{namespace}/{locale}` files instead of
+         * a single catalog per locale. Unnamespaced messages stay in the root
+         * `{locale}` file.
+         */
+        split?: CatalogSplit;
         /** @deprecated Prefer `messages.sourceLocale`. */
         sourceLocale?: string;
       };
@@ -76,6 +85,7 @@ export type ExtractorConfig = {
     path: string;
     sourceLocale: string;
     srcPath: string | Array<string>;
+    split?: CatalogSplit;
   };
   messages: {
     format: MessagesFormat;

--- a/packages/next-intl/src/extractor/utils.test.tsx
+++ b/packages/next-intl/src/extractor/utils.test.tsx
@@ -1,5 +1,9 @@
 import {describe, expect, it, vi} from 'vitest';
-import {getSortedMessages, setNestedProperty} from './utils.js';
+import {
+  getCatalogNamespace,
+  getSortedMessages,
+  setNestedProperty
+} from './utils.js';
 
 describe('getSortedMessages', () => {
   it('sorts by reference path', () => {
@@ -95,6 +99,22 @@ describe('getSortedMessages', () => {
     );
 
     warnSpy.mockRestore();
+  });
+});
+
+describe('getCatalogNamespace', () => {
+  it('returns the first id segment', () => {
+    expect(getCatalogNamespace('login.saas-login.form.x')).toBe('login');
+    expect(getCatalogNamespace('ui.OpKKos')).toBe('ui');
+  });
+
+  it('returns undefined for unnamespaced or unsafe ids', () => {
+    expect(getCatalogNamespace('OpKKos')).toBeUndefined();
+    expect(getCatalogNamespace('.leading')).toBeUndefined();
+    expect(getCatalogNamespace('..hidden.x')).toBeUndefined();
+    expect(getCatalogNamespace('foo/bar.x')).toBeUndefined();
+    expect(getCatalogNamespace('foo\\bar.x')).toBeUndefined();
+    expect(getCatalogNamespace('__proto__.x')).toBeUndefined();
   });
 });
 

--- a/packages/next-intl/src/extractor/utils.tsx
+++ b/packages/next-intl/src/extractor/utils.tsx
@@ -24,6 +24,31 @@ export function isForbiddenObjectKey(key: string): boolean {
   return FORBIDDEN_OBJECT_KEYS.has(key);
 }
 
+/**
+ * First id segment used as a catalog directory when `extract.split` is
+ * `'namespace'`. Returns `undefined` for unnamespaced or unsafe ids so they
+ * stay in the root `{locale}` file.
+ */
+export function getCatalogNamespace(id: string): string | undefined {
+  const separatorIndex = id.indexOf('.');
+  if (separatorIndex <= 0) {
+    return undefined;
+  }
+
+  const namespace = id.slice(0, separatorIndex);
+  if (
+    namespace === '.' ||
+    namespace === '..' ||
+    namespace.includes('/') ||
+    namespace.includes('\\') ||
+    isForbiddenObjectKey(namespace)
+  ) {
+    return undefined;
+  }
+
+  return namespace;
+}
+
 export function hasLocalesToExtract(
   config: Pick<ExtractorConfig, 'extract'>
 ): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,52 @@ importers:
         specifier: ^5.5.3
         version: 5.9.3
 
+  e2e/extracted-po-split:
+    dependencies:
+      e2e-utils:
+        specifier: workspace:*
+        version: link:../utils
+      next:
+        specifier: ^16.3.0
+        version: 16.3.0(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@25.0.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next-intl:
+        specifier: workspace:*
+        version: link:../../packages/next-intl
+      react:
+        specifier: ^19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
+      use-intl:
+        specifier: workspace:*
+        version: link:../../packages/use-intl
+    devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.1.0
+        version: 3.3.3
+      '@playwright/test':
+        specifier: ^1.51.1
+        version: 1.57.0
+      '@types/react':
+        specifier: ^19.2.3
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      eslint:
+        specifier: ^9.38.0
+        version: 9.39.2(jiti@2.6.1)
+      eslint-config-next:
+        specifier: ^16.3.0
+        version: 16.3.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.8.0
+      typescript:
+        specifier: ^5.5.3
+        version: 5.9.3
+
   e2e/no-js:
     dependencies:
       next:


### PR DESCRIPTION
Supports splitting extracted catalogs by namespace so large `useExtracted` apps can keep one file per feature instead of one monolith per locale:

```ts
extract: {
  split: 'namespace'
}
```

```
messages/
  en.po
  de.po
  ui/en.po
  ui/de.po
```

## Motivation

Extraction always writes one catalog per locale (`messages/en.po`). Namespaces from `useExtracted('ui')` are only a logical grouping inside that file (`msgctxt` / nested JSON). That works until the catalog grows to thousands of messages: diffs, merge conflicts, and translation tools all operate on a single huge file.

`messages.path` as an array already supports **per-package** catalogs in a monorepo, but not **per-namespace** files within one app. Manual multi-file loading is documented for `useTranslations` JSON, but the extractor will not maintain those files.

This is opt-in and format-agnostic (`.po` and `.json`). Default behavior is unchanged.

## Implementation

- `extract.split: 'namespace'` on the object form of `extract` (not on `extract: true`).
- Partition key is the first `.` segment of the **combined message id** (`login.saas-login.form.x` → `login/`). The extractor only sees the combined id, so it cannot recover the original `useExtracted('login')` argument vs a dotted explicit id.
- Full ids stay inside each file. The filename is only a partition — the catalog loader still infers locale from the basename (`en.po` → `en`), so `{namespace}/{locale}.po` needs no loader change. `{locale}/{namespace}.po` would break that.
- Unnamespaced ids, and unsafe first segments (`/`, `..`, `__proto__`, …), stay in the root `{locale}` file. That root file is always written (header-only if needed) so locale inference still has a locale marker when every message is namespaced.
- `CatalogPersister` reads root + `{ns}/{locale}` files (namespace files win on id overlap), writes the partition, and deletes stale namespace files. `getLastModified` uses the max mtime across those files so translator edits to a single namespace file are not missed.
- `CatalogLocales` infers locales from file basenames in the root **and** one level of `{ns}/*{ext}` (Crowdin can create `ui/fr.po` before `fr.po` exists) and watches recursively when split is on.
- Enabling split against an existing monolith: the next save moves namespaced entries out and preserves translations. Runtime loading is still the app's job — merge the root file with each namespace file in `getRequestConfig` (shallow spread; each file owns a distinct top-level key).

Out of scope: tree-shaking / client bundle size, `{locale}/{namespace}.po`, stripping the namespace from ids because the filename is the namespace, a `loadCatalogs()` helper, and configurable split depth.

## Tests

- `getCatalogNamespace` unit tests for first-segment partition and unsafe fallbacks.
- `ExtractionCompiler` coverage for JSON and PO: write layout, target-locale translations, monolith migration, stale namespace delete, inferring a locale from only `ui/fr.po`, and the default single-file path when `split` is unset.
- New `e2e/extracted-po-split` app: root + `ui` catalogs, merge in `getRequestConfig`, and extraction of a new namespaced message into `ui/en.po`.

## Docs

`plugin.mdx`: `extract.split`. `extraction.mdx`: file layout and `getRequestConfig` merge example.