### PR TITLE
fix: Allow `@eloqnt/*` patches to resolve by moving to `^0.1.0` ranges

### DIFF
--- a/packages/next-intl/package.json
+++ b/packages/next-intl/package.json
@@ -124,9 +124,9 @@
     "next.js"
   ],
   "dependencies": {
-    "@eloqnt/config": "^0.0.2",
-    "@eloqnt/format-json": "^0.0.3",
-    "@eloqnt/format-po": "^0.0.3",
+    "@eloqnt/config": "^0.1.0",
+    "@eloqnt/format-json": "^0.1.0",
+    "@eloqnt/format-po": "^0.1.0",
     "@formatjs/intl-localematcher": "^0.8.1",
     "@parcel/watcher": "^2.4.1",
     "@swc/core": "~1.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -811,14 +811,14 @@ importers:
   packages/next-intl:
     dependencies:
       '@eloqnt/config':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.1.0
+        version: 0.1.0
       '@eloqnt/format-json':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.1.0
+        version: 0.1.0
       '@eloqnt/format-po':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.1.0
+        version: 0.1.0
       '@formatjs/intl-localematcher':
         specifier: ^0.8.1
         version: 0.8.1
@@ -1930,14 +1930,14 @@ packages:
     resolution: {integrity: sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==}
     engines: {node: '>=18'}
 
-  '@eloqnt/config@0.0.2':
-    resolution: {integrity: sha512-xz86UU1TJQPSzb0XJ3PkoyDlv3wdIiHfuu2wD/8m9ponHx0uSasYRDj4S+dpwQkIQaPYibN1oRr5HBll2GQkog==}
+  '@eloqnt/config@0.1.0':
+    resolution: {integrity: sha512-SLR6ZSHxu6XdZtmOz3xRmC3gsY/sCzqtLMD1gxbW2I3XXPBbupwL5RZbkLU/NcZm74AKZrIUPfz3CtEJfxUKqQ==}
 
-  '@eloqnt/format-json@0.0.3':
-    resolution: {integrity: sha512-zgDUVryBYQyM0WZGAoVr+FXjrzRjKkBGJran0E3i5LBcvTycl9ScFVhkF7aRBg8mHrU9xxvclUtSDIYg2mRTQg==}
+  '@eloqnt/format-json@0.1.0':
+    resolution: {integrity: sha512-4Pkb+HyzgWNJXoU48aJhUyNZSjZvMGooPCNG1ZFmBm55xTiNNPQCNXH66Ob6sXS6RvbWZrRpCf+Uo/Jz9K9g+A==}
 
-  '@eloqnt/format-po@0.0.3':
-    resolution: {integrity: sha512-4r36qEd7KJFV+IMKUv5czNXbGVys8ahxlQKWoUDV20eGl4Oxr+YZ2O5IEQU09S+d7FvPJ1USnyc/wtCLNCo1Ng==}
+  '@eloqnt/format-po@0.1.0':
+    resolution: {integrity: sha512-odgtuICWs67GdkNqY51/d2vaIukuOdlGalKASUGkI5c4cyWOmv/WIVyk5gZyn3xr614RzwWp57s9WB40lRLlBw==}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -7025,6 +7025,7 @@ packages:
   eslint@9.11.1:
     resolution: {integrity: sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -7035,6 +7036,7 @@ packages:
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -13220,15 +13222,15 @@ snapshots:
     dependencies:
       '@edge-runtime/primitives': 6.0.0
 
-  '@eloqnt/config@0.0.2': {}
+  '@eloqnt/config@0.1.0': {}
 
-  '@eloqnt/format-json@0.0.3':
+  '@eloqnt/format-json@0.1.0':
     dependencies:
-      '@eloqnt/config': 0.0.2
+      '@eloqnt/config': 0.1.0
 
-  '@eloqnt/format-po@0.0.3':
+  '@eloqnt/format-po@0.1.0':
     dependencies:
-      '@eloqnt/config': 0.0.2
+      '@eloqnt/config': 0.1.0
       po-parser: 2.2.0
 
   '@emnapi/core@1.8.1':


### PR DESCRIPTION
Fixes #2397.

## Problem

`next-intl` declared caret ranges on `0.0.x` versions of the `@eloqnt/*` packages. Under semver, caret only allows changes that don't modify the leftmost non-zero digit — and at `0.0.x` that digit is the patch, so a caret there is equivalent to an exact pin:

```js
new Range('^0.0.2').range     // '>=0.0.2 <0.0.3-0'
satisfies('0.0.3', '^0.0.2')  // false
```

Consumers therefore resolved `@eloqnt/config@0.0.2`, `@eloqnt/format-json@0.0.3` and `@eloqnt/format-po@0.0.3` — none of which carry a license grant — and no package manager could resolve upward into the MIT-licensed releases, on a clean install or with `--force`.

## Change

The `@eloqnt/*` packages have been promoted to `0.1.0`, so the ranges move with them:

```diff
-"@eloqnt/config": "^0.0.2",
-"@eloqnt/format-json": "^0.0.3",
-"@eloqnt/format-po": "^0.0.3",
+"@eloqnt/config": "^0.1.0",
+"@eloqnt/format-json": "^0.1.0",
+"@eloqnt/format-po": "^0.1.0",
```

At `0.1.x` the leftmost non-zero digit is the minor, so `^0.1.0` desugars to `>=0.1.0 <0.2.0-0`. The whole `0.1.x` patch line now reaches consumers without a `next-intl` release, while `0.2.0` still requires a deliberate bump — the guardrail is preserved, just moved to where it belongs.

## Verification

All three packages now resolve to MIT-licensed releases, confirmed in `node_modules` after install:

| Package | Resolved | `license` field | LICENSE file |
| --- | --- | --- | --- |
| `@eloqnt/config` | `0.1.0` | MIT | present |
| `@eloqnt/format-json` | `0.1.0` | MIT | present |
| `@eloqnt/format-po` | `0.1.0` | MIT | present |

Note that `format-po` moves `0.0.3 → 0.1.0`, which sweeps up real behavior changes (blank-catalog parse fix, PO reference-style and header-order preservation, empty-`msgstr` error), so this is not a license-only bump. The PO codec is covered by the 32 `ExtractionCompiler` tests, which pass unchanged.

- `pnpm run build-packages` — 3/3 successful
- `vitest run` (next-intl) — 30 files, **896 tests passing**
- `pnpm run lint:source` — eslint, `tsc --noEmit` and prettier all clean

## Notes for review

- The lockfile diff is scoped to `@eloqnt` resolutions. It also picks up two `deprecated:` metadata annotations that pnpm refreshed for existing `eslint` entries — annotations only, no version change. I regenerated with `--lockfile-only` specifically to avoid the unrelated `@typescript-eslint/parser` churn that a plain `--no-frozen-lockfile` install introduced.
- The `@eloqnt` cross-dependencies on `@eloqnt/config` were also tightened upstream from the unbounded `>=0.0.3` to `^0.1.0`, so the transitive resolution is bounded too.
- Now that patches flow through automatically, a `@eloqnt/*` patch published on its own will land in fresh installs of already-released `next-intl` versions without a CI run here. That's the intended trade-off, but worth being deliberate about.

---
_Generated by [Claude Code](https://claude.ai/code/session_018HWdJit3LkB78z72jwU3Cd)_