### PR TITLE
fix: Keep `$` patterns in route param values literally

### DIFF
--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -27,7 +27,7 @@ const config: SizeLimitConfig = [
     name: "import {createNavigation} from 'next-intl/navigation' (react-server)",
     path: 'dist/esm/production/navigation.react-server.js',
     import: '{createNavigation}',
-    limit: '3.155 KB'
+    limit: '3.16 KB'
   },
   {
     name: "import * from 'next-intl/server' (react-client)",

--- a/packages/next-intl/src/middleware/utils.test.tsx
+++ b/packages/next-intl/src/middleware/utils.test.tsx
@@ -177,6 +177,15 @@ describe('formatPathname', () => {
       '/users/23/42'
     );
   });
+
+  it('keeps `$` patterns in parameter values literally', () => {
+    expect(formatPathnameTemplate('/users/[userId]', {userId: 'a$&b'})).toBe(
+      '/users/a$&b'
+    );
+    expect(formatPathnameTemplate('/users/[userId]', {userId: "$'`$1"})).toBe(
+      "/users/$'`$1"
+    );
+  });
 });
 
 describe('getInternalTemplate', () => {

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -247,7 +247,7 @@ export function formatPathnameTemplate(template: string, params?: object) {
 
   let result = template;
   Object.entries(params).forEach(([key, value]) => {
-    result = result.replace(`[${key}]`, value);
+    result = result.replace(`[${key}]`, () => value);
   });
 
   return result;

--- a/packages/next-intl/src/navigation/shared/utils.test.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.test.tsx
@@ -126,6 +126,38 @@ describe('compileLocalizedPathname', () => {
       ].join('\n')
     );
   });
+
+  it('keeps `$` patterns in param values literally', () => {
+    expect(
+      compileLocalizedPathname<Locales, '/about/[param]'>({
+        locale: 'en',
+        pathname: '/about/[param]',
+        params: {param: 'a$&b'},
+        pathnames
+      })
+    ).toBe('/about/a$&b');
+
+    expect(
+      compileLocalizedPathname<Locales, '/about/[param]'>({
+        locale: 'en',
+        pathname: '/about/[param]',
+        params: {param: "$'`$1"},
+        pathnames
+      })
+      // Note: `` ` `` is percent-encoded by URL normalization
+    ).toBe("/about/$'%60$1");
+  });
+
+  it('keeps `$` patterns in catch-all param values literally', () => {
+    expect(
+      compileLocalizedPathname<Locales, '/test/[...params]'>({
+        locale: 'en',
+        pathname: '/test/[...params]',
+        params: {params: ['a$&b', 'c']},
+        pathnames
+      })
+    ).toBe('/test/a$&b/c');
+  });
 });
 
 describe('getBasePath', () => {

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -144,7 +144,7 @@ export function compileLocalizedPathname<AppLocales extends Locales, Pathname>({
             replacer = String(paramValue);
           }
 
-          compiled = compiled.replace(new RegExp(regexp, 'g'), replacer);
+          compiled = compiled.replace(new RegExp(regexp, 'g'), () => replacer);
         });
       }
 


### PR DESCRIPTION
Fixes #2405.

Route param values containing `$` replacement patterns (`$&`, `$'`, `` $` ``, `$1`) were interpreted by `String.replace`, corrupting localized URLs from the navigation APIs (`getPathname`, `Link`, `redirect`, `useRouter`) and from middleware localized-pathname redirects. With `$&` the placeholder was re-inserted and `compileLocalizedPathname` even threw `Insufficient params provided`.

Both substitution sites now pass a replacer function so values are inserted verbatim. Regression tests added in `navigation/shared/utils.test.tsx` and `middleware/utils.test.tsx`.

Verification: full `next-intl` suite 899/899 green, `tsc --noEmit`, ESLint and Prettier clean.