### PR TITLE
docs: Lint messages with `@eloqnt/cli` in `example-app-router`

### DIFF
--- a/examples/example-app-router/.eloqnt/config.ts
+++ b/examples/example-app-router/.eloqnt/config.ts
@@ -1,0 +1,11 @@
+import {defineConfig} from '@eloqnt/cli';
+
+export default defineConfig({
+  srcPath: './src',
+  messages: {
+    path: './messages',
+    locales: 'infer',
+    sourceLocale: 'en',
+    format: 'json'
+  }
+});

--- a/examples/example-app-router/README.md
+++ b/examples/example-app-router/README.md
@@ -4,8 +4,6 @@ An example that showcases basic usage of `next-intl` with the App Router, includ
 
 [Demo](https://next-intl-example-app-router.vercel.app/)
 
-Messages are linted with [`@eloqnt/cli`](https://cli.eloqnt.dev/docs) as part of `pnpm lint`, see [Linting messages](https://next-intl.dev/docs/workflows/messages).
-
 ## Deploy your own
 
 By deploying to [Vercel](https://vercel.com), you can check out the example in action. Note that you'll be prompted to create a new GitHub repository as part of this, allowing you to make subsequent changes.

--- a/examples/example-app-router/README.md
+++ b/examples/example-app-router/README.md
@@ -4,6 +4,8 @@ An example that showcases basic usage of `next-intl` with the App Router, includ
 
 [Demo](https://next-intl-example-app-router.vercel.app/)
 
+Messages are linted with [`@eloqnt/cli`](https://cli.eloqnt.dev/docs) as part of `pnpm lint`, see [Linting messages](https://next-intl.dev/docs/workflows/messages).
+
 ## Deploy your own
 
 By deploying to [Vercel](https://vercel.com), you can check out the example in action. Note that you'll be prompted to create a new GitHub repository as part of this, allowing you to make subsequent changes.

--- a/examples/example-app-router/messages/de.json
+++ b/examples/example-app-router/messages/de.json
@@ -15,7 +15,7 @@
     "locale": "{locale, select, de {Deutsch} en {English} other {Unbekannt}}"
   },
   "Manifest": {
-    "name": ""
+    "name": "next-intl Beispiel"
   },
   "Navigation": {
     "home": "Start",

--- a/examples/example-app-router/package.json
+++ b/examples/example-app-router/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "lint": "eslint src && prettier src --check",
+    "lint": "eslint src && prettier src --check && eloqnt lint",
     "test": "pnpm run test:playwright && pnpm run test:jest",
     "test:playwright": "playwright test",
     "test:jest": "jest",
@@ -19,6 +19,7 @@
     "tailwindcss": "^3.4.4"
   },
   "devDependencies": {
+    "@eloqnt/cli": "^0.6.29",
     "@eslint/eslintrc": "^3.1.0",
     "@jest/globals": "^29.7.0",
     "@playwright/test": "^1.51.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         version: 1.29.2
       tailwindcss:
         specifier: ^3.4.4
-        version: 3.4.19(yaml@2.8.2)
+        version: 3.4.19(yaml@2.9.0)
     devDependencies:
       '@types/node':
         specifier: ^20.14.5
@@ -94,7 +94,7 @@ importers:
         version: 9.11.1(jiti@1.21.7)
       eslint-config-molindo:
         specifier: ^8.0.0
-        version: 8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@3.4.19(yaml@2.8.2))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+        version: 8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@3.4.19(yaml@2.9.0))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
@@ -149,10 +149,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       prettier:
         specifier: ^3.3.3
         version: 3.8.0
@@ -195,10 +195,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       postcss:
         specifier: ^8.5.3
         version: 8.5.6
@@ -244,10 +244,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       prettier:
         specifier: ^3.3.3
         version: 3.8.0
@@ -284,10 +284,10 @@ importers:
         version: link:../utils
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       prettier:
         specifier: ^3.3.3
         version: 3.8.0
@@ -324,10 +324,10 @@ importers:
         version: link:../utils
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       prettier:
         specifier: ^3.3.3
         version: 3.8.0
@@ -349,10 +349,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       next-intl:
         specifier: workspace:*
         version: link:../../packages/next-intl
@@ -392,8 +392,11 @@ importers:
         version: 19.2.3(react@19.2.3)
       tailwindcss:
         specifier: ^3.4.4
-        version: 3.4.19(yaml@2.8.2)
+        version: 3.4.19(yaml@2.9.0)
     devDependencies:
+      '@eloqnt/cli':
+        specifier: ^0.6.29
+        version: 0.6.29(@swc/helpers@0.5.23)
       '@eslint/eslintrc':
         specifier: ^3.1.0
         version: 3.3.3
@@ -423,10 +426,10 @@ importers:
         version: 10.4.23(postcss@8.5.6)
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.29)
@@ -469,13 +472,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       prettier:
         specifier: ^3.3.3
         version: 3.8.0
@@ -484,7 +487,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^3.0.8
-        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.0.8)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.0.8)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
 
   examples/example-app-router-migration:
     dependencies:
@@ -515,10 +518,10 @@ importers:
         version: 19.2.14
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       prettier:
         specifier: ^3.3.3
         version: 3.8.0
@@ -606,10 +609,10 @@ importers:
         version: 6.11.0(webpack@5.104.1(esbuild@0.25.1))
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.29)
@@ -658,10 +661,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       prettier:
         specifier: ^3.3.3
         version: 3.8.0
@@ -701,10 +704,10 @@ importers:
         version: 19.2.14
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.3.1
-        version: 16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+        version: 16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       prettier:
         specifier: ^3.3.3
         version: 3.8.0
@@ -751,7 +754,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       prettier:
         specifier: ^3.3.3
         version: 3.8.0
@@ -760,7 +763,7 @@ importers:
         version: 6.0.2
       vite:
         specifier: ^6.2.1
-        version: 6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
 
   packages/icu-minify:
     dependencies:
@@ -779,10 +782,10 @@ importers:
         version: 20.19.29
       eslint:
         specifier: 9.11.1
-        version: 9.11.1(jiti@2.6.1)
+        version: 9.11.1(jiti@2.7.0)
       eslint-config-molindo:
         specifier: ^8.0.0
-        version: 8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+        version: 8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       intl-messageformat:
         specifier: ^11.1.0
         version: 11.1.0
@@ -806,7 +809,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^3.0.8
-        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
 
   packages/next-intl:
     dependencies:
@@ -870,13 +873,13 @@ importers:
         version: 5.28.5(@swc/core@1.16.0(@swc/helpers@0.5.23))(esbuild@0.27.2)
       eslint:
         specifier: 9.11.1
-        version: 9.11.1(jiti@2.6.1)
+        version: 9.11.1(jiti@2.7.0)
       eslint-config-molindo:
         specifier: ^8.0.0
-        version: 8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+        version: 8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       eslint-plugin-react-compiler:
         specifier: 0.0.0-experimental-8e3b87c-20240822
-        version: 0.0.0-experimental-8e3b87c-20240822(eslint@9.11.1(jiti@2.6.1))
+        version: 0.0.0-experimental-8e3b87c-20240822(eslint@9.11.1(jiti@2.7.0))
       next:
         specifier: ^16.3.1
         version: 16.3.1(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@20.19.29)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -915,7 +918,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^3.0.8
-        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
 
   packages/swc-plugin-extractor: {}
 
@@ -957,13 +960,13 @@ importers:
         version: 4.1.0
       eslint:
         specifier: 9.11.1
-        version: 9.11.1(jiti@2.6.1)
+        version: 9.11.1(jiti@2.7.0)
       eslint-config-molindo:
         specifier: ^8.0.0
-        version: 8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+        version: 8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       eslint-plugin-react-compiler:
         specifier: 0.0.0-experimental-8e3b87c-20240822
-        version: 0.0.0-experimental-8e3b87c-20240822(eslint@9.11.1(jiti@2.6.1))
+        version: 0.0.0-experimental-8e3b87c-20240822(eslint@9.11.1(jiti@2.7.0))
       prettier:
         specifier: ^3.3.3
         version: 3.8.0
@@ -993,7 +996,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^3.0.8
-        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
 
   tools:
     devDependencies:
@@ -1023,10 +1026,10 @@ importers:
         version: 0.4.4(rollup@4.55.1)
       eslint:
         specifier: ^9.38.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-molindo:
         specifier: ^8.0.0
-        version: 8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(jest@30.2.0(@types/node@25.0.8)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+        version: 8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(jest@30.2.0(@types/node@25.0.8)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       execa:
         specifier: ^9.5.2
         version: 9.6.1
@@ -1048,6 +1051,22 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ai-sdk/gateway@4.0.76':
+    resolution: {integrity: sha512-hWNtiveILLtkXm1t5tNmzeII8p+j/mzxlL2OtPAgU/0h4ZInkIVILX8Svx4SzI5U9d80B59gCPaKRAhb7jTtAw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.37':
+    resolution: {integrity: sha512-WzLQPWtpLpunKBanq/TX8+rbBz7JdKpl8Io4nl/g+bLvePbxMlMuxLrxT8JzquxJmgWKbW4nfFrQ5mnX4A8mpw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.11':
+    resolution: {integrity: sha512-A/Cyjma9RLTLsF9xv/2OSaw9eyFhOIBqzoeOVZhp+xKZD8wv5opN+qyIa83NE4Jug2SjQ/Kaf08w1JX6CESR/w==}
+    engines: {node: '>=22'}
 
   '@algolia/abtesting@1.12.3':
     resolution: {integrity: sha512-0SpSdnME0RCS6UHSs9XD3ox4bMcCg1JTmjAJ3AU6rcTlX54CZOAEPc2as8uSghX6wfKGT0HWes4TeUpjJMg6FQ==}
@@ -1847,6 +1866,14 @@ packages:
   '@chevrotain/utils@11.0.3':
     resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
 
+  '@clack/core@1.5.0':
+    resolution: {integrity: sha512-zNikCcd8BbcEvzzG1sbXFrRHFk5kHPrpwZwksPvf9qyQO1Teb7JaXaOAxXZei9nZLDW0gaZawiuTCji88bTBhw==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.8.0':
+    resolution: {integrity: sha512-PXzLZ8N34rxmuo4dJg3xtOXhcBse94qGjDqsteoEYrFrrZ5FSjIGwMAuOcv64ln8rHVBBD06XeVGr+/JX+plcA==}
+    engines: {node: '>= 20.12.0'}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -1930,6 +1957,10 @@ packages:
     resolution: {integrity: sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==}
     engines: {node: '>=18'}
 
+  '@eloqnt/cli@0.6.29':
+    resolution: {integrity: sha512-IEqOlk6vEBYTzgTRzhNNOoSLXKafJuudigC9hZSOQKTblMGZ+2Vy7I7oI/Jj2Lq/sDFPpSgN7jEuT4La2SDGQA==}
+    hasBin: true
+
   '@eloqnt/config@0.1.0':
     resolution: {integrity: sha512-SLR6ZSHxu6XdZtmOz3xRmC3gsY/sCzqtLMD1gxbW2I3XXPBbupwL5RZbkLU/NcZm74AKZrIUPfz3CtEJfxUKqQ==}
 
@@ -1938,6 +1969,9 @@ packages:
 
   '@eloqnt/format-po@0.1.0':
     resolution: {integrity: sha512-odgtuICWs67GdkNqY51/d2vaIukuOdlGalKASUGkI5c4cyWOmv/WIVyk5gZyn3xr614RzwWp57s9WB40lRLlBw==}
+
+  '@eloqnt/sdk@0.6.27':
+    resolution: {integrity: sha512-dIvAXFXyAYOdoCIc+RQk+q1avI7wb8e5VSbQyYy08UVbmjXilmyNl/hey5LuqWK1ZZZ5Qw3EajfyKQt92GFtVA==}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -2373,8 +2407,14 @@ packages:
   '@formatjs/icu-messageformat-parser@3.4.0':
     resolution: {integrity: sha512-2bSQc59NFiEuN5VW0dUh7Txn5Qbeib5kZtzxFDXXqxUljvwhA3Qsrv2AwuVCRMISjbgOYwA2Rp5HW6tbdTnv9g==}
 
+  '@formatjs/icu-messageformat-parser@3.5.17':
+    resolution: {integrity: sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==}
+
   '@formatjs/icu-skeleton-parser@2.1.0':
     resolution: {integrity: sha512-wNer4imHDFBVAJnMb2OGoSyM4wL/uuLnuo5mrenliqkDaNjRbG4jzlJcwTTDEBhai8iCjnzUsE7xwNJC29SfWw==}
+
+  '@formatjs/icu-skeleton-parser@2.1.11':
+    resolution: {integrity: sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==}
 
   '@formatjs/intl-localematcher@0.5.10':
     resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
@@ -5176,6 +5216,10 @@ packages:
       vue-router:
         optional: true
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vercel/speed-insights@1.3.1':
     resolution: {integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==}
     peerDependencies:
@@ -5342,6 +5386,9 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@xmldom/xmldom@0.9.8':
     resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
     engines: {node: '>=14.6'}
@@ -5407,6 +5454,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@7.0.95:
+    resolution: {integrity: sha512-prgjHfcKBMINf5263rl8DIiGfck+DcTLXkfEn4D0zCLEpFxk9VywnoZ+k7O3TxygLHFcpPtFpkIm43O5Yr0n9w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -5960,6 +6013,9 @@ packages:
   cipher-base@1.0.4:
     resolution: {integrity: sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==}
 
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
@@ -6122,6 +6178,10 @@ packages:
   connect-history-api-fallback@2.0.0:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
     engines: {node: '>=0.8'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   console-browserify@1.2.0:
     resolution: {integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==}
@@ -6558,6 +6618,10 @@ packages:
 
   default-browser@5.4.0:
     resolution: {integrity: sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.1:
+    resolution: {integrity: sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==}
     engines: {node: '>=18'}
 
   defaults@1.0.4:
@@ -7125,6 +7189,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
   eventsource@2.0.2:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
     engines: {node: '>=12.0.0'}
@@ -7209,6 +7277,9 @@ packages:
 
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -7970,6 +8041,10 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
@@ -8411,6 +8486,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -8479,6 +8558,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -9216,6 +9298,9 @@ packages:
     resolution: {integrity: sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  next-intl-swc-plugin-extractor@4.14.2:
+    resolution: {integrity: sha512-R+i9Xw6XKyn1QVx+I5IDZQNGQBwT79ugGwzbuJudgejob/IYnXXrRKMlLhmMxLdKH8jUWh92nqwNnp+5rtSVJA==}
+
   next-sitemap@4.2.3:
     resolution: {integrity: sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==}
     engines: {node: '>=14.18'}
@@ -9496,6 +9581,10 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
+  open@11.0.2:
+    resolution: {integrity: sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==}
+    engines: {node: '>=20'}
+
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
@@ -9737,6 +9826,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -9898,6 +9991,14 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
+  powershell-utils@0.2.1:
+    resolution: {integrity: sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==}
+    engines: {node: '>=20'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -11129,6 +11230,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -11399,6 +11504,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -11998,6 +12107,10 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  wsl-utils@1.0.0:
+    resolution: {integrity: sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==}
+    engines: {node: '>=20'}
+
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
@@ -12036,6 +12149,11 @@ packages:
 
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -12106,6 +12224,9 @@ packages:
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -12117,6 +12238,26 @@ snapshots:
     optional: true
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@ai-sdk/gateway@4.0.76(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.11
+      '@ai-sdk/provider-utils': 5.0.37(zod@4.5.4)
+      '@vercel/oidc': 3.2.0
+      zod: 4.5.4
+
+  '@ai-sdk/provider-utils@5.0.37(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.11
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.1
+      zod: 4.5.4
+
+  '@ai-sdk/provider@4.0.11':
+    dependencies:
+      json-schema: 0.4.0
 
   '@algolia/abtesting@1.12.3':
     dependencies:
@@ -13156,6 +13297,18 @@ snapshots:
 
   '@chevrotain/utils@11.0.3': {}
 
+  '@clack/core@1.5.0':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.8.0':
+    dependencies:
+      '@clack/core': 1.5.0
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -13222,6 +13375,16 @@ snapshots:
     dependencies:
       '@edge-runtime/primitives': 6.0.0
 
+  '@eloqnt/cli@0.6.29(@swc/helpers@0.5.23)':
+    dependencies:
+      '@clack/prompts': 1.8.0
+      '@eloqnt/sdk': 0.6.27(@swc/helpers@0.5.23)
+      citty: 0.1.6
+      open: 11.0.2
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
   '@eloqnt/config@0.1.0': {}
 
   '@eloqnt/format-json@0.1.0':
@@ -13232,6 +13395,23 @@ snapshots:
     dependencies:
       '@eloqnt/config': 0.1.0
       po-parser: 2.2.0
+
+  '@eloqnt/sdk@0.6.27(@swc/helpers@0.5.23)':
+    dependencies:
+      '@eloqnt/config': 0.1.0
+      '@eloqnt/format-json': 0.1.0
+      '@eloqnt/format-po': 0.1.0
+      '@formatjs/icu-messageformat-parser': 3.5.17
+      '@swc/core': 1.16.0(@swc/helpers@0.5.23)
+      ai: 7.0.95(zod@4.5.4)
+      jiti: 2.7.0
+      magic-string: 0.30.21
+      next-intl-swc-plugin-extractor: 4.14.2
+      tinyglobby: 0.2.17
+      yaml: 2.9.0
+      zod: 4.5.4
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@emnapi/core@1.8.1':
     dependencies:
@@ -13407,14 +13587,14 @@ snapshots:
       eslint: 9.11.1(jiti@1.21.7)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.11.1(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.11.1(jiti@2.7.0))':
     dependencies:
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.7.0))':
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -13545,10 +13725,16 @@ snapshots:
       '@formatjs/icu-skeleton-parser': 2.1.0
       tslib: 2.8.1
 
+  '@formatjs/icu-messageformat-parser@3.5.17':
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.11
+
   '@formatjs/icu-skeleton-parser@2.1.0':
     dependencies:
       '@formatjs/ecma402-abstract': 3.1.0
       tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@2.1.11': {}
 
   '@formatjs/intl-localematcher@0.5.10':
     dependencies:
@@ -14614,9 +14800,9 @@ snapshots:
 
   '@next/env@16.3.1': {}
 
-  '@next/eslint-plugin-next@16.3.1(eslint@9.39.2(jiti@2.6.1))':
+  '@next/eslint-plugin-next@16.3.1(eslint@9.39.2(jiti@2.7.0))':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
       fast-glob: 3.3.1
     transitivePeerDependencies:
       - eslint
@@ -15689,8 +15875,7 @@ snapshots:
       '@size-limit/file': 11.2.0(size-limit@11.2.0)
       size-limit: 11.2.0
 
-  '@standard-schema/spec@1.1.0':
-    optional: true
+  '@standard-schema/spec@1.1.0': {}
 
   '@storybook/builder-webpack5@8.6.15(esbuild@0.25.1)(storybook@8.6.15(prettier@3.8.0))(typescript@6.0.2)':
     dependencies:
@@ -16569,15 +16754,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/type-utils': 8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/type-utils': 8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.46.2
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -16586,15 +16771,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/type-utils': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.2
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -16603,15 +16788,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/type-utils': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/type-utils': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.46.2
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -16637,15 +16822,15 @@ snapshots:
       - supports-color
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 8.53.0
-      '@typescript-eslint/type-utils': 8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/type-utils': 8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.53.0
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@6.0.2)
@@ -16654,15 +16839,15 @@ snapshots:
       - supports-color
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 8.53.0
-      '@typescript-eslint/type-utils': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/type-utils': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.53.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@6.0.2)
@@ -16683,63 +16868,63 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.46.2
       debug: 4.4.3
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.2
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.46.2
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.53.0
       debug: 4.4.3
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.53.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -16809,37 +16994,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/type-utils@8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
       debug: 4.4.3
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       ts-api-utils: 2.1.0(typescript@6.0.2)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/type-utils@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       ts-api-utils: 2.1.0(typescript@6.0.2)
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -16858,26 +17043,26 @@ snapshots:
       - supports-color
     optional: true
 
-  '@typescript-eslint/type-utils@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/type-utils@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
       debug: 4.4.3
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       ts-api-utils: 2.4.0(typescript@6.0.2)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@typescript-eslint/type-utils@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/type-utils@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       ts-api-utils: 2.4.0(typescript@6.0.2)
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -16948,35 +17133,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/utils@8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.11.1(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.11.1(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@6.0.2)
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/utils@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@6.0.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -16993,25 +17178,25 @@ snapshots:
       - supports-color
     optional: true
 
-  '@typescript-eslint/utils@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/utils@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.11.1(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.11.1(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@6.0.2)
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@6.0.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -17102,12 +17287,14 @@ snapshots:
       next: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vercel/speed-insights@1.3.1(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
       next: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
@@ -17115,33 +17302,33 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@vitest/eslint-plugin@1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))':
     dependencies:
       '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2)
       eslint: 9.11.1(jiti@1.21.7)
     optionalDependencies:
       typescript: 6.0.2
-      vitest: 4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vitest: 4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
 
-  '@vitest/eslint-plugin@1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@vitest/eslint-plugin@1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))':
     dependencies:
-      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
-      eslint: 9.11.1(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
+      eslint: 9.11.1(jiti@2.7.0)
     optionalDependencies:
       typescript: 6.0.2
-      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
 
-  '@vitest/eslint-plugin@1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@vitest/eslint-plugin@1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))':
     dependencies:
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
+      eslint: 9.39.2(jiti@2.7.0)
     optionalDependencies:
       typescript: 6.0.2
-      vitest: 4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vitest: 4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
 
   '@vitest/expect@2.0.5':
     dependencies:
@@ -17168,38 +17355,38 @@ snapshots:
       tinyrainbow: 3.0.3
     optional: true
 
-  '@vitest/mocker@3.2.4(vite@6.2.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(vite@6.2.1(@types/node@20.19.29)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.2.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 6.2.1(@types/node@20.19.29)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
 
-  '@vitest/mocker@3.2.4(vite@6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(vite@6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.0.17(vite@6.2.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.17(vite@6.2.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.2.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 6.2.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
     optional: true
 
-  '@vitest/mocker@4.0.17(vite@6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.17(vite@6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
     optional: true
 
   '@vitest/pretty-format@2.0.5':
@@ -17359,6 +17546,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@workflow/serde@4.1.0': {}
+
   '@xmldom/xmldom@0.9.8': {}
 
   '@xtuc/ieee754@1.2.0': {}
@@ -17412,6 +17601,13 @@ snapshots:
   agent-base@7.1.3: {}
 
   agent-base@7.1.4: {}
+
+  ai@7.0.95(zod@4.5.4):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.76(zod@4.5.4)
+      '@ai-sdk/provider': 4.0.11
+      '@ai-sdk/provider-utils': 5.0.37(zod@4.5.4)
+      zod: 4.5.4
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -17936,7 +18132,6 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
-    optional: true
 
   busboy@1.6.0:
     dependencies:
@@ -18088,6 +18283,10 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       safe-buffer: 5.2.1
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
 
   cjs-module-lexer@1.4.3: {}
 
@@ -18251,6 +18450,8 @@ snapshots:
 
   connect-history-api-fallback@2.0.0:
     optional: true
+
+  consola@3.4.2: {}
 
   console-browserify@1.2.0: {}
 
@@ -18748,14 +18949,18 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
-  default-browser-id@5.0.1:
-    optional: true
+  default-browser-id@5.0.1: {}
 
   default-browser@5.4.0:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
     optional: true
+
+  default-browser@5.5.1:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
 
   defaults@1.0.4:
     dependencies:
@@ -18769,8 +18974,7 @@ snapshots:
 
   define-lazy-prop@2.0.0: {}
 
-  define-lazy-prop@3.0.0:
-    optional: true
+  define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
@@ -19189,11 +19393,11 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-molindo@8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@3.4.19(yaml@2.8.2))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)):
+  eslint-config-molindo@8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@3.4.19(yaml@2.9.0))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)):
     dependencies:
       '@eslint/js': 9.38.0
       '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2)
-      '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       confusing-browser-globals: 1.0.11
       eslint: 9.11.1(jiti@1.21.7)
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@1.21.7))
@@ -19204,7 +19408,7 @@ snapshots:
       eslint-plugin-react: 7.37.1(eslint@9.11.1(jiti@1.21.7))
       eslint-plugin-react-hooks: 5.0.0(eslint@9.11.1(jiti@1.21.7))
       eslint-plugin-sort-destructure-keys: 2.0.0(eslint@9.11.1(jiti@1.21.7))
-      eslint-plugin-tailwindcss: 3.13.0(tailwindcss@3.4.19(yaml@2.8.2))
+      eslint-plugin-tailwindcss: 3.13.0(tailwindcss@3.4.19(yaml@2.9.0))
       eslint-plugin-unicorn: 56.0.0(eslint@9.11.1(jiti@1.21.7))
       eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))
       typescript-eslint: 8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2)
@@ -19220,25 +19424,25 @@ snapshots:
       - typescript
       - vitest
 
-  eslint-config-molindo@8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)):
+  eslint-config-molindo@8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)):
     dependencies:
       '@eslint/js': 9.38.0
-      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
-      '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
+      '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       confusing-browser-globals: 1.0.11
-      eslint: 9.11.1(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.6.1))
-      eslint-plugin-css-modules: 2.11.0(eslint@9.11.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@2.6.1))
-      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(typescript@6.0.2)
-      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.11.1(jiti@2.6.1))
-      eslint-plugin-react: 7.37.1(eslint@9.11.1(jiti@2.6.1))
-      eslint-plugin-react-hooks: 5.0.0(eslint@9.11.1(jiti@2.6.1))
-      eslint-plugin-sort-destructure-keys: 2.0.0(eslint@9.11.1(jiti@2.6.1))
+      eslint: 9.11.1(jiti@2.7.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.7.0))
+      eslint-plugin-css-modules: 2.11.0(eslint@9.11.1(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@2.7.0))
+      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(typescript@6.0.2)
+      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.11.1(jiti@2.7.0))
+      eslint-plugin-react: 7.37.1(eslint@9.11.1(jiti@2.7.0))
+      eslint-plugin-react-hooks: 5.0.0(eslint@9.11.1(jiti@2.7.0))
+      eslint-plugin-sort-destructure-keys: 2.0.0(eslint@9.11.1(jiti@2.7.0))
       eslint-plugin-tailwindcss: 3.13.0(tailwindcss@4.2.4)
-      eslint-plugin-unicorn: 56.0.0(eslint@9.11.1(jiti@2.6.1))
-      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))
-      typescript-eslint: 8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
+      eslint-plugin-unicorn: 56.0.0(eslint@9.11.1(jiti@2.7.0))
+      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))
+      typescript-eslint: 8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
     transitivePeerDependencies:
       - '@typescript-eslint/eslint-plugin'
       - '@typescript-eslint/parser'
@@ -19251,25 +19455,25 @@ snapshots:
       - typescript
       - vitest
 
-  eslint-config-molindo@8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(jest@30.2.0(@types/node@25.0.8)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)):
+  eslint-config-molindo@8.0.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(jest@30.2.0(@types/node@25.0.8)(esbuild-register@3.6.0(esbuild@0.27.2)))(tailwindcss@4.2.4)(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)):
     dependencies:
       '@eslint/js': 9.38.0
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
-      '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
+      '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)(vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       confusing-browser-globals: 1.0.11
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-css-modules: 2.11.0(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(jest@30.2.0(@types/node@25.0.8)(esbuild-register@3.6.0(esbuild@0.27.2)))(typescript@6.0.2)
-      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react: 7.37.1(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react-hooks: 5.0.0(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-sort-destructure-keys: 2.0.0(eslint@9.39.2(jiti@2.6.1))
+      eslint: 9.39.2(jiti@2.7.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-css-modules: 2.11.0(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(jest@30.2.0(@types/node@25.0.8)(esbuild-register@3.6.0(esbuild@0.27.2)))(typescript@6.0.2)
+      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-react: 7.37.1(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-react-hooks: 5.0.0(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-sort-destructure-keys: 2.0.0(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-tailwindcss: 3.13.0(tailwindcss@4.2.4)
-      eslint-plugin-unicorn: 56.0.0(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))
-      typescript-eslint: 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      eslint-plugin-unicorn: 56.0.0(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))
+      typescript-eslint: 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
     transitivePeerDependencies:
       - '@typescript-eslint/eslint-plugin'
       - '@typescript-eslint/parser'
@@ -19282,18 +19486,18 @@ snapshots:
       - typescript
       - vitest
 
-  eslint-config-next@16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.3.1(eslint@9.39.2(jiti@2.6.1))
-      eslint: 9.39.2(jiti@2.6.1)
+      '@next/eslint-plugin-next': 16.3.1(eslint@9.39.2(jiti@2.7.0))
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react: 7.37.1(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-react: 7.37.1(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.7.0))
       globals: 16.4.0
-      typescript-eslint: 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      typescript-eslint: 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19302,18 +19506,18 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-next@16.3.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2):
+  eslint-config-next@16.3.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2):
     dependencies:
-      '@next/eslint-plugin-next': 16.3.1(eslint@9.39.2(jiti@2.6.1))
-      eslint: 9.39.2(jiti@2.6.1)
+      '@next/eslint-plugin-next': 16.3.1(eslint@9.39.2(jiti@2.7.0))
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react: 7.37.1(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-react: 7.37.1(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.7.0))
       globals: 16.4.0
-      typescript-eslint: 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      typescript-eslint: 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -19349,57 +19553,57 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
       enhanced-resolve: 5.21.0
-      eslint: 9.11.1(jiti@2.6.1)
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.6.1)))(eslint@9.11.1(jiti@2.6.1))
+      eslint: 9.11.1(jiti@2.7.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.7.0)))(eslint@9.11.1(jiti@2.7.0))
       fast-glob: 3.3.3
       get-tsconfig: 4.7.5
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@2.7.0))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
       enhanced-resolve: 5.21.0
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint: 9.39.2(jiti@2.7.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       fast-glob: 3.3.3
       get-tsconfig: 4.7.5
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
       enhanced-resolve: 5.21.0
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint: 9.39.2(jiti@2.7.0)
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       fast-glob: 3.3.3
       get-tsconfig: 4.7.5
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -19417,35 +19621,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.6.1)))(eslint@9.11.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.7.0)))(eslint@9.11.1(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
-      eslint: 9.11.1(jiti@2.6.1)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
+      eslint: 9.11.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -19455,15 +19659,15 @@ snapshots:
       gonzales-pe: 4.3.0
       lodash: 4.17.21
 
-  eslint-plugin-css-modules@2.11.0(eslint@9.11.1(jiti@2.6.1)):
+  eslint-plugin-css-modules@2.11.0(eslint@9.11.1(jiti@2.7.0)):
     dependencies:
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       gonzales-pe: 4.3.0
       lodash: 4.17.21
 
-  eslint-plugin-css-modules@2.11.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-css-modules@2.11.0(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       gonzales-pe: 4.3.0
       lodash: 4.17.21
 
@@ -19496,7 +19700,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19505,9 +19709,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.6.1)))(eslint@9.11.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.11.1(jiti@2.7.0)))(eslint@9.11.1(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19519,13 +19723,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19534,9 +19738,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19548,13 +19752,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19563,9 +19767,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19592,23 +19796,23 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(typescript@6.0.2):
+  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(jest@30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2)))(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
-      eslint: 9.11.1(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
+      eslint: 9.11.1(jiti@2.7.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
       jest: 30.2.0(@types/node@20.19.29)(esbuild-register@3.6.0(esbuild@0.27.2))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(jest@30.2.0(@types/node@25.0.8)(esbuild-register@3.6.0(esbuild@0.27.2)))(typescript@6.0.2):
+  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(jest@30.2.0(@types/node@25.0.8)(esbuild-register@3.6.0(esbuild@0.27.2)))(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
+      eslint: 9.39.2(jiti@2.7.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       jest: 30.2.0(@types/node@25.0.8)(esbuild-register@3.6.0(esbuild@0.27.2))
     transitivePeerDependencies:
       - supports-color
@@ -19634,7 +19838,7 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-jsx-a11y@6.10.0(eslint@9.11.1(jiti@2.6.1)):
+  eslint-plugin-jsx-a11y@6.10.0(eslint@9.11.1(jiti@2.7.0)):
     dependencies:
       aria-query: 5.1.3
       array-includes: 3.1.9
@@ -19645,7 +19849,7 @@ snapshots:
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       es-iterator-helpers: 1.0.19
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -19654,7 +19858,7 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-jsx-a11y@6.10.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-jsx-a11y@6.10.0(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       aria-query: 5.1.3
       array-includes: 3.1.9
@@ -19665,7 +19869,7 @@ snapshots:
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       es-iterator-helpers: 1.0.19
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -19674,12 +19878,12 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-compiler@0.0.0-experimental-8e3b87c-20240822(eslint@9.11.1(jiti@2.6.1)):
+  eslint-plugin-react-compiler@0.0.0-experimental-8e3b87c-20240822(eslint@9.11.1(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.28.6
       '@babel/parser': 7.21.9
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.28.6)
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       hermes-parser: 0.20.1
       zod: 3.25.76
       zod-validation-error: 3.4.0(zod@3.25.76)
@@ -19690,19 +19894,19 @@ snapshots:
     dependencies:
       eslint: 9.11.1(jiti@1.21.7)
 
-  eslint-plugin-react-hooks@5.0.0(eslint@9.11.1(jiti@2.6.1)):
+  eslint-plugin-react-hooks@5.0.0(eslint@9.11.1(jiti@2.7.0)):
     dependencies:
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
 
-  eslint-plugin-react-hooks@5.0.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react-hooks@5.0.0(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.28.6
       '@babel/parser': 7.21.9
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       hermes-parser: 0.25.1
       zod: 4.3.5
       zod-validation-error: 4.0.2(zod@4.3.5)
@@ -19731,7 +19935,7 @@ snapshots:
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-react@7.37.1(eslint@9.11.1(jiti@2.6.1)):
+  eslint-plugin-react@7.37.1(eslint@9.11.1(jiti@2.7.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -19739,7 +19943,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.0.19
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -19753,7 +19957,7 @@ snapshots:
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-react@7.37.1(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react@7.37.1(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -19761,7 +19965,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.0.19
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -19780,21 +19984,21 @@ snapshots:
       eslint: 9.11.1(jiti@1.21.7)
       natural-compare-lite: 1.4.0
 
-  eslint-plugin-sort-destructure-keys@2.0.0(eslint@9.11.1(jiti@2.6.1)):
+  eslint-plugin-sort-destructure-keys@2.0.0(eslint@9.11.1(jiti@2.7.0)):
     dependencies:
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       natural-compare-lite: 1.4.0
 
-  eslint-plugin-sort-destructure-keys@2.0.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-sort-destructure-keys@2.0.0(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       natural-compare-lite: 1.4.0
 
-  eslint-plugin-tailwindcss@3.13.0(tailwindcss@3.4.19(yaml@2.8.2)):
+  eslint-plugin-tailwindcss@3.13.0(tailwindcss@3.4.19(yaml@2.9.0)):
     dependencies:
       fast-glob: 3.3.3
       postcss: 8.5.6
-      tailwindcss: 3.4.19(yaml@2.8.2)
+      tailwindcss: 3.4.19(yaml@2.9.0)
 
   eslint-plugin-tailwindcss@3.13.0(tailwindcss@4.2.4):
     dependencies:
@@ -19822,14 +20026,14 @@ snapshots:
       semver: 7.7.3
       strip-indent: 3.0.0
 
-  eslint-plugin-unicorn@56.0.0(eslint@9.11.1(jiti@2.6.1)):
+  eslint-plugin-unicorn@56.0.0(eslint@9.11.1(jiti@2.7.0)):
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.11.1(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.11.1(jiti@2.7.0))
       ci-info: 4.3.1
       clean-regexp: 1.0.0
       core-js-compat: 3.41.0
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
       esquery: 1.6.0
       globals: 15.15.0
       indent-string: 4.0.0
@@ -19842,14 +20046,14 @@ snapshots:
       semver: 7.7.3
       strip-indent: 3.0.0
 
-  eslint-plugin-unicorn@56.0.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-unicorn@56.0.0(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
       ci-info: 4.3.1
       clean-regexp: 1.0.0
       core-js-compat: 3.41.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       esquery: 1.6.0
       globals: 15.15.0
       indent-string: 4.0.0
@@ -19868,17 +20072,17 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2))(eslint@9.11.1(jiti@1.21.7))(typescript@6.0.2)
 
-  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1)):
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0)):
     dependencies:
-      eslint: 9.11.1(jiti@2.6.1)
+      eslint: 9.11.1(jiti@2.7.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
 
-  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -19938,9 +20142,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@9.11.1(jiti@2.6.1):
+  eslint@9.11.1(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.11.1(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.11.1(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.18.0
       '@eslint/core': 0.6.0
@@ -19978,13 +20182,13 @@ snapshots:
       strip-ansi: 6.0.1
       text-table: 0.2.0
     optionalDependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint@9.39.2(jiti@2.6.1):
+  eslint@9.39.2(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
@@ -20019,7 +20223,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.3
     optionalDependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -20099,6 +20303,8 @@ snapshots:
   eventemitter3@5.0.1: {}
 
   events@3.3.0: {}
+
+  eventsource-parser@3.1.1: {}
 
   eventsource@2.0.2:
     optional: true
@@ -20251,6 +20457,10 @@ snapshots:
 
   fast-uri@3.0.6: {}
 
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -20275,6 +20485,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
 
   fflate@0.8.2: {}
 
@@ -21145,6 +21359,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-in-ssh@1.0.0: {}
 
   is-inside-container@1.0.0:
     dependencies:
@@ -22062,6 +22278,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jiti@2.7.0: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -22156,6 +22374,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -23242,6 +23462,8 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
+  next-intl-swc-plugin-extractor@4.14.2: {}
+
   next-sitemap@4.2.3(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       '@corex/deepmerge': 4.0.43
@@ -23699,6 +23921,15 @@ snapshots:
       wsl-utils: 0.1.0
     optional: true
 
+  open@11.0.2:
+    dependencies:
+      default-browser: 5.5.1
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.2.1
+      wsl-utils: 1.0.0
+
   open@8.4.2:
     dependencies:
       define-lazy-prop: 2.0.0
@@ -23976,6 +24207,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.7: {}
+
   pify@2.3.0: {}
 
   pify@6.1.0: {}
@@ -24045,13 +24278,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.8.2):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.6
-      yaml: 2.8.2
+      yaml: 2.9.0
 
   postcss-loader@8.1.1(postcss@8.5.6)(typescript@6.0.2)(webpack@5.104.1(esbuild@0.25.1)):
     dependencies:
@@ -24131,6 +24364,10 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  powershell-utils@0.1.0: {}
+
+  powershell-utils@0.2.1: {}
 
   prelude-ls@1.2.1: {}
 
@@ -24836,8 +25073,7 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
-  run-applescript@7.1.0:
-    optional: true
+  run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -25592,7 +25828,7 @@ snapshots:
 
   tabbable@6.2.0: {}
 
-  tailwindcss@3.4.19(yaml@2.8.2):
+  tailwindcss@3.4.19(yaml@2.9.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -25611,7 +25847,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.8.2)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.9.0)
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -25732,6 +25968,11 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
 
   tinypool@1.1.1: {}
 
@@ -25969,35 +26210,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2):
+  typescript-eslint@8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2))(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
-      '@typescript-eslint/parser': 8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2))(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.6.1))(typescript@6.0.2)
-      eslint: 9.11.1(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.11.1(jiti@2.7.0))(typescript@6.0.2)
+      eslint: 9.11.1(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2):
+  typescript-eslint@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
-      '@typescript-eslint/parser': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.2)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -26024,6 +26265,8 @@ snapshots:
 
   undici-types@7.16.0:
     optional: true
+
+  undici@7.29.1: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -26270,13 +26513,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.2.4(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2):
+  vite-node@3.2.4(@types/node@20.19.29)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 6.2.1(@types/node@20.19.29)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -26291,13 +26534,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2):
+  vite-node@3.2.4(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -26312,7 +26555,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2):
+  vite@6.2.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.6
@@ -26323,10 +26566,10 @@ snapshots:
       jiti: 1.21.7
       lightningcss: 1.32.0
       terser: 5.45.0
-      yaml: 2.8.2
+      yaml: 2.9.0
     optional: true
 
-  vite@6.2.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2):
+  vite@6.2.1(@types/node@20.19.29)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.6
@@ -26334,12 +26577,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.29
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.32.0
       terser: 5.45.0
-      yaml: 2.8.2
+      yaml: 2.9.0
 
-  vite@6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2):
+  vite@6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.6
@@ -26347,16 +26590,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.0.8
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.32.0
       terser: 5.45.0
-      yaml: 2.8.2
+      yaml: 2.9.0
 
-  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2):
+  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.19.29)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.2.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@6.2.1(@types/node@20.19.29)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -26374,8 +26617,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.2.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 6.2.1(@types/node@20.19.29)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@20.19.29)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
@@ -26396,11 +26639,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.0.8)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2):
+  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.0.8)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -26418,8 +26661,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
@@ -26440,10 +26683,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2):
+  vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(jiti@1.21.7)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(vite@6.2.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.17(vite@6.2.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.0.17
       '@vitest/runner': 4.0.17
       '@vitest/snapshot': 4.0.17
@@ -26460,7 +26703,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.2.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 6.2.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
@@ -26481,10 +26724,10 @@ snapshots:
       - yaml
     optional: true
 
-  vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2):
+  vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(vite@6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.17(vite@6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.0.17
       '@vitest/runner': 4.0.17
       '@vitest/snapshot': 4.0.17
@@ -26501,7 +26744,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.2.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 6.2.1(@types/node@25.0.8)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
@@ -26947,6 +27190,11 @@ snapshots:
       is-wsl: 3.1.0
     optional: true
 
+  wsl-utils@1.0.0:
+    dependencies:
+      is-wsl: 3.1.0
+      powershell-utils: 0.1.0
+
   xml-name-validator@4.0.0: {}
 
   xml-name-validator@5.0.0:
@@ -26969,6 +27217,8 @@ snapshots:
   yaml@1.10.2: {}
 
   yaml@2.8.2: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@13.1.2:
     dependencies:
@@ -27047,5 +27297,7 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.5: {}
+
+  zod@4.5.4: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Adds `@eloqnt/cli` as a dev dependency to `example-app-router` with an `.eloqnt/config.ts`, runs `eloqnt lint` as part of the example's `lint` script, and fills in the German `Manifest.name` that the first run reported as missing.

`pnpm lint` in the example passes, including `eloqnt lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)