### PR TITLE
fix: improved the isPromise promise validation logic

### DIFF
--- a/packages/next-intl/src/shared/utils.tsx
+++ b/packages/next-intl/src/shared/utils.tsx
@@ -201,5 +201,5 @@ export function isPromise<Value>(
   value: Value | Promise<Value>
 ): value is Promise<Value> {
   // https://github.com/amannn/next-intl/issues/1711
-  return typeof (value as any).then === 'function';
+  return Promise.resolve(value as any) === value;
 }


### PR DESCRIPTION
I have improved the existing validation logic for the isPromise utility from checking for a `.then` to use a safer, more modern approach via `Promise.resolve()`