### PR TITLE
fix(navigation): read the pathname in useRouter only when the locale cookie is enabled

### DIFF
--- a/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.test.tsx
@@ -313,6 +313,28 @@ describe("localePrefix: 'always', with `localeCookie`", () => {
   });
 });
 
+describe("localePrefix: 'always', with `localeCookie: false`", () => {
+  const {useRouter} = createNavigation({
+    locales,
+    defaultLocale,
+    localePrefix: 'always',
+    localeCookie: false
+  });
+
+  describe('useRouter', () => {
+    const invokeRouter = getInvokeRouter(useRouter);
+
+    it('navigates without reading the pathname', () => {
+      vi.mocked(useNextPathname).mockClear();
+
+      invokeRouter((router) => router.push('/about', {locale: 'de'}));
+
+      expect(useNextRouter().push).toHaveBeenCalledWith('/de/about');
+      expect(useNextPathname).not.toHaveBeenCalled();
+    });
+  });
+});
+
 describe("localePrefix: 'always', with `basePath`", () => {
   const {useRouter} = createNavigation({
     locales,

--- a/packages/next-intl/src/navigation/react-client/createNavigation.tsx
+++ b/packages/next-intl/src/navigation/react-client/createNavigation.tsx
@@ -69,10 +69,17 @@ export default function createNavigation<
     );
   }
 
+  // Reading the pathname subscribes the caller to URL data, which blocks the
+  // App Shell of routes with dynamic params. It's only needed to sync the
+  // locale cookie, therefore the hook is picked once per navigation instance.
+  const usePathnameForCookie = config.localeCookie
+    ? useNextPathname
+    : () => null;
+
   function useRouter() {
     const router = useNextRouter();
     const curLocale = useLocale();
-    const nextPathname = useNextPathname();
+    const nextPathname = usePathnameForCookie();
 
     return useMemo(() => {
       function createHandler<


### PR DESCRIPTION
Closes #2412.

`useRouter` called `usePathname()` on every render, although the value is only passed to `syncLocaleCookie`. With Next.js Cache Components that read blocks the App Shell of every route with dynamic params, so any shared component using the router — header, bottom nav, link wrapper — takes the shell down with it, even when `localeCookie: false`.

The hook is now picked once per navigation instance: with a locale cookie it stays `usePathname`, without one it returns `null` and nothing subscribes to URL data. Hook order stays stable because the config is fixed when `createNavigation` runs.

Apps with a locale cookie still read the pathname — the base path is derived from it, so dropping the read there needs a different source.

`pnpm --filter next-intl vitest run src/navigation/react-client` — 93 passed, including the added case.
