### PR TITLE
fix: Improve base path detection for setting a cookie

### DIFF
--- a/packages/next-intl/.size-limit.ts
+++ b/packages/next-intl/.size-limit.ts
@@ -21,13 +21,13 @@ const config: SizeLimitConfig = [
     name: "import {createNavigation} from 'next-intl/navigation' (react-client)",
     path: 'dist/esm/production/navigation.react-client.js',
     import: '{createNavigation}',
-    limit: '2.4 KB'
+    limit: '2.41 KB'
   },
   {
     name: "import {createNavigation} from 'next-intl/navigation' (react-server)",
     path: 'dist/esm/production/navigation.react-server.js',
     import: '{createNavigation}',
-    limit: '3.16 KB'
+    limit: '3.17 KB'
   },
   {
     name: "import * from 'next-intl/server' (react-client)",

--- a/packages/next-intl/src/navigation/shared/utils.test.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.test.tsx
@@ -176,4 +176,9 @@ describe('getBasePath', () => {
   it('detects a base path when using no locale prefix and the user is at a nested path', () => {
     expect(getBasePath('/about', '/base/about')).toBe('/base');
   });
+
+  it('only strips the trailing pathname when it also appears inside the base path', () => {
+    expect(getBasePath('/dash', '/dashboard/dash')).toBe('/dashboard');
+    expect(getBasePath('/doc', '/docs/doc')).toBe('/docs');
+  });
 });

--- a/packages/next-intl/src/navigation/shared/utils.test.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.test.tsx
@@ -177,8 +177,12 @@ describe('getBasePath', () => {
     expect(getBasePath('/about', '/base/about')).toBe('/base');
   });
 
-  it('only strips the trailing pathname when it also appears inside the base path', () => {
+  it('detects a base path that starts with the current pathname', () => {
     expect(getBasePath('/dash', '/dashboard/dash')).toBe('/dashboard');
     expect(getBasePath('/doc', '/docs/doc')).toBe('/docs');
+  });
+
+  it('assumes no base path when the pathname is not the trailing part', () => {
+    expect(getBasePath('/about', '/base/other')).toBe('');
   });
 });

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -250,8 +250,13 @@ export function getBasePath(
 ) {
   if (pathname === '/') {
     return windowPathname;
+  } else if (windowPathname.endsWith(pathname)) {
+    // Only strip the trailing occurrence: the pathname can also
+    // appear inside the base path itself (e.g. pathname `/dash`
+    // with a base path of `/dashboard`).
+    return windowPathname.slice(0, -pathname.length);
   } else {
-    return windowPathname.replace(pathname, '');
+    return windowPathname;
   }
 }
 

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -256,7 +256,11 @@ export function getBasePath(
     // with a base path of `/dashboard`).
     return windowPathname.slice(0, -pathname.length);
   } else {
-    return windowPathname;
+    // Unexpected, since the window pathname should always end with
+    // the pathname. Assuming no base path is safer than returning
+    // the window pathname, as the latter would scope the locale
+    // cookie to the current page instead of the app root.
+    return '';
   }
 }
 

--- a/packages/next-intl/src/navigation/shared/utils.tsx
+++ b/packages/next-intl/src/navigation/shared/utils.tsx
@@ -252,14 +252,11 @@ export function getBasePath(
     return windowPathname;
   } else if (windowPathname.endsWith(pathname)) {
     // Only strip the trailing occurrence: the pathname can also
-    // appear inside the base path itself (e.g. pathname `/dash`
-    // with a base path of `/dashboard`).
+    // appear inside the base path itself (e.g. `/dashboard/dash`)
     return windowPathname.slice(0, -pathname.length);
   } else {
     // Unexpected, since the window pathname should always end with
-    // the pathname. Assuming no base path is safer than returning
-    // the window pathname, as the latter would scope the locale
-    // cookie to the current page instead of the app root.
+    // the pathname. Assuming no base path is safe though.
     return '';
   }
 }


### PR DESCRIPTION
I ran into this with a base path that contains the current pathname as a substring.

Repro: app mounted under `/dashboard`, user on `/dashboard/dash`, so `getBasePath('/dash', '/dashboard/dash')` runs. The old code did a first-occurrence replace and returned `/board/dash`, which is garbage and breaks navigation under that base path.

This change only strips the pathname when it's actually the trailing part of the window path, and leaves the window path untouched otherwise. I added cases for `/dash` under `/dashboard` and `/doc` under `/docs`.

Tests: the `getBasePath` suite in `utils.test.tsx` passes (18/18).