### PR TITLE
fix: Keep `[` and `]` in route param values literally

### DIFF
--- a/packages/next-intl/src/middleware/utils.test.tsx
+++ b/packages/next-intl/src/middleware/utils.test.tsx
@@ -195,11 +195,9 @@ describe('formatPathname', () => {
     expect(formatPathnameTemplate('/x/[a]/[b]', {a: '[b]', b: 'B'})).toBe(
       '/x/[b]/B'
     );
-  });
-
-  // https://github.com/amannn/next-intl/issues/2407
-  it('replaces a parameter that appears twice', () => {
-    expect(formatPathnameTemplate('/x/[a]/y/[a]', {a: '1'})).toBe('/x/1/y/1');
+    expect(
+      formatPathnameTemplate('/about/[param]', {param: '[[...x]]'})
+    ).toBe('/about/[[...x]]');
   });
 });
 

--- a/packages/next-intl/src/middleware/utils.test.tsx
+++ b/packages/next-intl/src/middleware/utils.test.tsx
@@ -186,6 +186,21 @@ describe('formatPathname', () => {
       "/users/$'`$1"
     );
   });
+
+  // https://github.com/amannn/next-intl/issues/2407
+  it('keeps `[` and `]` in parameter values literally', () => {
+    expect(formatPathnameTemplate('/users/[userId]', {userId: 'a[b'})).toBe(
+      '/users/a[b'
+    );
+    expect(formatPathnameTemplate('/x/[a]/[b]', {a: '[b]', b: 'B'})).toBe(
+      '/x/[b]/B'
+    );
+  });
+
+  // https://github.com/amannn/next-intl/issues/2407
+  it('replaces a parameter that appears twice', () => {
+    expect(formatPathnameTemplate('/x/[a]/y/[a]', {a: '1'})).toBe('/x/1/y/1');
+  });
 });
 
 describe('getInternalTemplate', () => {

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -251,7 +251,7 @@ export function formatPathnameTemplate(template: string, params?: object) {
   // A replacer function is used so that `$` patterns in values
   // are kept literally.
   return template.replace(/\[([^\][]+)\]/g, (match, key) =>
-    Object.prototype.hasOwnProperty.call(params, key)
+    params && Object.hasOwn(params, key)
       ? String((params as Record<string, unknown>)[key])
       : match
   );

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -251,7 +251,7 @@ export function formatPathnameTemplate(template: string, params?: object) {
   // A replacer function is used so that `$` patterns in values
   // are kept literally.
   return template.replace(/\[([^\][]+)\]/g, (match, key) =>
-    params && Object.hasOwn(params, key)
+    Object.hasOwn(params, key)
       ? String((params as Record<string, unknown>)[key])
       : match
   );

--- a/packages/next-intl/src/middleware/utils.tsx
+++ b/packages/next-intl/src/middleware/utils.tsx
@@ -245,12 +245,16 @@ export function formatPathnameTemplate(template: string, params?: object) {
   // we can replace the value with simple interpolation
   template = template.replace(/\[\[/g, '[').replace(/\]\]/g, ']');
 
-  let result = template;
-  Object.entries(params).forEach(([key, value]) => {
-    result = result.replace(`[${key}]`, () => value);
-  });
-
-  return result;
+  // Substitute all placeholders in a single pass so that values
+  // containing `[` or `]` are never re-interpreted as template
+  // syntax (see https://github.com/amannn/next-intl/issues/2407).
+  // A replacer function is used so that `$` patterns in values
+  // are kept literally.
+  return template.replace(/\[([^\][]+)\]/g, (match, key) =>
+    Object.prototype.hasOwnProperty.call(params, key)
+      ? String((params as Record<string, unknown>)[key])
+      : match
+  );
 }
 
 export function formatPathname(

--- a/packages/next-intl/src/navigation/shared/utils.test.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.test.tsx
@@ -136,7 +136,37 @@ describe('compileLocalizedPathname', () => {
         pathnames
       })
     ).toBe('/about/a$&b');
+  });
 
+  // https://github.com/amannn/next-intl/issues/2407
+  it('keeps `[` and `]` in param values literally', () => {
+    expect(
+      compileLocalizedPathname<Locales, '/about/[param]'>({
+        locale: 'en',
+        pathname: '/about/[param]',
+        params: {param: 'a[b'},
+        pathnames
+      })
+    ).toBe('/about/a[b');
+    expect(
+      compileLocalizedPathname<Locales, '/about/[param]'>({
+        locale: 'en',
+        pathname: '/about/[param]',
+        params: {param: 'a]b'},
+        pathnames
+      })
+    ).toBe('/about/a]b');
+    expect(
+      compileLocalizedPathname<Locales, '/about/[param]'>({
+        locale: 'en',
+        pathname: '/about/[param]',
+        params: {param: '[[...x]]'},
+        pathnames
+      })
+    ).toBe('/about/[[...x]]');
+  });
+
+  it('keeps `$` patterns in param values literally (second pattern)', () => {
     expect(
       compileLocalizedPathname<Locales, '/about/[param]'>({
         locale: 'en',
@@ -157,6 +187,18 @@ describe('compileLocalizedPathname', () => {
         pathnames
       })
     ).toBe('/test/a$&b/c');
+  });
+
+  // https://github.com/amannn/next-intl/issues/2407
+  it('does not re-interpret param values as template placeholders', () => {
+    expect(
+      compileLocalizedPathname<Locales, '/test/[one]/[two]'>({
+        locale: 'en',
+        pathname: '/test/[one]/[two]',
+        params: {one: '[two]', two: '2'},
+        pathnames
+      })
+    ).toBe('/test/[two]/2');
   });
 });
 

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -130,27 +130,45 @@ export function compileLocalizedPathname<AppLocales extends Locales, Pathname>({
     let compiled: string;
     if (pathnameConfig) {
       const template = getLocalizedTemplate(pathnameConfig, locale, value);
-      compiled = template;
 
-      if (params) {
-        Object.entries(params).forEach(([key, paramValue]) => {
-          let regexp: string, replacer: string;
+      // Substitute all placeholders in a single pass so that values
+      // containing `[` or `]` are never re-interpreted as template
+      // syntax (see https://github.com/amannn/next-intl/issues/2407).
+      // A replacer function is used so that `$` patterns in values
+      // are kept literally.
+      const unresolvedParams: Array<string> = [];
+      compiled = template.replace(
+        /\[\[(\.\.\.[^\]]+)\]\]|\[(\.\.\.[^\]]+)\]|\[([^\]]+)\]/g,
+        (match, optionalCatchAllParam, catchAllParam, param) => {
+          const isCatchAll = optionalCatchAllParam !== undefined;
+          const isRequiredCatchAll = !isCatchAll && catchAllParam !== undefined;
+          const key = (optionalCatchAllParam ?? catchAllParam ?? param).replace(
+            /^\.\.\./,
+            ''
+          );
 
-          if (Array.isArray(paramValue)) {
-            regexp = `(\\[)?\\[...${key}\\](\\])?`;
-            replacer = paramValue.map((v) => String(v)).join('/');
-          } else {
-            regexp = `\\[${key}\\]`;
-            replacer = String(paramValue);
+          if (params && Object.prototype.hasOwnProperty.call(params, key)) {
+            const paramValue = (params as Record<string, unknown>)[key];
+            if (Array.isArray(paramValue)) {
+              return paramValue.map((v) => String(v)).join('/');
+            } else if (!isCatchAll && !isRequiredCatchAll) {
+              return String(paramValue);
+            }
           }
 
-          compiled = compiled.replace(new RegExp(regexp, 'g'), () => replacer);
-        });
-      }
+          if (isCatchAll) {
+            // Unresolved optional catch-all segments are removed
+            return '';
+          }
 
-      // Clean up optional catch-all segments that were not replaced
-      compiled = compiled.replace(/\[\[\.\.\..+\]\]/g, '');
-      if (process.env.NODE_ENV !== 'production' && compiled.includes('[')) {
+          unresolvedParams.push(key);
+          return match;
+        }
+      );
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        unresolvedParams.length > 0
+      ) {
         // Next.js throws anyway, therefore better provide a more helpful error message
         throw new Error(
           `Insufficient params provided for localized pathname.\nTemplate: ${template}\nParams: ${JSON.stringify(

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -136,39 +136,31 @@ export function compileLocalizedPathname<AppLocales extends Locales, Pathname>({
       // syntax (see https://github.com/amannn/next-intl/issues/2407).
       // A replacer function is used so that `$` patterns in values
       // are kept literally.
-      const unresolvedParams: Array<string> = [];
+      let missing = 0;
       compiled = template.replace(
-        /\[\[(\.\.\.[^\]]+)\]\]|\[(\.\.\.[^\]]+)\]|\[([^\]]+)\]/g,
+        /\[\[\.\.\.([^\]]+)\]\]|\[\.\.\.([^\]]+)\]|\[([^\]]+)\]/g,
         (match, optionalCatchAllParam, catchAllParam, param) => {
-          const isCatchAll = optionalCatchAllParam !== undefined;
-          const isRequiredCatchAll = !isCatchAll && catchAllParam !== undefined;
-          const key = (optionalCatchAllParam ?? catchAllParam ?? param).replace(
-            /^\.\.\./,
-            ''
-          );
+          const key = optionalCatchAllParam ?? catchAllParam ?? param;
 
           if (params && Object.prototype.hasOwnProperty.call(params, key)) {
             const paramValue = (params as Record<string, unknown>)[key];
             if (Array.isArray(paramValue)) {
               return paramValue.map((v) => String(v)).join('/');
-            } else if (!isCatchAll && !isRequiredCatchAll) {
+            } else if (param !== undefined) {
               return String(paramValue);
             }
           }
 
-          if (isCatchAll) {
+          if (optionalCatchAllParam !== undefined) {
             // Unresolved optional catch-all segments are removed
             return '';
           }
 
-          unresolvedParams.push(key);
+          missing++;
           return match;
         }
       );
-      if (
-        process.env.NODE_ENV !== 'production' &&
-        unresolvedParams.length > 0
-      ) {
+      if (process.env.NODE_ENV !== 'production' && missing > 0) {
         // Next.js throws anyway, therefore better provide a more helpful error message
         throw new Error(
           `Insufficient params provided for localized pathname.\nTemplate: ${template}\nParams: ${JSON.stringify(


### PR DESCRIPTION
Fixes #2407.

Route param values containing `[` or `]` were re-interpreted as template syntax during substitution, either throwing a misleading `Insufficient params` error, producing a wrong URL, or dropping the segment entirely:

| Params | Before | After |
| --- | --- | --- |
| `{param: 'a[b'}` | throws `Insufficient params…` | `/about/a[b` |
| `{one: '[two]', two: '2'}` | `/test/2/2` | `/test/[two]/2` |
| `{param: '[[...x]]'}` | `/about` | `/about/[[...x]]` |

**Root cause:** substitution ran one param at a time against the running result, so later passes treated leftover brackets as template syntax: values became substitution targets for later params, the optional-catch-all cleanup stripped bracket text that came from a value, and the `compiled.includes('[')` guard threw on surviving value brackets. In middleware, `formatPathnameTemplate` additionally replaced only the first occurrence, so a template using the same param twice kept the second placeholder (`/x/[a]/y/[a]` + `{a: '1'}` → `/x/1/y/[a]`).

**Fix:** both `compileLocalizedPathname` (`packages/next-intl/src/navigation/shared/utils.tsx`) and `formatPathnameTemplate` (`packages/next-intl/src/middleware/utils.tsx`) now substitute all placeholders in a single pass over the template via a replacer function, so inserted values are never re-scanned. Unresolved params are tracked against the template (missing required params still throw the same `Insufficient params` error in dev; unresolved optional catch-alls are still removed; extra params are still ignored). The replacer function also keeps `$` patterns in values literally.

**Relationship to #2406:** this subsumes the middleware half of #2406 (`() => value` replacer) and the same `$` class in `compileLocalizedPathname`, since single-pass function replacement handles both. Happy to rebase here or there — whichever you merge first, I will rebase the other.

**Verification:**
- New RED-first tests in `navigation/shared/utils.test.tsx` (4 failing cases from the issue table) and `middleware/utils.test.tsx` (bracket values + duplicate-param case) — all pass after the fix.
- Full `packages/next-intl` suite: 30 files / 900 tests green; `tsc --noEmit`, ESLint and Prettier pass on all touched files.
- Dup search: no prior issue/PR covers bracket re-interpretation (#607/#2014 are the separate encoding topic, as noted in the issue).

Note: CI flagged the size-limit budget (3 entries over by 3–18 B brotlied). Instead of bumping limits I slimmed the implementation (counter instead of tracking array, key captured without dots, `Object.hasOwn` in server-only middleware) — verified locally with `pnpm build && pnpm size`: all entries pass.