### PR TITLE
docs: Update eloqnt links after the rename to eloqnt/cli

### DIFF
--- a/docs/src/components/Footer.tsx
+++ b/docs/src/components/Footer.tsx
@@ -19,10 +19,7 @@ export default function Footer() {
           <FooterSeparator />
           <FooterLink href="/examples">Examples</FooterLink>
           <FooterSeparator />
-          <FooterLink
-            className="relative"
-            href="https://studio.eloqnt.dev/docs"
-          >
+          <FooterLink className="relative" href="https://cli.eloqnt.dev/docs">
             CLI
             <span className="absolute -right-2 top-0.5 rotate-6 rounded-sm bg-blue-500 px-1 text-[8px] font-semibold uppercase tracking-wider text-white group-[.navbar-home]:bg-blue-300 group-[.navbar-home]:text-blue-900 dark:bg-blue-300 dark:text-blue-900">
               Beta

--- a/docs/src/pages/_meta.tsx
+++ b/docs/src/pages/_meta.tsx
@@ -29,7 +29,7 @@ export default {
       sidebar: false,
       toc: false
     },
-    href: 'https://studio.eloqnt.dev/docs'
+    href: 'https://cli.eloqnt.dev/docs'
   },
   learn: {
     title: 'Learn',

--- a/docs/src/pages/docs/usage/extraction.mdx
+++ b/docs/src/pages/docs/usage/extraction.mdx
@@ -278,7 +278,7 @@ Messages can be extracted as [`.json`](/docs/usage/plugin#formats-json), [`.po`]
 
 <Callout>
 
-AI-based translation can be automated with tools like [eloqnt/studio](https://studio.eloqnt.dev).
+AI-based translation can be automated with tools like [eloqnt/cli](https://cli.eloqnt.dev).
 
 </Callout>
 

--- a/docs/src/pages/docs/usage/plugin.mdx
+++ b/docs/src/pages/docs/usage/plugin.mdx
@@ -219,7 +219,7 @@ Note that JSON files can only hold pairs of keys and values. To provide more con
 
 <Callout>
 
-Translations can be AI-generated with tools like [eloqnt/studio](https://studio.eloqnt.dev).
+Translations can be AI-generated with tools like [eloqnt/cli](https://cli.eloqnt.dev).
 
 </Callout>
 
@@ -249,7 +249,7 @@ Besides the message key and the label itself, this format also supports optional
 
 <Callout>
 
-Translations can be AI-generated with tools like [eloqnt/studio](https://studio.eloqnt.dev).
+Translations can be AI-generated with tools like [eloqnt/cli](https://cli.eloqnt.dev).
 
 </Callout>
 

--- a/docs/src/pages/docs/workflows/agents.mdx
+++ b/docs/src/pages/docs/workflows/agents.mdx
@@ -55,6 +55,6 @@ While agents can help with many aspects of internationalization, translating mes
 3. **Language nuances**: Generic agents may guess at aspects like plural rules for target languages, leading to subtle errors that are easy to miss.
 4. **Context pollution**: Editing catalogs for many locales fills up the context window with content that's mostly irrelevant for the agent's main task.
 
-To address these issues, [eloqnt/studio](https://studio.eloqnt.dev) was created as a companion for `next-intl`. It's a CLI tool that analyzes your source code to enrich messages with usage context, applies per-locale styleguides, and verifies translations after they've been generated.
+To address these issues, [eloqnt/cli](https://cli.eloqnt.dev) was created as a companion for `next-intl`. It's a CLI tool that analyzes your source code to enrich messages with usage context, applies per-locale styleguides, and verifies translations after they've been generated.
 
 Is localization outgrowing your repo? By using a translation management system like <PartnerContentLink href="https://crowdin.com/">Crowdin</PartnerContentLink>, you can leverage review workflows, 3rd-party integrations, collaboration tooling and more.

--- a/docs/src/pages/docs/workflows/messages.mdx
+++ b/docs/src/pages/docs/workflows/messages.mdx
@@ -2,7 +2,7 @@ import Callout from '@/components/Callout';
 
 # Linting messages
 
-To ensure quality and completeness of your messages, you can lint them with [`@eloqnt/cli`](https://studio.eloqnt.dev/docs).
+To ensure quality and completeness of your messages, you can lint them with [`@eloqnt/cli`](https://cli.eloqnt.dev/docs).
 
 This tool is purpose-built for `next-intl`, and uses AST-level analysis to catch common issues like missing translations, inconsistent ICU arguments, and more.
 
@@ -30,7 +30,7 @@ export default defineConfig({
 });
 ```
 
-See [configuration](https://studio.eloqnt.dev/docs/configuration) in the `@eloqnt/cli` docs.
+See [configuration](https://cli.eloqnt.dev/docs/configuration) in the `@eloqnt/cli` docs.
 
 **Run the `lint` command:**
 
@@ -72,10 +72,10 @@ export default defineConfig({
 });
 ```
 
-See [custom formats](https://studio.eloqnt.dev/docs/configuration#format) in the `@eloqnt/cli` docs.
+See [custom formats](https://cli.eloqnt.dev/docs/configuration#format) in the `@eloqnt/cli` docs.
 
 ## GitHub Actions
 
 `eloqnt lint` can be integrated on continuous integration systems like GitHub Actions, while optionally also filling in missing translations.
 
-See [GitHub Actions](https://studio.eloqnt.dev/docs/guides/github-actions) in the `@eloqnt/cli` docs.
+See [GitHub Actions](https://cli.eloqnt.dev/docs/guides/github-actions) in the `@eloqnt/cli` docs.


### PR DESCRIPTION
Updates the docs links for the eloqnt CLI: the docs site moved from `studio.eloqnt.dev` to `cli.eloqnt.dev`, and prose that still called the product `eloqnt/studio` now says `eloqnt/cli`.

Changed files:
- `docs/src/components/Footer.tsx` — footer "CLI" link
- `docs/src/pages/_meta.tsx` — top-level nav entry
- `docs/src/pages/docs/usage/extraction.mdx`, `docs/src/pages/docs/usage/plugin.mdx`, `docs/src/pages/docs/workflows/agents.mdx` — callout/prose links and product name
- `docs/src/pages/docs/workflows/messages.mdx` — links to the CLI docs, configuration, custom formats and GitHub Actions guide

Verification:
- No `studio.eloqnt.dev` or `eloqnt/studio` references remain in the repo.
- All new URLs (`/docs`, `/docs/configuration`, `/docs/guides/github-actions`, root) return 200; the old host 308-redirects to the new one, so nothing was broken before this change.
- Prettier passes on the changed files (the `Footer.tsx` link now fits on one line, so it collapses).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmfSSqk3J22GibHC44KbHF)_